### PR TITLE
notify/email.go: fixup smtp.NewClient second param

### DIFF
--- a/backend/app/notify/email.go
+++ b/backend/app/notify/email.go
@@ -464,7 +464,7 @@ func (s *emailClient) Create(params SmtpParams) (smtpClient, error) {
 		return nil, errors.Wrapf(err, "timeout connecting to %s", srvAddress)
 	}
 
-	c, err = smtp.NewClient(conn, srvAddress)
+	c, err = smtp.NewClient(conn, params.Host)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to dial")
 	}


### PR DESCRIPTION
1. second param is wrong

2. most time it does not effact the result, but when you are connecting to a localhost smtp server with 
PLAIN AUTH enabled but without TLS enabled. it will fail

I also marked this problem in my smtp-brd [FAQ](https://github.com/ttys3/smtp-brd#faq)

>  `smtp.plainAuth failed: unencrypted connection`
    You need either to setup TLS on your SMTP server,
    use localhost as a relay or disable authentication.
    the answer come from  
    [this issue](https://github.com/prometheus/alertmanager/issues/1358#issuecomment-386209698)

    The error is because the Go SMTP package doesn't allow authentication without encryption.
    From <https://godoc.org/net/smtp#PlainAuth>

>   PlainAuth will only send the credentials if the connection is using TLS
        or is connected to `localhost`. Otherwise authentication
        will fail with an error, without sending the credentials.

the important part is `localhost`, if your send it `localhost:25` or other addr with port, it will fail.
