### PR TITLE
Commit proxy images same (delayed) way as normally uploaded ones

### DIFF
--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -586,6 +586,7 @@ func (s *ServerCommand) makeAvatarStore() (avatar.Store, error) {
 func (s *ServerCommand) makePicturesStore() (*image.Service, error) {
 	imageServiceParams := image.ServiceParams{
 		ImageAPI:     s.RemarkURL + "/api/v1/picture/",
+		ProxyAPI:     s.RemarkURL + "/api/v1/img",
 		EditDuration: s.EditDuration,
 		MaxSize:      s.Image.MaxSize,
 		MaxHeight:    s.Image.ResizeHeight,

--- a/backend/app/rest/proxy/image.go
+++ b/backend/app/rest/proxy/image.go
@@ -131,7 +131,6 @@ func (p Image) cacheImage(r io.Reader, imgID string) {
 	if err != nil {
 		log.Printf("[WARN] unable to save image to the storage: %+v", err)
 	}
-	p.ImageService.Submit(func() []string { return []string{imgID} })
 }
 
 // download an image.

--- a/backend/app/rest/proxy/image_test.go
+++ b/backend/app/rest/proxy/image_test.go
@@ -180,7 +180,6 @@ func TestImage_RoutesCachingImage(t *testing.T) {
 
 	imageStore.On("Load", mock.Anything).Once().Return(nil, nil)
 	imageStore.On("Save", mock.Anything, mock.Anything).Once().Return(nil)
-	imageStore.On("Commit", mock.Anything).Once().Return(nil)
 
 	resp, err := http.Get(ts.URL + "/?src=" + encodedImgURL)
 	require.Nil(t, err)
@@ -191,7 +190,6 @@ func TestImage_RoutesCachingImage(t *testing.T) {
 
 	imageStore.AssertCalled(t, "Load", mock.Anything)
 	imageStore.AssertCalled(t, "Save", "cached_images/4b84b15bff6ee5796152495a230e45e3d7e947d9-"+image.Sha1Str(imgURL), gopherPNGBytes())
-	imageStore.AssertCalled(t, "Commit", mock.Anything)
 }
 
 func TestImage_RoutesUsingCachedImage(t *testing.T) {

--- a/backend/app/store/image/image_test.go
+++ b/backend/app/store/image/image_test.go
@@ -3,6 +3,8 @@ package image
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
+	"fmt"
 	"image"
 	"io"
 	"io/ioutil"
@@ -72,24 +74,52 @@ func TestService_WrongFormat(t *testing.T) {
 }
 
 func TestService_ExtractPictures(t *testing.T) {
-	svc := Service{ServiceParams: ServiceParams{ImageAPI: "/blah/"}}
-	html := `blah <img src="/blah/user1/pic1.png"/> foo 
+	svc := Service{ServiceParams: ServiceParams{ImageAPI: "/blah/", ProxyAPI: "/non_existent"}}
+	html := `blah <img src="/blah/user1/pic1.png"/> foo
 <img src="/blah/user2/pic3.png"/> xyz <p>123</p> <img src="/pic3.png"/> <img src="https://i.ibb.co/0cqqqnD/ezgif-5-3b07b6b97610.png" alt="">`
 	ids, err := svc.ExtractPictures(html)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(ids), "two images")
 	assert.Equal(t, "user1/pic1.png", ids[0])
 	assert.Equal(t, "user2/pic3.png", ids[1])
-}
 
-func TestService_ExtractPictures2(t *testing.T) {
-	svc := Service{ServiceParams: ServiceParams{ImageAPI: "https://remark42.radio-t.com/api/v1/picture/"}}
-	html := "<p>TLDR: такое в go пока правильно посчитать трудно. То, что они считают это общее количество go packages в коде." +
-		"</p>\n\n<p>Пакеты в го это средство организации кода, они могут быть связанны друг с другом в рамках одной библиотеки (модуля). Например одна из моих вот так выглядит на libraries.io:</p>\n\n<p><img src=\"https://remark42.radio-t.com/api/v1/picture/github_ef0f706a79cc24b17bbbb374cd234a691d034128/bjttt8ahajfmrhsula10.png\" alt=\"bjtr0-201906-08110846-i324c.png\"/></p>\n\n<p>По форме все верно, это все packages, но по сути это все одна библиотека организованная таким образом. При ее импорте, например посредством go mod, она выглядит как один модуль, т.е. <code>github.com/go-pkgz/auth v0.5.2</code>.</p>\n"
-	ids, err := svc.ExtractPictures(html)
+	svc = Service{ServiceParams: ServiceParams{ImageAPI: "https://remark42.radio-t.com/api/v1/picture/", ProxyAPI: "https://remark42.radio-t.com/api/v1/img"}}
+	html = `<p>TLDR: такое в go пока правильно посчитать трудно. То, что они считают это общее количество go packages в коде.
+</p>\n\n<p>Пакеты в го это средство организации кода, они могут быть связанны друг с другом в рамках одной библиотеки (модуля).
+Например одна из моих вот так выглядит на libraries.io:</p>\n\n
+<p><img src="https://remark42.radio-t.com/api/v1/picture/github_ef0f706a79cc24b17bbbb374cd234a691d034128/bjttt8ahajfmrhsula10.png" alt="bjtr0-201906-08110846-i324c.png"/></p>\n\n<p>
+По форме все верно, это все packages, но по сути это все одна библиотека организованная таким образом. При ее импорте, например посредством go mod, она выглядит как один модуль, т.е.
+<code>github.com/go-pkgz/auth v0.5.2</code>.</p>\n`
+	ids, err = svc.ExtractPictures(html)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(ids), "one image in")
 	assert.Equal(t, "github_ef0f706a79cc24b17bbbb374cd234a691d034128/bjttt8ahajfmrhsula10.png", ids[0])
+
+	// proxied image
+	html = `<img src="https://remark42.radio-t.com/api/v1/img?src=aHR0cHM6Ly9ob21lcGFnZXMuY2FlLndpc2MuZWR1L35lY2U1MzMvaW1hZ2VzL2JvYXQucG5n" alt="cat.png">`
+	ids, err = svc.ExtractPictures(html)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(ids), "one image in")
+	assert.Equal(t, "cached_images/12318fbd4c55e9d177b8b5ae197bc89c5afd8e07-a41fcb00643f28d700504256ec81cbf2e1aac53e", ids[0])
+
+	// bad url
+	html = `<img src=" https://remark42.radio-t.com/api/v1/img">`
+	ids, err = svc.ExtractPictures(html)
+	require.NoError(t, err)
+	require.Empty(t, ids)
+
+	// bad src
+	html = `<img src="https://remark42.radio-t.com/api/v1/img?src=bad">`
+	ids, err = svc.ExtractPictures(html)
+	require.NoError(t, err)
+	require.Empty(t, ids)
+
+	// good src with bad content
+	badURL := base64.URLEncoding.EncodeToString([]byte(" http://foo.bar"))
+	html = fmt.Sprintf(`<img src="https://remark42.radio-t.com/api/v1/img?src=%s">`, badURL)
+	ids, err = svc.ExtractPictures(html)
+	require.NoError(t, err)
+	require.Empty(t, ids)
 }
 
 func TestService_Cleanup(t *testing.T) {


### PR DESCRIPTION
Resolves #694.

Behavior before this PR

- Set `EDIT_TIME=20s` and `IMAGE_PROXY_CACHE_EXTERNAL=true` in docker-compose.yml
- Start dev instance using docker-compose, post comment with text `![](https://homepages.cae.wisc.edu/~ece533/images/cat.png)`
- Restart docker-compose
- Wait for 2 minutes
- Reload the page: image from the comment will be re-loaded as it was stuck in Staging without commit and then was deleted after `EDIT_TIME*5`, `1m40s` in this case. And with current logic, we re-load it in case it's not in storage.

Behavior after this PR

- Set `EDIT_TIME=20s` and `IMAGE_PROXY_CACHE_EXTERNAL=true` in docker-compose.yml
- Start dev instance using docker-compose, post comment with text `![](https://homepages.cae.wisc.edu/~ece533/images/cat.png)`
- Restart docker-compose
- Wait for 2 minutes
- Reload the page: the image is still in place and loaded from storage.
  Message in logs:
  ```
  Commit image cached_images/da39a3ee5e6b4b0d3255bfef95601890afd80709-da39a3ee5e6b4b0d3255bfef95601890afd80709
  ```
