### PR TITLE
 serve proxified images disregarding if saving is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -879,5 +879,6 @@ _all admin calls require auth and admin privilege_
 * User can edit comments in 5 mins (configurable) window after creation.
 * User ID hashed and prefixed by oauth provider name to avoid collisions and potential abuse.
 * All avatars resized and cached locally to prevent rate limiters from oauth providers, part of [go-pkgz/auth](https://github.com/go-pkgz/auth) functionality.
-* Images can be proxied (`IMG_PROXY=true`) to prevent mixed http/https.
+* Images can be proxied (`IMAGE_PROXY_HTTP2HTTPS=true`) to prevent mixed http/https.
+* All images can be proxied and saved (`IMAGE_PROXY_CACHE_EXTERNAL=true`) instead of serving from original location. Beware, images which are posted with this parameter enabled will be served from proxy even after it will be disabled.
 * Docker build uses [publicly available](https://github.com/umputun/baseimage) base images.


### PR DESCRIPTION
Resolves #614.

- serve `/api/v1/img` requests disregarding if saving of image proxy is enabled or not
  This does increase the load time for every proxified image with caching disabled, as we first try to read it from cache anyway.
- document behavior above in the readme
- fix reference to outdated  ENV configuration variable in Readme