### PR TITLE
remove t.Log from test server.Run in memory_store

### DIFF
--- a/backend/_example/memory_store/server/rpc_test.go
+++ b/backend/_example/memory_store/server/rpc_test.go
@@ -63,7 +63,7 @@ func prepTestStore(t *testing.T) (s *RPC, port int, teardown func()) {
 
 	port = chooseRandomUnusedPort()
 	go func() {
-		t.Logf("%v", s.Run(port))
+		_ = s.Run(port)
 	}()
 
 	waitForHTTPServerStart(port)


### PR DESCRIPTION
This resolves panic in memory_store tests.