### PR TITLE
Remove unused sed from artifacts build

### DIFF
--- a/Dockerfile.artifacts
+++ b/Dockerfile.artifacts
@@ -45,7 +45,6 @@ COPY --from=build-frontend /srv/frontend/public/ web
 RUN \
     export WEB_ROOT=/build/backend/web && \
     sed -i "s|https://demo.remark42.com|http://127.0.0.1:8080|g" ${WEB_ROOT}/*.js && \
-    sed -i "/REMOVE-START/,/REMOVE-END/d" ${WEB_ROOT}/iframe.html && \
     statik --src=${WEB_ROOT} --dest=/build/backend/app/rest -p api -f && \
     ls -la /build/backend/app/rest/api/statik.go && \
     ls -la /build/backend/web/


### PR DESCRIPTION
I removed this part in docker build in this [PR](https://github.com/umputun/remark42/pull/663/files)
Because it was changed to webpack replacement.