### PR TITLE
Fix username escape

### DIFF
--- a/frontend/app/embed.ts
+++ b/frontend/app/embed.ts
@@ -172,7 +172,9 @@ async function init(): Promise<void> {
       const queryUserInfo =
         query +
         '&page=user-info&' +
-        `&id=${user.id}&name=${user.name}&picture=${user.picture || ''}&isDefaultPicture=${user.isDefaultPicture || 0}`;
+        `&id=${encodeURIComponent(user.id)}&name=${encodeURIComponent(user.name)}&picture=${encodeURIComponent(
+          user.picture
+        ) || ''}&isDefaultPicture=${user.isDefaultPicture || 0}`;
       this.node.innerHTML = `
       <iframe
         src="${HOST}/web/iframe.html?${queryUserInfo}"

--- a/frontend/app/last-comments.tsx
+++ b/frontend/app/last-comments.tsx
@@ -10,6 +10,7 @@ import { getLastComments } from './common/api';
 import { LastCommentsConfig } from '@app/common/config-types';
 import { BASE_URL, DEFAULT_LAST_COMMENTS_MAX, LAST_COMMENTS_NODE_CLASSNAME } from '@app/common/constants';
 import { ListComments } from '@app/components/list-comments';
+import { unescapeComment } from './utils/unescapeComment';
 
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', init);
@@ -53,7 +54,7 @@ async function init(): Promise<void> {
       DEFAULT_LAST_COMMENTS_MAX;
     getLastComments(remark_config.site_id!, max).then(comments => {
       try {
-        render(<ListComments comments={comments} />, node);
+        render(<ListComments comments={comments.map(unescapeComment)} />, node);
       } catch (e) {
         console.error('Remark42: Something went wrong with last comments rendering');
         console.error(e);

--- a/frontend/app/remark.tsx
+++ b/frontend/app/remark.tsx
@@ -53,7 +53,7 @@ async function init(): Promise<void> {
     .reduce<{ [key: string]: string }>((memo, value) => {
       const vals = value.split('=');
       if (vals.length === 2) {
-        memo[vals[0]] = vals[1];
+        memo[vals[0]] = decodeURIComponent(vals[1]);
       }
       return memo;
     }, {});

--- a/frontend/app/store/comments/reducers.ts
+++ b/frontend/app/store/comments/reducers.ts
@@ -14,6 +14,7 @@ import {
 } from './types';
 import { getPinnedComments } from './utils';
 import { cmpRef } from '@app/utils/cmpRef';
+import { unescapeComment } from '@app/utils/unescapeComment';
 
 export const topComments = (
   state: (Comment['id'])[] = [],
@@ -80,7 +81,7 @@ const cmpComment = (a: Comment | undefined, b: Comment): Comment => {
 };
 
 const reduceComments = (c: Record<Comment['id'], Comment>, x: Node): Record<Comment['id'], Comment> => {
-  c[x.comment.id] = cmpComment(c[x.comment.id], x.comment);
+  c[x.comment.id] = cmpComment(c[x.comment.id], unescapeComment(x.comment));
   if (x.replies) {
     x.replies.reduce(reduceComments, c);
   }

--- a/frontend/app/utils/htmlUnescape.test.ts
+++ b/frontend/app/utils/htmlUnescape.test.ts
@@ -1,4 +1,4 @@
-import { htmlUnescape } from './htmlUnescape';
+import { htmlUnescape, htmlPartialUnescape } from './htmlUnescape';
 
 describe('htmlUnescape', () => {
   const data: ([string, string])[] = [
@@ -10,6 +10,21 @@ describe('htmlUnescape', () => {
   for (const example of data) {
     it(`unescapes ${example[0]} to ${example[1]}`, () => {
       expect(htmlUnescape(example[0])).toStrictEqual(example[1]);
+    });
+  }
+});
+
+describe('htmlPartialUnescape', () => {
+  const data: ([string, string])[] = [
+    ['blah &amp; &amp; &#34; &#39; 123', 'blah & & " \' 123'],
+    ['&amp;&amp;&amp;&amp;', '&&&&'],
+    ['blah & & 123 &mdash; &mdash;', 'blah & & 123 &mdash; &mdash;'],
+    ['name &lt;&gt; & \' ` "', 'name &lt;&gt; & \' ` "'],
+  ];
+
+  for (const example of data) {
+    it(`unescapes ${example[0]} to ${example[1]}`, () => {
+      expect(htmlPartialUnescape(example[0])).toStrictEqual(example[1]);
     });
   }
 });

--- a/frontend/app/utils/htmlUnescape.test.ts
+++ b/frontend/app/utils/htmlUnescape.test.ts
@@ -1,0 +1,15 @@
+import { htmlUnescape } from './htmlUnescape';
+
+describe('htmlUnescape', () => {
+  const data: ([string, string])[] = [
+    ['blah &amp; &amp; 123', 'blah & & 123'],
+    ['blah & & 123 &mdash; &mdash;', 'blah & & 123 — —'],
+    ['name &lt;&gt; & \' ` "', 'name <> & \' ` "'],
+  ];
+
+  for (const example of data) {
+    it(`unescapes ${example[0]} to ${example[1]}`, () => {
+      expect(htmlUnescape(example[0])).toStrictEqual(example[1]);
+    });
+  }
+});

--- a/frontend/app/utils/htmlUnescape.ts
+++ b/frontend/app/utils/htmlUnescape.ts
@@ -4,3 +4,16 @@ export function htmlUnescape(input: string): string {
   htmlDecodeElement.innerHTML = input;
   return htmlDecodeElement.childNodes.length === 0 ? '' : htmlDecodeElement.childNodes[0].nodeValue || '';
 }
+
+const replaceRegexes: ([RegExp, string])[] = [[/&#34;/g, '"'], [/&#39;/g, "'"], [/&amp;/g, '&']];
+
+/**
+ * Performs partial unescape for [", ', &] symbols
+ */
+export function htmlPartialUnescape(input: string): string {
+  let out = input;
+  for (const op of replaceRegexes) {
+    out = out.replace(op[0], op[1]);
+  }
+  return out;
+}

--- a/frontend/app/utils/htmlUnescape.ts
+++ b/frontend/app/utils/htmlUnescape.ts
@@ -1,0 +1,6 @@
+const htmlDecodeElement = document.createElement('div');
+
+export function htmlUnescape(input: string): string {
+  htmlDecodeElement.innerHTML = input;
+  return htmlDecodeElement.childNodes.length === 0 ? '' : htmlDecodeElement.childNodes[0].nodeValue || '';
+}

--- a/frontend/app/utils/unescapeComment.ts
+++ b/frontend/app/utils/unescapeComment.ts
@@ -1,0 +1,13 @@
+import { Comment } from '@app/common/types';
+import { htmlUnescape } from './htmlUnescape';
+
+/**
+ * comment received from api has name of user html escaped,
+ * To render it well we must unescape this property
+ */
+export const unescapeComment = (comment: Comment): Comment => {
+  return {
+    ...comment,
+    user: { ...comment.user, name: htmlUnescape(comment.user.name) },
+  };
+};

--- a/frontend/app/utils/unescapeComment.ts
+++ b/frontend/app/utils/unescapeComment.ts
@@ -1,5 +1,5 @@
 import { Comment } from '@app/common/types';
-import { htmlUnescape } from './htmlUnescape';
+import { htmlPartialUnescape } from './htmlUnescape';
 
 /**
  * comment received from api has name of user html escaped,
@@ -8,6 +8,6 @@ import { htmlUnescape } from './htmlUnescape';
 export const unescapeComment = (comment: Comment): Comment => {
   return {
     ...comment,
-    user: { ...comment.user, name: htmlUnescape(comment.user.name) },
+    user: { ...comment.user, name: htmlPartialUnescape(comment.user.name) },
   };
 };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10244,9 +10244,9 @@
       }
     },
     "preact": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-8.4.2.tgz",
-      "integrity": "sha512-TsINETWiisfB6RTk0wh3/mvxbGRvx+ljeBccZ4Z6MPFKgu/KFGyf2Bmw3Z/jlXhL5JlNKY6QAbA9PVyzIy9//A=="
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-8.5.2.tgz",
+      "integrity": "sha512-37tlDJGq5IQKqGUbqPZ7qPtsTOWFyxe+ojAOFfzKo0dEPreenqrqgJuS83zGpeGAqD9h9L9Yr7QuxH2W4ZrKxg=="
     },
     "preact-context": {
       "version": "1.1.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -99,7 +99,7 @@
     "core-js": "^3.1.4",
     "focus-visible": "^5.0.2",
     "intersection-observer": "^0.7.0",
-    "preact": "^8.4.2",
+    "preact": "^8.5.2",
     "preact-redux": "^2.0.3",
     "redux": "^4.0.4",
     "redux-thunk": "^2.3.0"


### PR DESCRIPTION
to #415 

Adds unescaping for username in main widget and last comments. (Not sure if I had to)

![Screenshot 2019-08-21 at 01 51 43](https://user-images.githubusercontent.com/884649/63390046-58099d00-c3b6-11e9-9ee5-ef32128afedb.png)
![Screenshot 2019-08-21 at 01 51 31](https://user-images.githubusercontent.com/884649/63390038-563fd980-c3b6-11e9-9caf-dea1080cdae9.png)
