### PR TITLE
Remove .golangci.yml file for golangci-lint service

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,2 +1,0 @@
-service:
-  golangci-lint-version: 1.19.1


### PR DESCRIPTION
Fix #615. Please remove repo from https://golangci.com/ to prevent errors from happening in the period before service will be decommissioned.