### PR TITLE
locale: zh.json: fixup typo for subscribeByEmail.submit

### DIFF
--- a/frontend/app/locales/zh.json
+++ b/frontend/app/locales/zh.json
@@ -136,7 +136,7 @@
   "subscribeByEmail.have-been-subscribed": "您已通过电子邮件订阅了更新通知",
   "subscribeByEmail.have-been-unsubscribed": "您已退订电子邮件更新通知",
   "subscribeByEmail.only-registered-users": "仅适用于注册用户",
-  "subscribeByEmail.submit": "年底",
+  "subscribeByEmail.submit": "提交",
   "subscribeByEmail.subscribe": "订阅",
   "subscribeByEmail.subscribe-by-email": "通过邮件订阅",
   "subscribeByEmail.subscribe-to-replies": "订阅回复",


### PR DESCRIPTION
locale: zh.json: fixup typo for subscribeByEmail.submit