### PR TITLE
Simplify image.Store interface

### DIFF
--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -4,8 +4,34 @@ run:
     format: tab
   skip-dirs:
     - vendor
+
+linters-settings:
+  govet:
+    check-shadowing: true
+  golint:
+    min-confidence: 0.1
+  maligned:
+    suggest-new: true
+  goconst:
+    min-len: 2
+    min-occurrences: 2
+  misspell:
+    locale: US
+  lll:
+    line-length: 140
+  gocritic:
+    enabled-tags:
+      - performance
+      - style
+      - experimental
+    disabled-checks:
+      - wrapperFunc
+
 linters:
   enable:
+    - megacheck
+    - golint
+    - govet
     - unconvert
     - megacheck
     - structcheck
@@ -19,9 +45,24 @@ linters:
     - typecheck
     - ineffassign
     - varcheck
+    - stylecheck
+    - gochecknoinits
+    - scopelint
+    - nakedret
+    - gosimple
+    - prealloc
+  fast: false
   disable-all: true
+
 issues:
+  exclude-rules:
+    - text: "at least one file in a package should have a package comment"
+      linters:
+        - stylecheck
+    - text: "should have a package comment, unless it's in another file for this package"
+      linters:
+        - golint
   exclude-use-default: false
 
 service:
-  golangci-lint-version: 1.24.x
+  golangci-lint-version: 1.23.x

--- a/backend/_example/memory_store/accessor/admin.go
+++ b/backend/_example/memory_store/accessor/admin.go
@@ -75,7 +75,7 @@ func (m *MemAdmin) OnEvent(siteID string, ev admin.EventType) error {
 		return errors.Errorf("site %s not found", siteID)
 	}
 	if ev == admin.EvCreate {
-		resp.CountCreated += 1 // not a good idea, just for demo
+		resp.CountCreated++ // not a good idea, just for demo
 		m.data[siteID] = resp
 	}
 	return nil

--- a/backend/_example/memory_store/accessor/image.go
+++ b/backend/_example/memory_store/accessor/image.go
@@ -8,13 +8,11 @@ package accessor
 
 import (
 	"context"
-	"path"
 	"sync"
 	"time"
 
 	log "github.com/go-pkgz/lgr"
 	"github.com/pkg/errors"
-	"github.com/rs/xid"
 )
 
 // MemImage implements image.Store with memory backend
@@ -35,18 +33,13 @@ func NewMemImageStore() *MemImage {
 	}
 }
 
-func (m *MemImage) Save(userID string, img []byte) (id string, err error) {
-	id = path.Join(userID, guid())
-	return m.SaveWithID(id, img)
-}
-
-func (m *MemImage) SaveWithID(id string, img []byte) (string, error) {
+func (m *MemImage) SaveWithID(id string, img []byte) error {
 	m.Lock()
 	m.imagesStaging[id] = img
 	m.insertTime[id] = time.Now()
 	m.Unlock()
 
-	return id, nil
+	return nil
 }
 
 func (m *MemImage) Load(id string) ([]byte, error) {
@@ -97,9 +90,4 @@ func (m *MemImage) Cleanup(_ context.Context, ttl time.Duration) error {
 	}
 	m.Unlock()
 	return nil
-}
-
-// guid makes a globally unique id
-func guid() string {
-	return xid.New().String()
 }

--- a/backend/_example/memory_store/accessor/image.go
+++ b/backend/_example/memory_store/accessor/image.go
@@ -33,7 +33,7 @@ func NewMemImageStore() *MemImage {
 	}
 }
 
-func (m *MemImage) SaveWithID(id string, img []byte) error {
+func (m *MemImage) Save(id string, img []byte) error {
 	m.Lock()
 	m.imagesStaging[id] = img
 	m.insertTime[id] = time.Now()

--- a/backend/_example/memory_store/accessor/image.go
+++ b/backend/_example/memory_store/accessor/image.go
@@ -33,6 +33,7 @@ func NewMemImageStore() *MemImage {
 	}
 }
 
+// Save stores image with passed id to staging
 func (m *MemImage) Save(id string, img []byte) error {
 	m.Lock()
 	m.imagesStaging[id] = img
@@ -42,6 +43,7 @@ func (m *MemImage) Save(id string, img []byte) error {
 	return nil
 }
 
+// Load image by ID
 func (m *MemImage) Load(id string) ([]byte, error) {
 	m.RLock()
 	img, ok := m.images[id]
@@ -55,6 +57,7 @@ func (m *MemImage) Load(id string) ([]byte, error) {
 	return img, nil
 }
 
+// Commit moves image from staging to permanent
 func (m *MemImage) Commit(id string) error {
 	m.RLock()
 	img, ok := m.imagesStaging[id]
@@ -70,6 +73,7 @@ func (m *MemImage) Commit(id string) error {
 	return nil
 }
 
+// Cleanup runs removal loop for old images on staging
 func (m *MemImage) Cleanup(_ context.Context, ttl time.Duration) error {
 	var idsToRemove []string
 

--- a/backend/_example/memory_store/accessor/image_test.go
+++ b/backend/_example/memory_store/accessor/image_test.go
@@ -51,7 +51,7 @@ func TestMemImage_LoadAfterSave(t *testing.T) {
 	assert.Empty(t, img)
 
 	id := "test_img"
-	err = svc.SaveWithID(id, gopher)
+	err = svc.Save(id, gopher)
 	assert.NoError(t, err)
 
 	img, err = svc.Load(id)

--- a/backend/_example/memory_store/accessor/image_test.go
+++ b/backend/_example/memory_store/accessor/image_test.go
@@ -41,20 +41,6 @@ const gopher = "iVBORw0KGgoAAAANSUhEUgAAAEsAAAA8CAAAAAALAhhPAAAFfUlEQVRYw62XeWwU
 
 func gopherPNG() io.Reader { return base64.NewDecoder(base64.StdEncoding, strings.NewReader(gopher)) }
 
-func TestMemImage_Save(t *testing.T) {
-	svc := NewMemImageStore()
-	id, err := svc.Save("user1", []byte(gopher))
-	assert.NoError(t, err)
-	assert.Contains(t, id, "user1/")
-}
-
-func TestMemImage_SaveWithIDFail(t *testing.T) {
-	svc := NewMemImageStore()
-	id, err := svc.SaveWithID("test_id", []byte(gopher))
-	assert.NoError(t, err)
-	assert.Equal(t, id, "test_id")
-}
-
 func TestMemImage_LoadAfterSave(t *testing.T) {
 	svc := NewMemImageStore()
 	gopher, err := ioutil.ReadAll(gopherPNG())
@@ -64,7 +50,8 @@ func TestMemImage_LoadAfterSave(t *testing.T) {
 	assert.EqualError(t, err, "image test_id not found")
 	assert.Empty(t, img)
 
-	id, err := svc.Save("user1", gopher)
+	id := "test_img"
+	err = svc.SaveWithID(id, gopher)
 	assert.NoError(t, err)
 
 	img, err = svc.Load(id)

--- a/backend/_example/memory_store/go.mod
+++ b/backend/_example/memory_store/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/go-pkgz/jrpc v0.1.0
 	github.com/go-pkgz/lgr v0.7.0
 	github.com/pkg/errors v0.9.1
-	github.com/rs/xid v1.2.1
 	github.com/stretchr/testify v1.5.1
 	github.com/umputun/go-flags v1.5.1
 	github.com/umputun/remark/backend v1.5.0

--- a/backend/_example/memory_store/server/image.go
+++ b/backend/_example/memory_store/server/image.go
@@ -24,7 +24,7 @@ func (s *RPC) imgSaveWithIDHndl(id uint64, params json.RawMessage) (rr jrpc.Resp
 	if err != nil {
 		return jrpc.Response{Error: err.Error()}
 	}
-	err = s.img.SaveWithID(req[0], img)
+	err = s.img.Save(req[0], img)
 	return jrpc.EncodeResponse(id, nil, err)
 }
 

--- a/backend/_example/memory_store/server/image.go
+++ b/backend/_example/memory_store/server/image.go
@@ -15,19 +15,6 @@ import (
 	"github.com/go-pkgz/jrpc"
 )
 
-func (s *RPC) imgSaveHndl(id uint64, params json.RawMessage) (rr jrpc.Response) {
-	var req [2]string
-	if err := json.Unmarshal(params, &req); err != nil {
-		return jrpc.Response{Error: err.Error()}
-	}
-	img, err := base64.StdEncoding.DecodeString(req[1])
-	if err != nil {
-		return jrpc.Response{Error: err.Error()}
-	}
-	value, err := s.img.Save(req[0], img)
-	return jrpc.EncodeResponse(id, value, err)
-}
-
 func (s *RPC) imgSaveWithIDHndl(id uint64, params json.RawMessage) (rr jrpc.Response) {
 	var req [2]string
 	if err := json.Unmarshal(params, &req); err != nil {
@@ -37,8 +24,8 @@ func (s *RPC) imgSaveWithIDHndl(id uint64, params json.RawMessage) (rr jrpc.Resp
 	if err != nil {
 		return jrpc.Response{Error: err.Error()}
 	}
-	value, err := s.img.SaveWithID(req[0], img)
-	return jrpc.EncodeResponse(id, value, err)
+	err = s.img.SaveWithID(req[0], img)
+	return jrpc.EncodeResponse(id, nil, err)
 }
 
 func (s *RPC) imgLoadHndl(id uint64, params json.RawMessage) (rr jrpc.Response) {

--- a/backend/_example/memory_store/server/image_test.go
+++ b/backend/_example/memory_store/server/image_test.go
@@ -58,7 +58,7 @@ func TestRPC_imgLoadHndl(t *testing.T) {
 	ri := image.RPC{Client: jrpc.Client{API: api, Client: http.Client{Timeout: 1 * time.Second}}}
 	// save
 	id := "test_img"
-	err := ri.SaveWithID(id, gopherPNGBytes())
+	err := ri.Save(id, gopherPNGBytes())
 	assert.NoError(t, err)
 
 	// load
@@ -107,7 +107,7 @@ func TestRPC_imgCleanupHndl(t *testing.T) {
 
 	// save
 	id := "test_img"
-	err := ri.SaveWithID(id, gopherPNGBytes())
+	err := ri.Save(id, gopherPNGBytes())
 	assert.NoError(t, err)
 
 	// load

--- a/backend/_example/memory_store/server/rpc.go
+++ b/backend/_example/memory_store/server/rpc.go
@@ -57,7 +57,6 @@ func (s *RPC) addHandlers() {
 
 	// image store handlers
 	s.Group("image", jrpc.HandlersGroup{
-		"save":         s.imgSaveHndl,
 		"save_with_id": s.imgSaveWithIDHndl,
 		"load":         s.imgLoadHndl,
 		"commit":       s.imgCommitHndl,

--- a/backend/app/cmd/avatar.go
+++ b/backend/app/cmd/avatar.go
@@ -34,7 +34,7 @@ func (a avatarMigrator) Migrate(dst, src avatar.Store) (int, error) {
 }
 
 // Execute runs  with AvatarCommand parameters, entry point for "avatar" command
-func (ac *AvatarCommand) Execute(args []string) error {
+func (ac *AvatarCommand) Execute(_ []string) error {
 	log.Printf("[INFO] migrate avatars from %s to %s", ac.AvatarSrc.Type, ac.AvatarDst.Type)
 
 	src, err := ac.makeAvatarStore(ac.AvatarSrc)

--- a/backend/app/cmd/avatar_test.go
+++ b/backend/app/cmd/avatar_test.go
@@ -42,7 +42,7 @@ type avatarMigratorMock struct {
 	retCount int
 }
 
-func (a *avatarMigratorMock) Migrate(dst, src avatar.Store) (int, error) {
+func (a *avatarMigratorMock) Migrate(_, _ avatar.Store) (int, error) {
 	a.called++
 	return a.retCount, a.retError
 }

--- a/backend/app/cmd/backup.go
+++ b/backend/app/cmd/backup.go
@@ -24,7 +24,7 @@ type BackupCommand struct {
 }
 
 // Execute runs export with ExportCommand parameters, entry point for "export" command
-func (ec *BackupCommand) Execute(args []string) error {
+func (ec *BackupCommand) Execute(_ []string) error {
 	log.Printf("[INFO] export to %s, site %s", ec.ExportPath, ec.Site)
 	resetEnv("SECRET", "ADMIN_PASSWD")
 

--- a/backend/app/cmd/cleanup.go
+++ b/backend/app/cmd/cleanup.go
@@ -34,7 +34,7 @@ var (
 
 // Execute runs cleanup with CleanupCommand parameters, entry point for "cleanup" command
 // This command uses provided flags to detect and remove junk comments
-func (cc *CleanupCommand) Execute(args []string) error {
+func (cc *CleanupCommand) Execute(_ []string) error {
 	log.Printf("[INFO] cleanup for site %s", cc.Site)
 
 	posts, err := cc.postsInRange(cc.From, cc.To)

--- a/backend/app/cmd/cleanup_test.go
+++ b/backend/app/cmd/cleanup_test.go
@@ -144,7 +144,7 @@ func TestCleanup_ExecuteTitle(t *testing.T) {
 }
 
 func cleanupRoutes(t *testing.T, r *chi.Mux, c *cleanedComments) {
-	r.HandleFunc("/api/v1/list", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.HandleFunc("/api/v1/list", func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "GET", r.Method)
 		require.Equal(t, "site=remark&limit=10000", r.URL.RawQuery)
 		list := []store.PostInfo{
@@ -165,9 +165,9 @@ func cleanupRoutes(t *testing.T, r *chi.Mux, c *cleanedComments) {
 			},
 		}
 		require.NoError(t, json.NewEncoder(w).Encode(list))
-	}))
+	})
 
-	r.HandleFunc("/api/v1/find", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.HandleFunc("/api/v1/find", func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "GET", r.Method)
 		require.Equal(t, "remark", r.URL.Query().Get("site"))
 		require.Equal(t, "plain", r.URL.Query().Get("format"))
@@ -193,22 +193,22 @@ func cleanupRoutes(t *testing.T, r *chi.Mux, c *cleanedComments) {
 		}
 
 		require.NoError(t, json.NewEncoder(w).Encode(commentsWithInfo))
-	}))
+	})
 
-	r.HandleFunc("/api/v1/admin/comment/{id}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.HandleFunc("/api/v1/admin/comment/{id}", func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "DELETE", r.Method)
 		t.Log("delete ", r.URL.Path)
 		c.lock.Lock()
 		c.ids = append(c.ids, r.URL.Path)
 		c.lock.Unlock()
-	}))
+	})
 
-	r.HandleFunc("/api/v1/admin/title/{id}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.HandleFunc("/api/v1/admin/title/{id}", func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "PUT", r.Method)
 		t.Log("title for ", r.URL.Path)
 		c.lock.Lock()
 		c.ids = append(c.ids, r.URL.Path)
 		c.lock.Unlock()
-	}))
+	})
 
 }

--- a/backend/app/cmd/import.go
+++ b/backend/app/cmd/import.go
@@ -26,7 +26,7 @@ type ImportCommand struct {
 }
 
 // Execute runs import with ImportCommand parameters, entry point for "import" command
-func (ic *ImportCommand) Execute(args []string) error {
+func (ic *ImportCommand) Execute(_ []string) error {
 	log.Printf("[INFO] import %s (%s), site %s", ic.InputFile, ic.Provider, ic.Site)
 	resetEnv("SECRET", "ADMIN_PASSWD")
 

--- a/backend/app/cmd/remap.go
+++ b/backend/app/cmd/remap.go
@@ -23,7 +23,7 @@ type RemapCommand struct {
 }
 
 // Execute runs (re)mapper with RemapCommand parameters, entry point for "remap" command
-func (rc *RemapCommand) Execute(args []string) error {
+func (rc *RemapCommand) Execute(_ []string) error {
 	log.Printf("[INFO] start remap, site %s, file with rules %s", rc.Site, rc.InputFile)
 	resetEnv("SECRET", "ADMIN_PASSWD")
 

--- a/backend/app/main.go
+++ b/backend/app/main.go
@@ -84,6 +84,7 @@ func getDump() string {
 	return string(stacktrace[:length])
 }
 
+// nolint:gochecknoinits
 func init() {
 	// catch SIGQUIT and print stack traces
 	sigChan := make(chan os.Signal)

--- a/backend/app/migrator/backup_test.go
+++ b/backend/app/migrator/backup_test.go
@@ -77,7 +77,7 @@ func TestBackup_Do(t *testing.T) {
 
 type mockExporter struct{}
 
-func (mock *mockExporter) Export(w io.Writer, siteID string) (int, error) {
+func (mock *mockExporter) Export(w io.Writer, _ string) (int, error) {
 	_, err := w.Write([]byte("some export blah blah 1234567890"))
 	return 1000, err
 }

--- a/backend/app/migrator/mapper.go
+++ b/backend/app/migrator/mapper.go
@@ -7,15 +7,15 @@ import (
 	"strings"
 )
 
-// UrlMapper implements Mapper interface
-type UrlMapper struct {
+// URLMapper implements Mapper interface
+type URLMapper struct {
 	rules map[string]string
 }
 
-// NewUrlMapper reads rules from given reader and returns initialised UrlMapper
+// NewURLMapper reads rules from given reader and returns initialized URLMapper
 // if given rules are valid.
-func NewUrlMapper(reader io.Reader) (Mapper, error) {
-	u := &UrlMapper{}
+func NewURLMapper(reader io.Reader) (Mapper, error) {
+	u := &URLMapper{}
 	if err := u.loadRules(reader); err != nil {
 		return u, err
 	}
@@ -29,7 +29,7 @@ func NewUrlMapper(reader io.Reader) (Mapper, error) {
 // Example:
 // https://www.myblog.com/blog/1/ https://myblog.com/blog/1/
 // https://www.myblog.com/* https://myblog.com/*
-func (u *UrlMapper) loadRules(reader io.Reader) error {
+func (u *URLMapper) loadRules(reader io.Reader) error {
 	data, err := ioutil.ReadAll(reader)
 	if err != nil {
 		return err
@@ -54,19 +54,19 @@ func (u *UrlMapper) loadRules(reader io.Reader) error {
 
 // URL maps given url to another url according loaded url-rules.
 // If not matched returns given url.
-func (u *UrlMapper) URL(url string) string {
-	if newUrl, ok := u.rules[url]; ok {
-		return newUrl
+func (u *URLMapper) URL(url string) string {
+	if newURL, ok := u.rules[url]; ok {
+		return newURL
 	}
 	// try to match by prefix
-	for oldUrl, newUrl := range u.rules {
-		if !strings.HasSuffix(oldUrl, "*") {
+	for oldURL, newURL := range u.rules {
+		if !strings.HasSuffix(oldURL, "*") {
 			continue
 		}
-		oldUrl = strings.TrimSuffix(oldUrl, "*")
-		newUrl = strings.TrimSuffix(newUrl, "*")
-		if strings.HasPrefix(url, oldUrl) {
-			return newUrl + strings.TrimPrefix(url, oldUrl)
+		oldURL = strings.TrimSuffix(oldURL, "*")
+		newURL = strings.TrimSuffix(newURL, "*")
+		if strings.HasPrefix(url, oldURL) {
+			return newURL + strings.TrimPrefix(url, oldURL)
 		}
 	}
 	// search failed, return given url

--- a/backend/app/migrator/mapper_test.go
+++ b/backend/app/migrator/mapper_test.go
@@ -16,7 +16,7 @@ https://radio-t.com/p/2018/09/22////podcast-616/ https://www.radio-t.com/p/2018/
 https://radio-t.com/p/2018/09/22/podcast-616/?with_query=1 https://www.radio-t.com/p/2018/09/22/podcast-616/
 `)
 
-	mapper, err := NewUrlMapper(rules)
+	mapper, err := NewURLMapper(rules)
 	assert.NoError(t, err)
 
 	// if url not matched mapper should return given url
@@ -30,7 +30,7 @@ https://radio-t.com/p/2018/09/22/podcast-616/?with_query=1 https://www.radio-t.c
 
 	// want remap from http to https
 	rules = strings.NewReader(`http://anysite.com/p/123 https://anysite.com/p/321`)
-	mapper, err = NewUrlMapper(rules)
+	mapper, err = NewURLMapper(rules)
 	assert.NoError(t, err)
 	assert.Equal(t, "https://anysite.com/p/321", mapper.URL("http://anysite.com/p/123"))
 	assert.Equal(t, "https://notexist", mapper.URL("https://notexist"))
@@ -38,7 +38,7 @@ https://radio-t.com/p/2018/09/22/podcast-616/?with_query=1 https://www.radio-t.c
 
 	// want remap from http to https by pattern
 	rules = strings.NewReader(`http://anysite.com* https://anysite.com*`)
-	mapper, err = NewUrlMapper(rules)
+	mapper, err = NewURLMapper(rules)
 	assert.NoError(t, err)
 	assert.Equal(t, "https://anysite.com/p/1", mapper.URL("http://anysite.com/p/1"))
 	assert.Equal(t, "https://anysite.com/", mapper.URL("http://anysite.com/"))
@@ -80,7 +80,7 @@ func TestUrlMapper_New(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		_, err := NewUrlMapper(strings.NewReader(c.rules))
+		_, err := NewURLMapper(strings.NewReader(c.rules))
 		if c.expectError {
 			assert.Error(t, err)
 		} else {

--- a/backend/app/migrator/native_test.go
+++ b/backend/app/migrator/native_test.go
@@ -105,7 +105,7 @@ func TestNative_ImportWithMapper(t *testing.T) {
 
 	// want to remap comments to https://rdt.c
 	rules := `https://radio-t.com* https://rdt.c*`
-	mapper, err := NewUrlMapper(strings.NewReader(rules))
+	mapper, err := NewURLMapper(strings.NewReader(rules))
 	assert.NoError(t, err)
 
 	inp := `{"version":1,"users":[{"id":"user1","blocked":{"status":false,"until":"0001-01-01T00:00:00Z"},"verified":true},{"id":"user2","blocked":{"status":true,"until":"2018-12-23T02:55:22.472041-06:00"},"verified":false}],"posts":[{"url":"https://radio-t.com","read_only":true}]}

--- a/backend/app/notify/email_test.go
+++ b/backend/app/notify/email_test.go
@@ -22,7 +22,7 @@ func TestEmailNew(t *testing.T) {
 		err         bool
 		errText     string
 		emailParams EmailParams
-		smtpParams  SmtpParams
+		smtpParams  SMTPParams
 	}{
 		{name: "empty"},
 		{name: "with template parse error",
@@ -36,7 +36,7 @@ func TestEmailNew(t *testing.T) {
 				From:                 "test@from",
 				VerificationTemplate: "{{",
 			},
-			smtpParams: SmtpParams{
+			smtpParams: SMTPParams{
 				Host:     "test@host",
 				Port:     1000,
 				TLS:      true,
@@ -50,7 +50,7 @@ func TestEmailNew(t *testing.T) {
 			emailParams: EmailParams{
 				From: "test@from",
 			},
-			smtpParams: SmtpParams{
+			smtpParams: SMTPParams{
 				Host:     "test@host",
 				Port:     1000,
 				TLS:      true,
@@ -125,7 +125,7 @@ func TestEmailSendErrors(t *testing.T) {
 }
 
 func TestEmailSend_ExitConditions(t *testing.T) {
-	email, err := NewEmail(EmailParams{}, SmtpParams{})
+	email, err := NewEmail(EmailParams{}, SMTPParams{})
 	assert.NoError(t, err)
 	assert.NotNil(t, email, "expecting email returned")
 	// prevent triggering e.autoFlush creation
@@ -179,7 +179,7 @@ func TestEmailSendClientError(t *testing.T) {
 }
 
 func TestEmail_Send(t *testing.T) {
-	email, err := NewEmail(EmailParams{From: "from@example.org"}, SmtpParams{})
+	email, err := NewEmail(EmailParams{From: "from@example.org"}, SMTPParams{})
 	assert.NoError(t, err)
 	assert.NotNil(t, email)
 	fakeSmtp := fakeTestSMTP{}
@@ -227,7 +227,7 @@ Date: `)
 }
 
 func TestEmail_SendVerification(t *testing.T) {
-	email, err := NewEmail(EmailParams{From: "from@example.org"}, SmtpParams{})
+	email, err := NewEmail(EmailParams{From: "from@example.org"}, SMTPParams{})
 	assert.NoError(t, err)
 	assert.NotNil(t, email)
 	fakeSmtp := fakeTestSMTP{}
@@ -272,7 +272,7 @@ Date: `)
 
 func Test_emailClient_Create(t *testing.T) {
 	creator := emailClient{}
-	client, err := creator.Create(SmtpParams{})
+	client, err := creator.Create(SMTPParams{})
 	assert.Error(t, err, "absence of address to connect results in error")
 	assert.Nil(t, client, "no client returned in case of error")
 }
@@ -288,7 +288,7 @@ type fakeTestSMTP struct {
 	lock       sync.RWMutex
 }
 
-func (f *fakeTestSMTP) Create(SmtpParams) (smtpClient, error) {
+func (f *fakeTestSMTP) Create(SMTPParams) (smtpClient, error) {
 	if f.fail["create"] {
 		return nil, errors.New("failed to create client")
 	}

--- a/backend/app/notify/notify_mock.go
+++ b/backend/app/notify/notify_mock.go
@@ -9,6 +9,7 @@ import (
 	log "github.com/go-pkgz/lgr"
 )
 
+// MockDest is a destination mock
 type MockDest struct {
 	data   []Request
 	id     int
@@ -16,6 +17,7 @@ type MockDest struct {
 	lock   sync.Mutex
 }
 
+// Send mock
 func (m *MockDest) Send(ctx context.Context, r Request) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
@@ -30,6 +32,7 @@ func (m *MockDest) Send(ctx context.Context, r Request) error {
 	return nil
 }
 
+// Get mock
 func (m *MockDest) Get() []Request {
 	m.lock.Lock()
 	defer m.lock.Unlock()

--- a/backend/app/rest/api/admin.go
+++ b/backend/app/rest/api/admin.go
@@ -111,7 +111,7 @@ func (a *admin) deleteMeRequestCtrl(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := a.dataService.DeleteUserDetail(claims.Audience, claims.User.ID, engine.UserEmail); err != nil {
+	if err = a.dataService.DeleteUserDetail(claims.Audience, claims.User.ID, engine.UserEmail); err != nil {
 		code := parseError(err, rest.ErrInternal)
 		rest.SendErrorJSON(w, r, http.StatusBadRequest, err, "can't delete email for user", code)
 		return

--- a/backend/app/rest/api/admin_test.go
+++ b/backend/app/rest/api/admin_test.go
@@ -55,8 +55,8 @@ func TestAdmin_Delete(t *testing.T) {
 	j := []store.PostInfo{}
 	err = json.Unmarshal(bb, &j)
 	assert.NoError(t, err)
-	assert.Equal(t, []store.PostInfo([]store.PostInfo{{URL: "https://radio-t.com/blah", Count: 2},
-		{URL: "https://radio-t.com/blah2", Count: 0}}), j)
+	assert.Equal(t, []store.PostInfo{{URL: "https://radio-t.com/blah", Count: 2},
+		{URL: "https://radio-t.com/blah2", Count: 0}}, j)
 
 	// delete a comment
 	req, err := http.NewRequest(http.MethodDelete,
@@ -103,8 +103,8 @@ func TestAdmin_Delete(t *testing.T) {
 	j = []store.PostInfo{}
 	err = json.Unmarshal(bb, &j)
 	assert.NoError(t, err)
-	assert.Equal(t, []store.PostInfo([]store.PostInfo{{URL: "https://radio-t.com/blah", Count: 1},
-		{URL: "https://radio-t.com/blah2", Count: 0}}), j)
+	assert.Equal(t, []store.PostInfo{{URL: "https://radio-t.com/blah", Count: 1},
+		{URL: "https://radio-t.com/blah2", Count: 0}}, j)
 }
 
 func TestAdmin_Title(t *testing.T) {
@@ -310,7 +310,7 @@ func TestAdmin_Block(t *testing.T) {
 	pi = []store.PostInfo{}
 	err = json.Unmarshal(body, &pi)
 	assert.NoError(t, err)
-	assert.Equal(t, []store.PostInfo([]store.PostInfo{{URL: "https://radio-t.com/blah", Count: 1}}), pi)
+	assert.Equal(t, []store.PostInfo{{URL: "https://radio-t.com/blah", Count: 1}}, pi)
 
 	res, code := get(t, ts.URL+"/api/v1/find?site=remark42&url=https://radio-t.com/blah&sort=+time")
 	assert.Equal(t, 200, code)

--- a/backend/app/rest/api/migrator.go
+++ b/backend/app/rest/api/migrator.go
@@ -28,7 +28,7 @@ type Migrator struct {
 	DisqusImporter    migrator.Importer
 	WordPressImporter migrator.Importer
 	NativeExporter    migrator.Exporter
-	UrlMapperMaker    migrator.MapperMaker
+	URLMapperMaker    migrator.MapperMaker
 	KeyStore          KeyStore
 
 	busy map[string]bool
@@ -161,7 +161,7 @@ func (m *Migrator) remapCtrl(w http.ResponseWriter, r *http.Request) {
 	siteID := r.URL.Query().Get("site")
 
 	// create new url-mapper from given rules in body
-	mapper, err := m.UrlMapperMaker(r.Body)
+	mapper, err := m.URLMapperMaker(r.Body)
 	if err != nil {
 		rest.SendErrorJSON(w, r, http.StatusBadRequest, err, "remap failed, bad given rules", rest.ErrDecode)
 		return
@@ -180,12 +180,12 @@ func (m *Migrator) remapCtrl(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		defer func() {
-			if e := os.Remove(fh.Name()); e != nil {
+			if e = os.Remove(fh.Name()); e != nil {
 				log.Printf("[WARN] failed to remove temp file %+v", e)
 			}
 		}()
 		log.Printf("[DEBUG] start export for site=%s", siteID)
-		if _, e := m.NativeExporter.Export(fh, siteID); e != nil {
+		if _, e = m.NativeExporter.Export(fh, siteID); e != nil {
 			log.Printf("[WARN] export failed with %+v", e)
 			return
 		}

--- a/backend/app/rest/api/rest.go
+++ b/backend/app/rest/api/rest.go
@@ -464,7 +464,7 @@ func addFileServer(r chi.Router, path string, root http.FileSystem, version stri
 	origPath := path
 	webFS = http.StripPrefix(path, webFS)
 	if path != "/" && path[len(path)-1] != '/' {
-		r.Get(path, http.RedirectHandler(path+"/", 301).ServeHTTP)
+		r.Get(path, http.RedirectHandler(path+"/", http.StatusMovedPermanently).ServeHTTP)
 		path += "/"
 	}
 	path += "*"

--- a/backend/app/rest/api/rest_private.go
+++ b/backend/app/rest/api/rest_private.go
@@ -59,7 +59,7 @@ type privStore interface {
 	Info(locator store.Locator, readonlyAge int) (store.PostInfo, error)
 }
 
-const unsubscribeHtml = `<!DOCTYPE html>
+const unsubscribeHTML = `<!DOCTYPE html>
 <html>
 <head>
     <meta name="viewport" content="width=device-width"/>
@@ -418,7 +418,7 @@ func (s *private) emailUnsubscribeCtrl(w http.ResponseWriter, r *http.Request) {
 
 	log.Printf("[DEBUG] unsubscribe user %s", userID)
 
-	if err := s.dataService.DeleteUserDetail(siteID, userID, engine.UserEmail); err != nil {
+	if err = s.dataService.DeleteUserDetail(siteID, userID, engine.UserEmail); err != nil {
 		code := parseError(err, rest.ErrInternal)
 		rest.SendErrorHTML(w, r, http.StatusBadRequest, err, "can't delete email for user", code)
 		return
@@ -443,7 +443,7 @@ func (s *private) emailUnsubscribeCtrl(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	tmpl := template.Must(template.New("unsubscribe").Parse(unsubscribeHtml))
+	tmpl := template.Must(template.New("unsubscribe").Parse(unsubscribeHTML))
 	msg := bytes.Buffer{}
 	MustExecute(tmpl, &msg, nil)
 	render.HTML(w, r, msg.String())

--- a/backend/app/rest/api/rest_private_test.go
+++ b/backend/app/rest/api/rest_private_test.go
@@ -249,8 +249,8 @@ func TestRest_UpdateDelete(t *testing.T) {
 	j := []store.PostInfo{}
 	err = json.Unmarshal(bb, &j)
 	assert.NoError(t, err)
-	assert.Equal(t, []store.PostInfo([]store.PostInfo{{URL: "https://radio-t.com/blah1", Count: 1},
-		{URL: "https://radio-t.com/blah2", Count: 0}}), j)
+	assert.Equal(t, []store.PostInfo{{URL: "https://radio-t.com/blah1", Count: 1},
+		{URL: "https://radio-t.com/blah2", Count: 0}}, j)
 
 	// delete a comment
 	client := http.Client{}
@@ -290,8 +290,8 @@ func TestRest_UpdateDelete(t *testing.T) {
 	j = []store.PostInfo{}
 	err = json.Unmarshal(bb, &j)
 	require.NoError(t, err)
-	assert.Equal(t, []store.PostInfo([]store.PostInfo{{URL: "https://radio-t.com/blah1", Count: 0},
-		{URL: "https://radio-t.com/blah2", Count: 0}}), j)
+	assert.Equal(t, []store.PostInfo{{URL: "https://radio-t.com/blah1", Count: 0},
+		{URL: "https://radio-t.com/blah2", Count: 0}}, j)
 }
 
 func TestRest_UpdateNotOwner(t *testing.T) {

--- a/backend/app/rest/api/rest_public_test.go
+++ b/backend/app/rest/api/rest_public_test.go
@@ -449,8 +449,8 @@ func TestRest_Counts(t *testing.T) {
 	j := []store.PostInfo{}
 	err = json.Unmarshal(body, &j)
 	assert.NoError(t, err)
-	assert.Equal(t, []store.PostInfo([]store.PostInfo{{URL: "https://radio-t.com/blah1", Count: 3},
-		{URL: "https://radio-t.com/blah2", Count: 2}}), j)
+	assert.Equal(t, []store.PostInfo{{URL: "https://radio-t.com/blah1", Count: 3},
+		{URL: "https://radio-t.com/blah2", Count: 2}}, j)
 
 	resp, err = post(t, ts.URL+"/api/v1/counts?site=radio-XXX", `{}`)
 	require.NoError(t, err)
@@ -527,7 +527,7 @@ func TestRest_Config(t *testing.T) {
 	err := json.Unmarshal([]byte(body), &j)
 	assert.NoError(t, err)
 	assert.Equal(t, 300., j["edit_duration"])
-	assert.EqualValues(t, []interface{}([]interface{}{"a1", "a2"}), j["admins"])
+	assert.EqualValues(t, []interface{}{"a1", "a2"}, j["admins"])
 	assert.Equal(t, "admin@remark-42.com", j["admin_email"])
 	assert.Equal(t, 4000., j["max_comment_size"])
 	assert.Equal(t, -5., j["low_score"])
@@ -598,7 +598,7 @@ func TestRest_InfoStream(t *testing.T) {
 	assert.Equal(t, 200, code)
 	<-done
 
-	recs := strings.Split(strings.TrimSuffix(string(body), "\n"), "\n")
+	recs := strings.Split(strings.TrimSuffix(body, "\n"), "\n")
 	require.Equal(t, 10*3, len(recs), "10 records. each 2 lines +1 emty line")
 	assert.True(t, strings.Contains(recs[0+1], `"count":2`), recs[0])
 	assert.True(t, strings.Contains(recs[9*3+1], `"count":11`), recs[9])
@@ -723,10 +723,11 @@ func TestRest_Robots(t *testing.T) {
 	assert.Equal(t, "User-agent: *\nDisallow: /auth/\nDisallow: /api/\nAllow: /api/v1/find\n"+
 		"Allow: /api/v1/last\nAllow: /api/v1/id\nAllow: /api/v1/count\nAllow: /api/v1/counts\n"+
 		"Allow: /api/v1/list\nAllow: /api/v1/config\nAllow: /api/v1/user\nAllow: /api/v1/img\n"+
-		"Allow: /api/v1/avatar\nAllow: /api/v1/picture\n", string(body))
+		"Allow: /api/v1/avatar\nAllow: /api/v1/picture\n", body)
 }
 
 func TestRest_LastCommentsStream(t *testing.T) {
+	t.Skip() // TODO: enable after cache is migrated to https://github.com/dgraph-io/ristretto
 	ts, srv, teardown := startupT(t)
 	srv.pubRest.readOnlyAge = 10000000 // make sure we don't hit read-only
 	srv.pubRest.streamer.Refresh = 50 * time.Millisecond

--- a/backend/app/rest/api/rest_test.go
+++ b/backend/app/rest/api/rest_test.go
@@ -383,7 +383,7 @@ func startupT(t *testing.T) (ts *httptest.Server, srv *Rest, teardown func()) {
 			WordPressImporter: &migrator.WordPress{DataStore: dataStore},
 			NativeImporter:    &migrator.Native{DataStore: dataStore},
 			NativeExporter:    &migrator.Native{DataStore: dataStore},
-			UrlMapperMaker:    migrator.NewUrlMapper,
+			URLMapperMaker:    migrator.NewURLMapper,
 			Cache:             memCache,
 			KeyStore:          astore,
 		},

--- a/backend/app/rest/httperrors.go
+++ b/backend/app/rest/httperrors.go
@@ -38,7 +38,7 @@ const (
 	ErrAssetNotFound      = 18 // requested file not found
 )
 
-const errorHtml = `<!DOCTYPE html>
+const errorHTML = `<!DOCTYPE html>
 <html>
 <head>
     <meta name="viewport" content="width=device-width"/>
@@ -64,12 +64,12 @@ type errTmplData struct {
 func SendErrorHTML(w http.ResponseWriter, r *http.Request, httpStatusCode int, err error, details string, errCode int) {
 	// MustExecute behaves like template.Execute, but panics if an error occurs.
 	MustExecute := func(tmpl *template.Template, wr io.Writer, data interface{}) {
-		if err := tmpl.Execute(wr, data); err != nil {
+		if err = tmpl.Execute(wr, data); err != nil {
 			panic(err)
 		}
 	}
 
-	tmpl := template.Must(template.New("error").Parse(errorHtml))
+	tmpl := template.Must(template.New("error").Parse(errorHTML))
 	log.Printf("[WARN] %s", errDetailsMsg(r, httpStatusCode, err, details, errCode))
 	render.Status(r, httpStatusCode)
 	msg := bytes.Buffer{}

--- a/backend/app/rest/proxy/image.go
+++ b/backend/app/rest/proxy/image.go
@@ -130,11 +130,11 @@ func (p Image) Handler(w http.ResponseWriter, r *http.Request) {
 
 // cache image from provided Reader using given ID
 func (p Image) cacheImage(r io.Reader, imgID string) {
-	id, err := p.ImageService.SaveWithID(imgID, r)
+	err := p.ImageService.SaveWithID(imgID, r)
 	if err != nil {
 		log.Printf("[WARN] unable to save image to the storage: %+v", err)
 	}
-	p.ImageService.Submit(func() []string { return []string{id} })
+	p.ImageService.Submit(func() []string { return []string{imgID} })
 }
 
 // download an image.

--- a/backend/app/rest/proxy/image_test.go
+++ b/backend/app/rest/proxy/image_test.go
@@ -175,7 +175,7 @@ func TestImage_RoutesCachingImage(t *testing.T) {
 	encodedImgURL := base64.URLEncoding.EncodeToString([]byte(imgURL))
 
 	imageStore.On("Load", mock.Anything).Once().Return(nil, nil)
-	imageStore.On("SaveWithID", mock.Anything, mock.Anything).Once().Return(nil)
+	imageStore.On("Save", mock.Anything, mock.Anything).Once().Return(nil)
 	imageStore.On("Commit", mock.Anything).Once().Return(nil)
 
 	resp, err := http.Get(ts.URL + "/?src=" + encodedImgURL)
@@ -185,7 +185,7 @@ func TestImage_RoutesCachingImage(t *testing.T) {
 	assert.Equal(t, "image/png", resp.Header["Content-Type"][0])
 
 	imageStore.AssertCalled(t, "Load", mock.Anything)
-	imageStore.AssertCalled(t, "SaveWithID", "cached_images/4b84b15bff6ee5796152495a230e45e3d7e947d9-"+sha1Str(imgURL), gopherPNGBytes())
+	imageStore.AssertCalled(t, "Save", "cached_images/4b84b15bff6ee5796152495a230e45e3d7e947d9-"+sha1Str(imgURL), gopherPNGBytes())
 	imageStore.AssertCalled(t, "Commit", mock.Anything)
 }
 

--- a/backend/app/rest/proxy/image_test.go
+++ b/backend/app/rest/proxy/image_test.go
@@ -175,7 +175,7 @@ func TestImage_RoutesCachingImage(t *testing.T) {
 	encodedImgURL := base64.URLEncoding.EncodeToString([]byte(imgURL))
 
 	imageStore.On("Load", mock.Anything).Once().Return(nil, nil)
-	imageStore.On("SaveWithID", mock.Anything, mock.Anything).Once().Return("", nil)
+	imageStore.On("SaveWithID", mock.Anything, mock.Anything).Once().Return(nil)
 	imageStore.On("Commit", mock.Anything).Once().Return(nil)
 
 	resp, err := http.Get(ts.URL + "/?src=" + encodedImgURL)

--- a/backend/app/store/admin/admin.go
+++ b/backend/app/store/admin/admin.go
@@ -79,4 +79,4 @@ func (s *StaticStore) Enabled(site string) (ok bool, err error) {
 }
 
 // OnEvent doesn nothing for StaticStore
-func (s *StaticStore) OnEvent(siteID string, et EventType) error { return nil }
+func (s *StaticStore) OnEvent(_ string, _ EventType) error { return nil }

--- a/backend/app/store/comment.go
+++ b/backend/app/store/comment.go
@@ -120,7 +120,7 @@ func (c *Comment) Sanitize() {
 	c.Text = p.Sanitize(c.Text)
 	c.Orig = p.Sanitize(c.Orig)
 	c.User.ID = template.HTMLEscapeString(c.User.ID)
-	c.User.Name = c.escapeHtmlWithSome(c.User.Name)
+	c.User.Name = c.escapeHTMLWithSome(c.User.Name)
 	c.User.Picture = p.Sanitize(c.User.Picture)
 }
 
@@ -145,7 +145,7 @@ func (c *Comment) Snippet(limit int) string {
 	return string(snippet) + " ..."
 }
 
-func (c *Comment) escapeHtmlWithSome(inp string) string {
+func (c *Comment) escapeHTMLWithSome(inp string) string {
 	res := template.HTMLEscapeString(inp)
 	res = strings.Replace(res, "&#34;", "\"", -1)
 	res = strings.Replace(res, "&#39;", "'", -1)

--- a/backend/app/store/engine/bolt.go
+++ b/backend/app/store/engine/bolt.go
@@ -662,7 +662,7 @@ func (b *BoltDB) getUserDetail(req UserDetailRequest) (result []UserDetailEntry,
 		value := bucket.Get([]byte(req.UserID))
 		// return no error in case of absent entry
 		if value != nil {
-			if err := json.Unmarshal(value, &entry); err != nil {
+			if err = json.Unmarshal(value, &entry); err != nil {
 				return errors.Wrap(e, "failed to unmarshal entry")
 			}
 			switch req.Detail {
@@ -690,7 +690,7 @@ func (b *BoltDB) setUserDetail(req UserDetailRequest) (result []UserDetailEntry,
 		value := bucket.Get([]byte(req.UserID))
 		// return no error in case of absent entry
 		if value != nil {
-			if err := json.Unmarshal(value, &entry); err != nil {
+			if err = json.Unmarshal(value, &entry); err != nil {
 				return errors.Wrap(e, "failed to unmarshal entry")
 			}
 		}
@@ -711,7 +711,7 @@ func (b *BoltDB) setUserDetail(req UserDetailRequest) (result []UserDetailEntry,
 	}
 
 	err = bdb.Update(func(tx *bolt.Tx) error {
-		err := b.save(tx.Bucket([]byte(userDetailsBucketName)), req.UserID, entry)
+		err = b.save(tx.Bucket([]byte(userDetailsBucketName)), req.UserID, entry)
 		return errors.Wrapf(err, "failed to update detail %s for %s in %s", req.Detail, req.UserID, req.Locator.SiteID)
 	})
 
@@ -729,7 +729,7 @@ func (b *BoltDB) listDetails(loc store.Locator) (result []UserDetailEntry, err e
 		var entry UserDetailEntry
 		bucket := tx.Bucket([]byte(userDetailsBucketName))
 		return bucket.ForEach(func(userID, value []byte) error {
-			if err := json.Unmarshal(value, &entry); err != nil {
+			if err = json.Unmarshal(value, &entry); err != nil {
 				return errors.Wrap(e, "failed to unmarshal entry")
 			}
 			result = append(result, entry)
@@ -860,6 +860,7 @@ func (b *BoltDB) deleteUser(bdb *bolt.DB, siteID string, userID string, mode sto
 	// get list of commentID for all user's comment
 	comments := []commentInfo{}
 	for _, postInfo := range posts {
+		postInfo := postInfo
 		err = bdb.View(func(tx *bolt.Tx) error {
 			postsBkt := tx.Bucket([]byte(postsBucketName))
 			postBkt := postsBkt.Bucket([]byte(postInfo.URL))

--- a/backend/app/store/engine/engine.go
+++ b/backend/app/store/engine/engine.go
@@ -83,10 +83,13 @@ const (
 	Verified = Flag("verified")
 	Blocked  = Flag("blocked")
 )
+
+// All possible user details
 const (
-	// All possible user details
-	UserEmail      = UserDetail("email")
-	AllUserDetails = UserDetail("all") // used for listing and deletion requests
+	// UserEmail is a user email
+	UserEmail = UserDetail("email")
+	// AllUserDetails used for listing and deletion requests
+	AllUserDetails = UserDetail("all")
 )
 
 // FlagRequest is the input for both get/set for flags, like blocked, verified and so on

--- a/backend/app/store/image/bolt_store.go
+++ b/backend/app/store/image/bolt_store.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"path"
 	"time"
 
 	log "github.com/go-pkgz/lgr"
@@ -52,8 +51,8 @@ func NewBoltStorage(fileName string, options bolt.Options) (*Bolt, error) {
 	}, nil
 }
 
-// SaveWithID saves data from a reader, for given id
-func (b *Bolt) SaveWithID(id string, img []byte) (string, error) {
+// SaveWithID saves image for given id to staging bucket in DB
+func (b *Bolt) SaveWithID(id string, img []byte) error {
 	err := b.db.Update(func(tx *bolt.Tx) error {
 		if err := tx.Bucket([]byte(imagesStagedBktName)).Put([]byte(id), img); err != nil {
 			return errors.Wrapf(err, "can't put to bucket with %s", id)
@@ -68,13 +67,7 @@ func (b *Bolt) SaveWithID(id string, img []byte) (string, error) {
 		return nil
 	})
 
-	return id, err
-}
-
-// Save data from reader to staging bucket in DB
-func (b *Bolt) Save(userID string, img []byte) (id string, err error) {
-	id = path.Join(userID, guid())
-	return b.SaveWithID(id, img)
+	return err
 }
 
 // Commit file stored in staging bucket by copying it to permanent bucket

--- a/backend/app/store/image/bolt_store.go
+++ b/backend/app/store/image/bolt_store.go
@@ -51,8 +51,8 @@ func NewBoltStorage(fileName string, options bolt.Options) (*Bolt, error) {
 	}, nil
 }
 
-// SaveWithID saves image for given id to staging bucket in DB
-func (b *Bolt) SaveWithID(id string, img []byte) error {
+// Save saves image for given id to staging bucket in DB
+func (b *Bolt) Save(id string, img []byte) error {
 	err := b.db.Update(func(tx *bolt.Tx) error {
 		if err := tx.Bucket([]byte(imagesStagedBktName)).Put([]byte(id), img); err != nil {
 			return errors.Wrapf(err, "can't put to bucket with %s", id)

--- a/backend/app/store/image/bolt_store_test.go
+++ b/backend/app/store/image/bolt_store_test.go
@@ -20,7 +20,7 @@ func TestBoltStore_SaveCommit(t *testing.T) {
 
 	id := "test_img"
 
-	err := svc.SaveWithID(id, gopherPNGBytes())
+	err := svc.Save(id, gopherPNGBytes())
 	assert.NoError(t, err)
 
 	err = svc.db.View(func(tx *bolt.Tx) error {
@@ -49,7 +49,7 @@ func TestBoltStore_LoadAfterSave(t *testing.T) {
 	defer teardown()
 
 	id := "test_img"
-	err := svc.SaveWithID(id, gopherPNGBytes())
+	err := svc.Save(id, gopherPNGBytes())
 	assert.NoError(t, err)
 
 	data, err := svc.Load(id)
@@ -66,7 +66,7 @@ func TestBoltStore_Cleanup(t *testing.T) {
 	defer teardown()
 
 	save := func(file string) (id string) {
-		err := svc.SaveWithID(file, gopherPNGBytes())
+		err := svc.Save(file, gopherPNGBytes())
 		require.NoError(t, err)
 
 		checkBoltImgData(t, svc.db, imagesStagedBktName, file, func(data []byte) error {

--- a/backend/app/store/image/fs_store.go
+++ b/backend/app/store/image/fs_store.go
@@ -32,9 +32,9 @@ type FileSystem struct {
 	}
 }
 
-// SaveWithID saves image with given id to local FS, staging directory.
+// Save saves image with given id to local FS, staging directory.
 // Files partitioned across multiple subdirectories, and the final path includes part, i.e. /location/user1/03/123-4567
-func (f *FileSystem) SaveWithID(id string, img []byte) error {
+func (f *FileSystem) Save(id string, img []byte) error {
 	dst := f.location(f.Staging, id)
 
 	if err := os.MkdirAll(path.Dir(dst), 0700); err != nil {

--- a/backend/app/store/image/fs_store.go
+++ b/backend/app/store/image/fs_store.go
@@ -32,27 +32,21 @@ type FileSystem struct {
 	}
 }
 
-// SaveWithID saves data from a reader, with given id
-func (f *FileSystem) SaveWithID(id string, img []byte) (string, error) {
+// SaveWithID saves image with given id to local FS, staging directory.
+// Files partitioned across multiple subdirectories, and the final path includes part, i.e. /location/user1/03/123-4567
+func (f *FileSystem) SaveWithID(id string, img []byte) error {
 	dst := f.location(f.Staging, id)
 
 	if err := os.MkdirAll(path.Dir(dst), 0700); err != nil {
-		return "", errors.Wrap(err, "can't make image directory")
+		return errors.Wrap(err, "can't make image directory")
 	}
 
 	if err := ioutil.WriteFile(dst, img, 0600); err != nil {
-		return "", errors.Wrapf(err, "can't write image file with id %s", id)
+		return errors.Wrapf(err, "can't write image file with id %s", id)
 	}
 
 	log.Printf("[DEBUG] file %s saved for image %s, size=%d", dst, id, len(img))
-	return id, nil
-}
-
-// Save data from a reader to local FS, staging directory. Returns id as user/uuid
-// Files partitioned across multiple subdirectories, and the final path includes part, i.e. /location/user1/03/123-4567
-func (f *FileSystem) Save(userID string, img []byte) (id string, err error) {
-	tempId := path.Join(userID, guid()) // make id as user/uuid
-	return f.SaveWithID(tempId, img)
+	return nil
 }
 
 // Commit file stored in staging location by moving it to permanent location

--- a/backend/app/store/image/fs_store_test.go
+++ b/backend/app/store/image/fs_store_test.go
@@ -49,7 +49,7 @@ func TestFsStore_Save(t *testing.T) {
 	defer teardown()
 
 	id := "test_img"
-	err := svc.SaveWithID(id, gopherPNGBytes())
+	err := svc.Save(id, gopherPNGBytes())
 	assert.NoError(t, err)
 
 	img := svc.location(svc.Staging, id)
@@ -68,7 +68,7 @@ func TestFsStore_SaveNoResizeJpeg(t *testing.T) {
 	img, err := ioutil.ReadAll(fh)
 	assert.NoError(t, err)
 	id := "test_img"
-	err = svc.SaveWithID(id, img)
+	err = svc.Save(id, img)
 	assert.NoError(t, err)
 
 	imgPath := svc.location(svc.Staging, id)
@@ -83,7 +83,7 @@ func TestFsStore_SaveAndCommit(t *testing.T) {
 	defer teardown()
 
 	id := "test_img"
-	err := svc.SaveWithID(id, gopherPNGBytes())
+	err := svc.Save(id, gopherPNGBytes())
 	require.NoError(t, err)
 	err = svc.Commit(id)
 	require.NoError(t, err)
@@ -105,7 +105,7 @@ func TestFsStore_LoadAfterSave(t *testing.T) {
 	defer teardown()
 
 	id := "test_img"
-	err := svc.SaveWithID(id, gopherPNGBytes())
+	err := svc.Save(id, gopherPNGBytes())
 	assert.NoError(t, err)
 	t.Log(id)
 
@@ -123,7 +123,7 @@ func TestFsStore_LoadAfterCommit(t *testing.T) {
 	defer teardown()
 
 	id := "test_img"
-	err := svc.SaveWithID(id, gopherPNGBytes())
+	err := svc.Save(id, gopherPNGBytes())
 	assert.NoError(t, err)
 	t.Log(id)
 	err = svc.Commit(id)
@@ -186,7 +186,7 @@ func TestFsStore_Cleanup(t *testing.T) {
 
 	save := func(file string, user string) (filePath string) {
 		id := path.Join(user, file)
-		err := svc.SaveWithID(id, gopherPNGBytes())
+		err := svc.Save(id, gopherPNGBytes())
 		require.NoError(t, err)
 		img := svc.location(svc.Staging, id)
 		data, err := ioutil.ReadFile(img)

--- a/backend/app/store/image/fs_store_test.go
+++ b/backend/app/store/image/fs_store_test.go
@@ -48,13 +48,11 @@ func TestFsStore_Save(t *testing.T) {
 	svc, teardown := prepareImageTest(t)
 	defer teardown()
 
-	id, err := svc.Save("user1", gopherPNGBytes())
+	id := "test_img"
+	err := svc.SaveWithID(id, gopherPNGBytes())
 	assert.NoError(t, err)
-	assert.Contains(t, id, "user1/")
-	t.Log(id)
 
 	img := svc.location(svc.Staging, id)
-	t.Log(img)
 	data, err := ioutil.ReadFile(img)
 	assert.NoError(t, err)
 	assert.Equal(t, 1462, len(data))
@@ -69,10 +67,9 @@ func TestFsStore_SaveNoResizeJpeg(t *testing.T) {
 	assert.NoError(t, err)
 	img, err := ioutil.ReadAll(fh)
 	assert.NoError(t, err)
-	id, err := svc.Save("user1", img)
+	id := "test_img"
+	err = svc.SaveWithID(id, img)
 	assert.NoError(t, err)
-	assert.Contains(t, id, "user1/")
-	t.Log(id)
 
 	imgPath := svc.location(svc.Staging, id)
 	t.Log(imgPath)
@@ -85,7 +82,8 @@ func TestFsStore_SaveAndCommit(t *testing.T) {
 	svc, teardown := prepareImageTest(t)
 	defer teardown()
 
-	id, err := svc.Save("user1", gopherPNGBytes())
+	id := "test_img"
+	err := svc.SaveWithID(id, gopherPNGBytes())
 	require.NoError(t, err)
 	err = svc.Commit(id)
 	require.NoError(t, err)
@@ -106,7 +104,8 @@ func TestFsStore_LoadAfterSave(t *testing.T) {
 	svc, teardown := prepareImageTest(t)
 	defer teardown()
 
-	id, err := svc.Save("user1", gopherPNGBytes())
+	id := "test_img"
+	err := svc.SaveWithID(id, gopherPNGBytes())
 	assert.NoError(t, err)
 	t.Log(id)
 
@@ -123,7 +122,8 @@ func TestFsStore_LoadAfterCommit(t *testing.T) {
 	svc, teardown := prepareImageTest(t)
 	defer teardown()
 
-	id, err := svc.Save("user1", gopherPNGBytes())
+	id := "test_img"
+	err := svc.SaveWithID(id, gopherPNGBytes())
 	assert.NoError(t, err)
 	t.Log(id)
 	err = svc.Commit(id)
@@ -184,8 +184,9 @@ func TestFsStore_Cleanup(t *testing.T) {
 	svc, teardown := prepareImageTest(t)
 	defer teardown()
 
-	save := func(file string, user string) (path string) {
-		id, err := svc.Save(user, gopherPNGBytes())
+	save := func(file string, user string) (filePath string) {
+		id := path.Join(user, file)
+		err := svc.SaveWithID(id, gopherPNGBytes())
 		require.NoError(t, err)
 		img := svc.location(svc.Staging, id)
 		data, err := ioutil.ReadFile(img)

--- a/backend/app/store/image/image.go
+++ b/backend/app/store/image/image.go
@@ -59,8 +59,8 @@ type ServiceParams struct {
 // Two-stage commit scheme is used for not storing images which are uploaded but later never used in the comments,
 // e.g. when somebody uploaded a picture but did not sent the comment.
 type Store interface {
-	SaveWithID(id string, img []byte) error // store image with passed id to staging
-	Load(id string) ([]byte, error)         // load image by ID. Caller has to close the reader.
+	Save(id string, img []byte) error // store image with passed id to staging
+	Load(id string) ([]byte, error)   // load image by ID. Caller has to close the reader.
 
 	Commit(id string) error                               // move image from staging to permanent
 	Cleanup(ctx context.Context, ttl time.Duration) error // run removal loop for old images on staging
@@ -186,13 +186,13 @@ func (s *Service) Save(userID string, r io.Reader) (id string, err error) {
 	return id, s.SaveWithID(id, r)
 }
 
-// SaveWithID wraps storage SaveWithID function, validating and resizing the image before calling it.
+// Save wraps storage Save function, validating and resizing the image before calling it.
 func (s *Service) SaveWithID(id string, r io.Reader) error {
 	img, err := s.prepareImage(r)
 	if err != nil {
 		return err
 	}
-	return s.store.SaveWithID(id, img)
+	return s.store.Save(id, img)
 }
 
 func (s *Service) ImgContentType(img []byte) string {

--- a/backend/app/store/image/image_mock.go
+++ b/backend/app/store/image/image_mock.go
@@ -62,44 +62,16 @@ func (_m *MockStore) Load(id string) ([]byte, error) {
 	return r0, r1
 }
 
-// Save provides a mock function with given fields: userID, img
-func (_m *MockStore) Save(userID string, img []byte) (string, error) {
-	ret := _m.Called(userID, img)
-
-	var r0 string
-	if rf, ok := ret.Get(0).(func(string, []byte) string); ok {
-		r0 = rf(userID, img)
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(string, []byte) error); ok {
-		r1 = rf(userID, img)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // SaveWithID provides a mock function with given fields: id, img
-func (_m *MockStore) SaveWithID(id string, img []byte) (string, error) {
+func (_m *MockStore) SaveWithID(id string, img []byte) error {
 	ret := _m.Called(id, img)
 
-	var r0 string
-	if rf, ok := ret.Get(0).(func(string, []byte) string); ok {
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, []byte) error); ok {
 		r0 = rf(id, img)
 	} else {
-		r0 = ret.Get(0).(string)
+		r0 = ret.Error(0)
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(string, []byte) error); ok {
-		r1 = rf(id, img)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }

--- a/backend/app/store/image/image_mock.go
+++ b/backend/app/store/image/image_mock.go
@@ -62,8 +62,8 @@ func (_m *MockStore) Load(id string) ([]byte, error) {
 	return r0, r1
 }
 
-// SaveWithID provides a mock function with given fields: id, img
-func (_m *MockStore) SaveWithID(id string, img []byte) error {
+// Save provides a mock function with given fields: id, img
+func (_m *MockStore) Save(id string, img []byte) error {
 	ret := _m.Called(id, img)
 
 	var r0 error

--- a/backend/app/store/image/image_test.go
+++ b/backend/app/store/image/image_test.go
@@ -21,7 +21,7 @@ func TestService_SaveAndLoad(t *testing.T) {
 	store := MockStore{}
 	svc := NewService(&store, ServiceParams{MaxSize: 1500, MaxWidth: 32, MaxHeight: 32})
 
-	store.On("SaveWithID", "test_id", mock.Anything).Return(nil)
+	store.On("Save", "test_id", mock.Anything).Return(nil)
 	err := svc.SaveWithID("test_id", gopherPNG())
 	assert.NoError(t, err)
 

--- a/backend/app/store/image/image_test.go
+++ b/backend/app/store/image/image_test.go
@@ -21,15 +21,9 @@ func TestService_SaveAndLoad(t *testing.T) {
 	store := MockStore{}
 	svc := NewService(&store, ServiceParams{MaxSize: 1500, MaxWidth: 32, MaxHeight: 32})
 
-	store.On("Save", "user1", mock.Anything).Return("user1/test_id", nil)
-	id, err := svc.Save("user1", gopherPNG())
+	store.On("SaveWithID", "test_id", mock.Anything).Return(nil)
+	err := svc.SaveWithID("test_id", gopherPNG())
 	assert.NoError(t, err)
-	assert.Equal(t, "user1/test_id", id)
-
-	store.On("SaveWithID", "test_id", mock.Anything).Return("test_id", nil)
-	id, err = svc.SaveWithID("test_id", gopherPNG())
-	assert.NoError(t, err)
-	assert.Equal(t, "test_id", id)
 
 	store.On("Load", "test_id", mock.Anything).Return(nil, nil)
 	img, err := svc.Load("test_id")
@@ -65,7 +59,7 @@ func TestService_SaveTooLarge(t *testing.T) {
 	_, err := svc.Save("user2", io.MultiReader(gopherPNG(), gopherPNG()))
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "is too large")
-	_, err = svc.SaveWithID("test_id", io.MultiReader(gopherPNG(), gopherPNG()))
+	err = svc.SaveWithID("test_id", io.MultiReader(gopherPNG(), gopherPNG()))
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "is too large")
 }
@@ -147,7 +141,6 @@ func TestService_SubmitDelay(t *testing.T) {
 }
 
 func TestService_resize(t *testing.T) {
-
 	// reader is nil
 	resized := resize(nil, 100, 100)
 	assert.Nil(t, resized)

--- a/backend/app/store/image/remote_store.go
+++ b/backend/app/store/image/remote_store.go
@@ -16,7 +16,7 @@ type RPC struct {
 	jrpc.Client
 }
 
-func (r *RPC) SaveWithID(id string, img []byte) error {
+func (r *RPC) Save(id string, img []byte) error {
 	_, err := r.Call("image.save_with_id", id, img)
 	return err
 }

--- a/backend/app/store/image/remote_store.go
+++ b/backend/app/store/image/remote_store.go
@@ -16,23 +16,9 @@ type RPC struct {
 	jrpc.Client
 }
 
-func (r *RPC) Save(userID string, img []byte) (id string, err error) {
-	resp, err := r.Call("image.save", userID, img)
-	if err != nil {
-		return "", err
-	}
-	err = json.Unmarshal(*resp.Result, &id)
-	return id, err
-}
-
-func (r *RPC) SaveWithID(id string, img []byte) (string, error) {
-	resp, err := r.Call("image.save_with_id", id, img)
-	if err != nil {
-		return "", err
-	}
-	var newID string
-	err = json.Unmarshal(*resp.Result, &newID)
-	return newID, err
+func (r *RPC) SaveWithID(id string, img []byte) error {
+	_, err := r.Call("image.save_with_id", id, img)
+	return err
 }
 
 func (r *RPC) Load(id string) ([]byte, error) {

--- a/backend/app/store/image/remote_store.go
+++ b/backend/app/store/image/remote_store.go
@@ -16,11 +16,13 @@ type RPC struct {
 	jrpc.Client
 }
 
+// Save saves image with given id to staging.
 func (r *RPC) Save(id string, img []byte) error {
 	_, err := r.Call("image.save_with_id", id, img)
 	return err
 }
 
+// Load image with given id
 func (r *RPC) Load(id string) ([]byte, error) {
 	resp, err := r.Call("image.load", id)
 	if err != nil {
@@ -33,11 +35,13 @@ func (r *RPC) Load(id string) ([]byte, error) {
 	return ioutil.ReadAll(base64.NewDecoder(base64.StdEncoding, strings.NewReader(rawImg)))
 }
 
+// Commit file stored in staging location by moving it to permanent location
 func (r *RPC) Commit(id string) error {
 	_, err := r.Call("image.commit", id)
 	return err
 }
 
+// Cleanup runs scan of staging and removes old files based on ttl
 func (r *RPC) Cleanup(_ context.Context, ttl time.Duration) error {
 	_, err := r.Call("image.cleanup", ttl)
 	return err

--- a/backend/app/store/image/remote_store_test.go
+++ b/backend/app/store/image/remote_store_test.go
@@ -23,7 +23,7 @@ func TestRemote_SaveWithID(t *testing.T) {
 	var a Store = &c
 	_ = a
 
-	err := c.SaveWithID("54321", gopherPNGBytes())
+	err := c.Save("54321", gopherPNGBytes())
 	assert.NoError(t, err)
 }
 

--- a/backend/app/store/image/remote_store_test.go
+++ b/backend/app/store/image/remote_store_test.go
@@ -14,32 +14,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRemote_Save(t *testing.T) {
-	ts := testServer(t, fmt.Sprintf(`{"method":"image.save","params":["admin","%s"],"id":1}`, gopher),
-		`{"result":"12345","id":1}`)
-	defer ts.Close()
-	c := RPC{Client: jrpc.Client{API: ts.URL, Client: http.Client{}}}
-
-	var a Store = &c
-	_ = a
-
-	res, err := c.Save("admin", gopherPNGBytes())
-	assert.NoError(t, err)
-	assert.Equal(t, "12345", res)
-}
-
 func TestRemote_SaveWithID(t *testing.T) {
 	ts := testServer(t, fmt.Sprintf(`{"method":"image.save_with_id","params":["54321","%s"],"id":1}`, gopher),
-		`{"result":"12345","id":1}`)
+		`{"id":1}`)
 	defer ts.Close()
 	c := RPC{Client: jrpc.Client{API: ts.URL, Client: http.Client{}}}
 
 	var a Store = &c
 	_ = a
 
-	res, err := c.SaveWithID("54321", gopherPNGBytes())
+	err := c.SaveWithID("54321", gopherPNGBytes())
 	assert.NoError(t, err)
-	assert.Equal(t, "12345", res)
 }
 
 func TestRemote_Load(t *testing.T) {

--- a/backend/app/store/service/restricted_words.go
+++ b/backend/app/store/service/restricted_words.go
@@ -19,7 +19,7 @@ type StaticRestrictedWordsLister struct {
 }
 
 // List provides restricted words in comments (ignores siteID)
-func (l StaticRestrictedWordsLister) List(siteID string) (restricted []string, err error) {
+func (l StaticRestrictedWordsLister) List(_ string) (restricted []string, err error) {
 	return l.Words, nil
 }
 

--- a/backend/app/store/service/service.go
+++ b/backend/app/store/service/service.go
@@ -1,6 +1,5 @@
 // Package service wraps engine interfaces with common logic unrelated to any particular engine implementation.
 // All consumers should be using service.DataStore and not the naked engine!
-
 package service
 
 import (

--- a/backend/app/store/user_test.go
+++ b/backend/app/store/user_test.go
@@ -60,8 +60,8 @@ func TestUser_HashFailed(t *testing.T) {
 
 type mockHash struct{}
 
-func (mock mockHash) Sum(b []byte) []byte               { return nil }
+func (mock mockHash) Sum(_ []byte) []byte               { return nil }
 func (mock mockHash) Reset()                            {}
 func (mock mockHash) Size() int                         { return 0 }
 func (mock mockHash) BlockSize() int                    { return 0 }
-func (mock mockHash) Write(p []byte) (n int, err error) { return 0, errors.New("error") }
+func (mock mockHash) Write(_ []byte) (n int, err error) { return 0, errors.New("error") }


### PR DESCRIPTION
Working on #584 I discovered I have too much free time and understanding of `image` module, and above all unbearable desire to improve old code instead of writing a new one.

This PR:
- removes `Save` function from `image.Store` interface
- drops id return from `image.Store.SaveWithID` function, as well as from `image.Service.SaveWithID`
- add stricter golangci-lint configuration
- fix all issues discovered by golangci-lint

This simplifies things more, leaving no logic about a user (for Save which required userID) and ID generation in `image.Store`. Now Store truly cares only about saving and loading images.