### PR TITLE
Site-wide email notifications for site owner 

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ _this is the recommended way to run remark42_
 | notify.telegram.timeout | NOTIFY_TELEGRAM_TIMEOUT | `5s`                     | telegram timeout                                |
 | notify.email.fromAddress | NOTIFY_EMAIL_FROM      |                          | from email address                              |
 | notify.email.verification_subj | NOTIFY_EMAIL_VERIFICATION_SUBJ | `Email verification` | verification message subject          |
+| notify.email.notify_admin | NOTIFY_EMAIL_ADMIN    | `false`                  | notify admin on new comments via ADMIN_SHARED_EMAIL |
 | smtp.host               | SMTP_HOST               |                          | SMTP host                                       |
 | smtp.port               | SMTP_PORT               |                          | SMTP port                                       |
 | smtp.username           | SMTP_USERNAME           |                          | SMTP user name                                  |

--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -200,6 +200,7 @@ type NotifyGroup struct {
 	Email struct {
 		From                string `long:"fromAddress" env:"FROM" description:"from email address"`
 		VerificationSubject string `long:"verification_subj" env:"VERIFICATION_SUBJ" description:"verification message subject"`
+		AdminNotifications  bool   `long:"notify_admin" env:"ADMIN" description:"notify admin on new comments via ADMIN_SHARED_EMAIL"`
 	} `group:"email" namespace:"email" env-namespace:"EMAIL"`
 }
 
@@ -785,6 +786,10 @@ func (s *ServerCommand) makeNotify(dataStore *service.DataStore, authenticator *
 					}
 					return tkn, nil
 				},
+			}
+			// enable admin notifications only if admin email is set
+			if s.Notify.Email.AdminNotifications && s.Admin.Shared.Email != "" {
+				emailParams.AdminEmail = s.Admin.Shared.Email
 			}
 			smtpParams := notify.SmtpParams{
 				Host:     s.SMTP.Host,

--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -438,6 +438,11 @@ func (s *ServerCommand) newServerApp() (*serverApp, error) {
 		SimpleView:         s.SimpleView,
 	}
 
+	// enable admin notifications only if admin email is set
+	if s.Notify.Email.AdminNotifications && s.Admin.Shared.Email != "" {
+		srv.AdminEmail = s.Admin.Shared.Email
+	}
+
 	srv.ScoreThresholds.Low, srv.ScoreThresholds.Critical = s.LowScore, s.CriticalScore
 
 	var devAuth *provider.DevAuthServer
@@ -786,10 +791,6 @@ func (s *ServerCommand) makeNotify(dataStore *service.DataStore, authenticator *
 					}
 					return tkn, nil
 				},
-			}
-			// enable admin notifications only if admin email is set
-			if s.Notify.Email.AdminNotifications && s.Admin.Shared.Email != "" {
-				emailParams.AdminEmail = s.Admin.Shared.Email
 			}
 			smtpParams := notify.SmtpParams{
 				Host:     s.SMTP.Host,

--- a/backend/app/notify/email_test.go
+++ b/backend/app/notify/email_test.go
@@ -100,17 +100,15 @@ func TestEmailSendErrors(t *testing.T) {
 
 	e.verifyTmpl, err = template.New("test").Parse("{{.Test}}")
 	assert.NoError(t, err)
-	err = e.Send(context.Background(), Request{Email: "bad@example.org", Verification: VerificationMetadata{Token: "some"}})
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "error executing template to build verification message: template: test:1:2: executing \"test\" at <.Test>: can't evaluate field Test in type notify.verifyTmplData")
+	assert.EqualError(t, e.Send(context.Background(), Request{Email: "bad@example.org", Verification: VerificationMetadata{Token: "some"}}),
+		"error executing template to build verification message: template: test:1:2: executing \"test\" at <.Test>: can't evaluate field Test in type notify.verifyTmplData")
 	e.verifyTmpl, err = template.New("test").Parse(defaultEmailVerificationTemplate)
 	assert.NoError(t, err)
 
 	e.msgTmpl, err = template.New("test").Parse("{{.Test}}")
 	assert.NoError(t, err)
-	err = e.Send(context.Background(), Request{Comment: store.Comment{ID: "999"}, parent: store.Comment{User: store.User{ID: "test"}}, Email: "bad@example.org"})
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "error executing template to build comment reply message: template: test:1:2: executing \"test\" at <.Test>: can't evaluate field Test in type notify.msgTmplData")
+	assert.EqualError(t, e.Send(context.Background(), Request{Comment: store.Comment{ID: "999"}, parent: store.Comment{User: store.User{ID: "test"}}, Email: "bad@example.org"}),
+		"error executing template to build comment reply message: template: test:1:2: executing \"test\" at <.Test>: can't evaluate field Test in type notify.msgTmplData")
 	e.msgTmpl, err = template.New("test").Parse(defaultEmailTemplate)
 	assert.NoError(t, err)
 
@@ -120,9 +118,8 @@ func TestEmailSendErrors(t *testing.T) {
 		"sending message to \"bad@example.org\" aborted due to canceled context")
 
 	e.smtp = &fakeTestSMTP{}
-	err = e.Send(context.Background(), Request{Comment: store.Comment{ID: "999"}, parent: store.Comment{User: store.User{ID: "error"}}, Email: "bad@example.org"})
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "error creating token for unsubscribe link: token generation error")
+	assert.EqualError(t, e.Send(context.Background(), Request{Comment: store.Comment{ID: "999"}, parent: store.Comment{User: store.User{ID: "error"}}, Email: "bad@example.org"}),
+		"error creating token for unsubscribe link: token generation error")
 	e.msgTmpl, err = template.New("test").Parse(defaultEmailTemplate)
 	assert.NoError(t, err)
 }
@@ -199,7 +196,7 @@ func TestEmail_Send(t *testing.T) {
 	assert.Equal(t, 1, fakeSmtp.readQuitCount())
 	assert.Equal(t, "test@example.org", fakeSmtp.readRcpt())
 	// test buildMessageFromRequest separately for message text
-	res, err := email.buildMessageFromRequest(req, false)
+	res, err := email.buildMessageFromRequest(req, req.ForAdmin)
 	assert.NoError(t, err)
 	assert.Contains(t, res, `From: from@example.org
 To: test@example.org
@@ -210,39 +207,15 @@ Content-Type: text/html; charset="UTF-8"
 List-Unsubscribe-Post: List-Unsubscribe=One-Click
 List-Unsubscribe: <https://remark42.com/api/v1/email/unsubscribe?site=&tkn=token>
 Date: `)
-}
 
-func TestEmail_SendAdmin(t *testing.T) {
-	email, err := NewEmail(EmailParams{From: "from@example.org", AdminEmail: "admin@example.org"}, SmtpParams{})
-	assert.NoError(t, err)
-	assert.NotNil(t, email)
-	fakeSmtp := fakeTestSMTP{}
-	email.smtp = &fakeSmtp
-	email.TokenGenFn = TokenGenFn
-	req := Request{
-		Comment: store.Comment{ID: "999", User: store.User{ID: "1", Name: "test_user"}, ParentID: "1", PostTitle: "test_title"},
-		parent:  store.Comment{ID: "1", User: store.User{ID: "999", Name: "parent_user"}},
-	}
-	assert.NoError(t, email.Send(context.TODO(), req))
-	assert.Equal(t, "from@example.org", fakeSmtp.readMail())
-	assert.Equal(t, 1, fakeSmtp.readQuitCount())
-	assert.Equal(t, "admin@example.org", fakeSmtp.readRcpt())
-	// test buildMessageFromRequest separately for message text
-	res, err := email.buildMessageFromRequest(req, true)
-	assert.NoError(t, err)
-	assert.Contains(t, res, `From: from@example.org
-To: admin@example.org
-Subject: New comment to your site for "test_title"
-Content-Transfer-Encoding: quoted-printable
-MIME-version: 1.0
-Content-Type: text/html; charset="UTF-8"
-Date: `)
 	// send email to admin without parent set
 	req = Request{
-		Comment: store.Comment{ID: "999", User: store.User{ID: "1", Name: "test_user"}, PostTitle: "test_title"},
+		Comment:  store.Comment{ID: "999", User: store.User{ID: "1", Name: "test_user"}, PostTitle: "test_title"},
+		Email:    "admin@example.org",
+		ForAdmin: true,
 	}
 	assert.NoError(t, email.Send(context.TODO(), req))
-	res, err = email.buildMessageFromRequest(req, true)
+	res, err = email.buildMessageFromRequest(req, req.ForAdmin)
 	assert.NoError(t, err)
 	assert.Contains(t, res, `From: from@example.org
 To: admin@example.org

--- a/backend/app/notify/telegram.go
+++ b/backend/app/notify/telegram.go
@@ -90,6 +90,11 @@ func (t *Telegram) Send(ctx context.Context, req Request) error {
 		// verification request received, send nothing
 		return nil
 	}
+	if req.ForAdmin {
+		// request for administrator received, do nothing with it
+		// as we already sent message on request without this flag set
+		return nil
+	}
 	client := http.Client{Timeout: telegramTimeOut}
 	log.Printf("[DEBUG] send telegram notification to %s, comment id %s", t.channelID, req.Comment.ID)
 

--- a/backend/app/rest/api/rest.go
+++ b/backend/app/rest/api/rest.go
@@ -50,6 +50,7 @@ type Rest struct {
 	AnonVote        bool
 	WebRoot         string
 	RemarkURL       string
+	AdminEmail      string
 	ReadOnlyAge     int
 	SharedSecret    string
 	ScoreThresholds struct {
@@ -364,6 +365,7 @@ func (s *Rest) controllerGroups() (public, private, admin, rss) {
 		authenticator:    s.Authenticator,
 		notifyService:    s.NotifyService,
 		remarkURL:        s.RemarkURL,
+		adminEmail:       s.AdminEmail,
 		anonVote:         s.AnonVote,
 	}
 

--- a/backend/app/rest/api/rest_private.go
+++ b/backend/app/rest/api/rest_private.go
@@ -39,6 +39,7 @@ type private struct {
 	notifyService    *notify.Service
 	authenticator    *auth.Service
 	remarkURL        string
+	adminEmail       string
 	anonVote         bool
 }
 
@@ -131,8 +132,13 @@ func (s *private) createCommentCtrl(w http.ResponseWriter, r *http.Request) {
 	s.cache.Flush(cache.Flusher(comment.Locator.SiteID).
 		Scopes(comment.Locator.URL, lastCommentsScope, comment.User.ID, comment.Locator.SiteID))
 
+	// user notification
 	if s.notifyService != nil {
 		s.notifyService.Submit(notify.Request{Comment: finalComment})
+	}
+	// admin notification
+	if s.notifyService != nil && s.adminEmail != "" {
+		s.notifyService.Submit(notify.Request{Comment: finalComment, Email: s.adminEmail, ForAdmin: true})
 	}
 
 	log.Printf("[DEBUG] created commend %+v", finalComment)

--- a/backend/app/rest/api/rest_test.go
+++ b/backend/app/rest/api/rest_test.go
@@ -368,9 +368,10 @@ func startupT(t *testing.T) (ts *httptest.Server, srv *Rest, teardown func()) {
 			SecretReader: token.SecretFunc(func() (string, error) { return "secret", nil }),
 			AvatarStore:  avatar.NewLocalFS(tmp + "/ava-remark42"),
 		}),
-		Cache:     memCache,
-		WebRoot:   tmp,
-		RemarkURL: "https://demo.remark42.com",
+		Cache:      memCache,
+		WebRoot:    tmp,
+		RemarkURL:  "https://demo.remark42.com",
+		AdminEmail: "admin@example.org",
 		ImageService: image.NewService(&image.FileSystem{
 			Location:   tmp + "/pics-remark42",
 			Partitions: 100,

--- a/compose-dev-backend.yml
+++ b/compose-dev-backend.yml
@@ -45,6 +45,8 @@ services:
             - NOTIFY_TELEGRAM_TOKEN
             - NOTIFY_TELEGRAM_CHAN
             - NOTIFY_EMAIL_FROM
+            - ADMIN_SHARED_EMAIL
+            - NOTIFY_EMAIL_ADMIN
             - SMTP_HOST
             - SMTP_USERNAME
             - SMTP_PASSWORD

--- a/docs/email.md
+++ b/docs/email.md
@@ -101,6 +101,9 @@ Here is the list of variables which affect email notifications:
 NOTIFY_TYPE
 NOTIFY_EMAIL_FROM
 NOTIFY_EMAIL_VERIFICATION_SUBJ
+# for administrator notifications for new comments on their site
+ADMIN_SHARED_EMAIL
+NOTIFY_EMAIL_ADMIN
 ```
 
 After `SMTP_` variables are set, you can allow email notifications by setting these two variables:


### PR DESCRIPTION
Add admin email notifications on new comments. Resolves #633.

<details>
<summary>Screenshots</summary>

Emails on new top-level comment and reply to it, with emails to admin and to parent comment user:

<img width="401" alt="image" src="https://user-images.githubusercontent.com/712534/78513194-2fe67700-77aa-11ea-9d67-0f1d3301654c.png">

Admin notification on top-level comment, style can be improved by frontenders (@akellbl4 ?):

<img width="661" alt="image" src="https://user-images.githubusercontent.com/712534/78513213-4e4c7280-77aa-11ea-8781-3daecff00aa7.png">

Notification on reply comment (I've removed "for dev_user" from here as well, screenshot is incorrect only about it):

<img width="652" alt="image" src="https://user-images.githubusercontent.com/712534/78513239-6cb26e00-77aa-11ea-9bee-67427ea353a8.png">

User notification on reply should be unaltered to the current state:

<img width="647" alt="image" src="https://user-images.githubusercontent.com/712534/78513297-d468b900-77aa-11ea-8b81-a5b5487f2107.png">
</details>