### PR TITLE
Fix docker run error without attached /srv/var

### DIFF
--- a/docker-init.sh
+++ b/docker-init.sh
@@ -5,4 +5,11 @@ sed -i "s|https://demo.remark42.com|${REMARK_URL}|g" /srv/web/*.js
 # remove devtools attach helper. TODO: move to webpack loader
 sed -i "/REMOVE-START/,/REMOVE-END/d" /srv/web/iframe.html
 
-chown -R app:app /srv/var 2>/dev/null
+if [ -d "/srv/var" ]; then
+  chown -R app:app /srv/var 2>/dev/null
+else
+  echo "ERROR: /srv/var doesn't exist, which means that state of the application"
+  echo "ERROR: will be lost on container stop or restart."
+  echo "ERROR: Please mount local directory to /srv/var in order for it to work."
+  exit 199
+fi


### PR DESCRIPTION
Before:

```
➜  docker run umputun/remark42:dev
init container
set timezone America/Chicago (Sat Apr 11 11:19:28 CDT 2020)
custom APP_UID not defined, using default uid=1001
execute /srv/init.sh
prepare environment
/srv/init.sh failed
```

After:

```
➜ docker run umputun/remark42:dev
init container
set timezone America/Chicago (Sat Apr 11 15:30:59 CDT 2020)
custom APP_UID not defined, using default uid=1001
execute /srv/init.sh
prepare environment
ERROR: /srv/var doesn't exist, which means that state of the application
ERROR: will be lost on container stop or restart.
ERROR: Please mount local directory to /srv/var in order for it to work.
/srv/init.sh failed
```