### PR TITLE
smtp buildMessage(): flush quotedprintable writer buff explicitly

### DIFF
--- a/backend/app/notify/email.go
+++ b/backend/app/notify/email.go
@@ -371,7 +371,10 @@ func (e *Email) buildMessage(subject, body, to, contentType, unsubscribeLink str
 	if _, err := qp.Write([]byte(body)); err != nil {
 		return "", err
 	}
-	defer qp.Close()
+	// flush now, must NOT use defer, for small body, defer may cause buff.String() got empty body
+	if err := qp.Close(); err != nil {
+		return "", fmt.Errorf("quotedprintable Write failed: %w", err)
+	}
 	m := buff.String()
 	message += "\n" + m
 	return message, nil


### PR DESCRIPTION
I found this problem when I was refactoring the `email provider` code ( the PR which got rejected by umputun).

a simple test run under my local machine ( 6 core 12 thread CPU with 4.7GHz freq) failed, the test code looks like:

```go
	htmlContent := "<strong>simple HTML body goes here</strong>"
	t.Logf("try send via SMTP from %s to %s", fromEmail, toEmail)

	msg, err := buildMessage(toEmail, htmlContent, "text/html")
	if err != nil {
		t.Error(err)
	}
        // now only got the headers, body is missing
	t.Logf("mail msg: %s", msg)
	if !strings.Contains(msg, htmlContent) {
		t.Errorf("BuildMessage lost body")
	}
```

look into `quotedprintable.Close()` function, you' find it implicitly called `flush()`:
```go
// Close closes the Writer, flushing any unwritten data to the underlying
// io.Writer, but does not close the underlying io.Writer.
func (w *Writer) Close() error {
	if err := w.checkLastByte(); err != nil {
		return err
	}

	return w.flush()
}
```

the old buggy code is 
https://github.com/umputun/remark42/blob/cab3b8a831ac482f112fb4ab3852688f9c4218b4/backend/app/notify/email.go#L374-L378

it called `buff.String()` after `defer qp.Close()`  but the buff actrully got flushed **after** the `m := buff.String()` call


