### PR TITLE
Add ability to disable user email notification UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ _this is the recommended way to run remark42_
 | notify.email.fromAddress | NOTIFY_EMAIL_FROM      |                          | from email address                              |
 | notify.email.verification_subj | NOTIFY_EMAIL_VERIFICATION_SUBJ | `Email verification` | verification message subject          |
 | notify.email.notify_admin | NOTIFY_EMAIL_ADMIN    | `false`                  | notify admin on new comments via ADMIN_SHARED_EMAIL |
+| notify.email.disable_user_notifications | NOTIFY_EMAIL_DISABLE_USER_NOTIFICATIONS | `false` | disable email notifications other than for admin |
 | smtp.host               | SMTP_HOST               |                          | SMTP host                                       |
 | smtp.port               | SMTP_PORT               |                          | SMTP port                                       |
 | smtp.username           | SMTP_USERNAME           |                          | SMTP user name                                  |

--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -198,9 +198,10 @@ type NotifyGroup struct {
 		API     string        `long:"api" env:"API" default:"https://api.telegram.org/bot" description:"telegram api prefix"`
 	} `group:"telegram" namespace:"telegram" env-namespace:"TELEGRAM"`
 	Email struct {
-		From                string `long:"from_address" env:"FROM" description:"from email address"`
-		VerificationSubject string `long:"verification_subj" env:"VERIFICATION_SUBJ" description:"verification message subject"`
-		AdminNotifications  bool   `long:"notify_admin" env:"ADMIN" description:"notify admin on new comments via ADMIN_SHARED_EMAIL"`
+		From                     string `long:"from_address" env:"FROM" description:"from email address"`
+		VerificationSubject      string `long:"verification_subj" env:"VERIFICATION_SUBJ" description:"verification message subject"`
+		AdminNotifications       bool   `long:"notify_admin" env:"ADMIN" description:"notify admin on new comments via ADMIN_SHARED_EMAIL"`
+		DisableUserNotifications bool   `long:"disable_user_notifications" env:"DISABLE_USER_NOTIFICATIONS" description:"disable email notifications other than for admin"`
 	} `group:"email" namespace:"email" env-namespace:"EMAIL"`
 }
 
@@ -446,7 +447,7 @@ func (s *ServerCommand) newServerApp() (*serverApp, error) {
 			Refresh:   s.Stream.RefreshInterval,
 			MaxActive: int32(s.Stream.MaxActive),
 		},
-		EmailNotifications: emailNotifications,
+		EmailNotifications: !s.Notify.Email.DisableUserNotifications && emailNotifications,
 		EmojiEnabled:       s.EnableEmoji,
 		AnonVote:           s.AnonymousVote && s.RestrictVoteIP,
 		SimpleView:         s.SimpleView,

--- a/docs/email.md
+++ b/docs/email.md
@@ -191,6 +191,10 @@ NOTIFY_EMAIL_VERIFICATION_SUBJ
 # for administrator notifications for new comments on their site
 ADMIN_SHARED_EMAIL
 NOTIFY_EMAIL_ADMIN
+# for enabling email notifications for admin only.
+# Beware, this disables UI access to user subscriptions but existing subscriptions will continue to work,
+# and subscription API endpoints would be still working
+NOTIFY_EMAIL_DISABLE_USER_NOTIFICATIONS
 ```
 
 After you set `SMTP_` variables, you can allow email notifications by setting these two variables:


### PR DESCRIPTION
Fix for #731. As stated in the documentation, it adds a new option to disable UI for email notifications when notifications themselves are enabled. API left enabled because it's enabled unconditionally now, so there is no change in that part.

This is necessary for the enablement of admin email notifications only, without this PR there is no workaround for it.

Truly disabling notifications other than for admin would require more significant changes and I don't know if it's necessary, leaving it for your judgment.