### PR TITLE
Bump CI go version to v1.14, golangci-lint to v1.23.8.

### DIFF
--- a/.github/workflows/ci-test-backend.yml
+++ b/.github/workflows/ci-test-backend.yml
@@ -29,7 +29,7 @@ jobs:
       - name: install go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.14
 
       - name: install golangci-lint and goveralls
         run: |

--- a/.github/workflows/ci-test-backend.yml
+++ b/.github/workflows/ci-test-backend.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: install golangci-lint and goveralls
         run: |
-          curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $GITHUB_WORKSPACE v1.23.0
+          curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $GITHUB_WORKSPACE v1.23.8
           go get -u github.com/mattn/goveralls
 
       - name: test and lint backend


### PR DESCRIPTION
I want to resolve #641 and it seems like all problems which we saw related to golangci-lint v1.24.0.
This PR updates lint to the latest minor version before the problem one as well as bumps CI go to 1.14.