### PR TITLE
Fix stuck in image submit while importing comments from backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,9 +292,9 @@ _instructions for google oauth2 setup borrowed from [oauth2_proxy](https://githu
 
 1.  Register a new application [using the Azure portal](https://docs.microsoft.com/en-us/graph/auth-register-app-v2).
 2.  Under **"Authentication/Platform configurations/Web"** enter the correct url constructed as domain + `/auth/microsoft/callback`. i.e. `https://example.mysite.com/auth/microsoft/callback`
-3.  In "Overview" take note of the **Application (client) ID** 
+3.  In "Overview" take note of the **Application (client) ID**
 4.  Choose the new project from the top right project dropdown (only if another project is selected)
-5.  Select "Certificates & secrets" and click on "+ New Client Secret". 
+5.  Select "Certificates & secrets" and click on "+ New Client Secret".
 
 ##### Twitter Auth Provider
 
@@ -323,6 +323,11 @@ Optionally, anonymous access can be turned on. In this case an extra `anonymous`
 
 - name should be at least 3 characters long
 - name has to start from the letter and contains letters, numbers, underscores and spaces only.
+
+### Importing comments
+
+Remark supports importing comments from Disqus, WordPress or native backup format.
+All imported comments has `Imported` field set to `true`.
 
 #### Initial import from Disqus
 

--- a/backend/app/migrator/disqus.go
+++ b/backend/app/migrator/disqus.go
@@ -135,6 +135,7 @@ func (d *Disqus) convert(r io.Reader, siteID string) (ch chan store.Comment) {
 						Text:      d.cleanText(comment.Message),
 						Timestamp: comment.CreatedAt,
 						ParentID:  comment.Pid.Val,
+						Imported:  true,
 					}
 					if c.User.ID == "disqus_" { // empty comment.AuthorUserName from disqus
 						c.User.ID = "disqus_" + c.User.Name

--- a/backend/app/migrator/disqus_test.go
+++ b/backend/app/migrator/disqus_test.go
@@ -39,6 +39,7 @@ func TestDisqus_Import(t *testing.T) {
 	assert.Equal(t, "Alexander Blah", c.User.Name)
 	assert.Equal(t, "disqus_328c8b68974aef73785f6b38c3d3fedfdf941434", c.User.ID)
 	assert.Equal(t, "2ba6b71dbf9750ae3356cce14cac6c1b1962747c", c.User.IP)
+	assert.True(t, c.Imported)
 
 	posts, err := dataStore.List("test", 0, 0)
 	assert.NoError(t, err)
@@ -71,6 +72,7 @@ func TestDisqus_Convert(t *testing.T) {
 			ID:   "disqus_328c8b68974aef73785f6b38c3d3fedfdf941434",
 			IP:   "178.178.178.178",
 		},
+		Imported: true,
 	}
 	exp0.Timestamp, _ = time.Parse("2006-01-02T15:04:05Z", "2011-08-31T15:16:29Z")
 	assert.Equal(t, exp0, res[0])

--- a/backend/app/migrator/native.go
+++ b/backend/app/migrator/native.go
@@ -155,6 +155,7 @@ func (n *Native) Import(reader io.Reader, siteID string) (size int, err error) {
 	for {
 		comment := store.Comment{}
 		err = dec.Decode(&comment)
+		comment.Imported = true
 		if err == io.EOF {
 			break
 		}

--- a/backend/app/migrator/native_test.go
+++ b/backend/app/migrator/native_test.go
@@ -73,7 +73,7 @@ func TestNative_Import(t *testing.T) {
 
 	inp := `{"version":1,"users":[{"id":"user1","blocked":{"status":false,"until":"0001-01-01T00:00:00Z"},"verified":true},{"id":"user2","blocked":{"status":true,"until":"2018-12-23T02:55:22.472041-06:00"},"verified":false}],"posts":[{"url":"https://radio-t.com","read_only":true}]}
 	{"id":"efbc17f177ee1a1c0ee6e1e025749966ec071adc","pid":"","text":"some text, <a href=\"http://radio-t.com\" rel=\"nofollow\">link</a>","user":{"name":"user name","id":"user1","picture":"","ip":"293ec5b0cf154855258824ec7fac5dc63d176915","admin":false},"locator":{"site":"radio-t","url":"https://radio-t.com"},"score":0,"votes":{},"time":"2017-12-20T15:18:22-06:00"}
-	{"id":"f863bd79-fec6-4a75-b308-61fe5dd02aa1","pid":"1234","text":"some text2","user":{"name":"user name","id":"user2","picture":"","ip":"293ec5b0cf154855258824ec7fac5dc63d176915","admin":false},"locator":{"site":"radio-t","url":"https://radio-t.com/2"},"score":0,"votes":{},"time":"2017-12-20T15:18:23-06:00"}`
+	{"id":"f863bd79-fec6-4a75-b308-61fe5dd02aa1","pid":"1234","text":"some text2","user":{"name":"user name","id":"user2","picture":"","ip":"293ec5b0cf154855258824ec7fac5dc63d176915","admin":false},"locator":{"site":"radio-t","url":"https://radio-t.com/2"},"score":0,"votes":{},"time":"2017-12-20T15:18:23-06:00","imported":false}`
 
 	b.AdminStore = admin.NewStaticStore("12345", nil, []string{}, "")
 	r := Native{DataStore: b}
@@ -87,10 +87,12 @@ func TestNative_Import(t *testing.T) {
 	assert.Equal(t, "f863bd79-fec6-4a75-b308-61fe5dd02aa1", comments[0].ID)
 	assert.Equal(t, "1234", comments[0].ParentID)
 	assert.Equal(t, false, b.IsReadOnly(comments[0].Locator))
+	assert.True(t, comments[0].Imported)
 
 	assert.Equal(t, "efbc17f177ee1a1c0ee6e1e025749966ec071adc", comments[1].ID)
 	assert.Equal(t, "https://radio-t.com", comments[1].Locator.URL)
 	assert.Equal(t, true, b.IsReadOnly(comments[1].Locator))
+	assert.True(t, comments[1].Imported)
 
 	assert.Equal(t, false, b.IsBlocked("radio-t", "user1"))
 	assert.Equal(t, true, b.IsVerified("radio-t", "user1"))

--- a/backend/app/migrator/wordpress.go
+++ b/backend/app/migrator/wordpress.go
@@ -139,6 +139,7 @@ func (w *WordPress) convert(r io.Reader, siteID string) chan store.Comment {
 								Text:      comment.Content,
 								Timestamp: comment.Date.time,
 								ParentID:  comment.PID,
+								Imported:  true,
 							}
 							commentsCh <- commentFormatter.Format(c)
 							stats.inpComments++

--- a/backend/app/migrator/wordpress_test.go
+++ b/backend/app/migrator/wordpress_test.go
@@ -42,6 +42,7 @@ func TestWordPress_Import(t *testing.T) {
 	ts, _ := time.Parse(wpTimeLayout, "2010-08-18 15:19:14")
 	assert.Equal(t, ts, c.Timestamp)
 	assert.Equal(t, c.Text, "<p>Mekkatorque was over in that tent up to the right</p>\n")
+	assert.True(t, c.Imported)
 
 	posts, err := dataStore.List(siteID, 0, 0)
 	assert.NoError(t, err)
@@ -77,6 +78,7 @@ func TestWordPress_Convert(t *testing.T) {
 			ID:   "wordpress_" + store.EncodeID("Wednesday Reading &laquo; Cynwise&#039;s Battlefield Manual"),
 			IP:   "74.200.244.101",
 		},
+		Imported: true,
 	}
 	exp1.Timestamp, _ = time.Parse(wpTimeLayout, "2010-07-21 14:02:08")
 	assert.Equal(t, exp1, comments[1])

--- a/backend/app/store/comment.go
+++ b/backend/app/store/comment.go
@@ -26,6 +26,7 @@ type Comment struct {
 	Edit        *Edit                  `json:"edit,omitempty" bson:"edit,omitempty"` // pointer to have empty default in json response
 	Pin         bool                   `json:"pin,omitempty" bson:"pin,omitempty"`
 	Deleted     bool                   `json:"delete,omitempty" bson:"delete"`
+	Imported    bool                   `json:"imported,omitempty" bson:"imported"`
 	PostTitle   string                 `json:"title,omitempty" bson:"title"`
 }
 

--- a/backend/app/store/image/image.go
+++ b/backend/app/store/image/image.go
@@ -102,7 +102,7 @@ func NewService(s Store, p ServiceParams) *Service {
 }
 
 // Submit multiple ids via function for delayed commit
-func (s *Service) Submit(idsFn func() []string) {
+func (s *Service) Submit(idsFn func() []string, ts time.Time) {
 	if idsFn == nil || s == nil {
 		return
 	}
@@ -130,7 +130,12 @@ func (s *Service) Submit(idsFn func() []string) {
 	})
 
 	atomic.AddInt32(&s.submitCount, 1)
-	s.submitCh <- submitReq{idsFn: idsFn, TS: time.Now()}
+
+	now := time.Now()
+	if ts.IsZero() || ts.After(now) {
+		ts = now
+	}
+	s.submitCh <- submitReq{idsFn: idsFn, TS: ts}
 }
 
 // ExtractPictures gets list of images from the doc html and convert from urls to ids, i.e. user/pic.png

--- a/backend/app/store/image/image.go
+++ b/backend/app/store/image/image.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/PuerkitoBio/goquery"
 	log "github.com/go-pkgz/lgr"
+	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/rs/xid"
 	"golang.org/x/image/draw"
@@ -102,12 +103,15 @@ func NewService(s Store, p ServiceParams) *Service {
 }
 
 // SubmitAndCommit multiple ids immediately
-func (s *Service) SubmitAndCommit(idsFn func() []string) {
+func (s *Service) SubmitAndCommit(idsFn func() []string) error {
+	errs := new(multierror.Error)
 	for _, id := range idsFn() {
-		if err := s.store.Commit(id); err != nil {
-			log.Printf("[WARN] failed to commit image %s", id)
+		err := s.store.Commit(id)
+		if err != nil {
+			errs = multierror.Append(errs, errors.Wrapf(err, "failed to commit image %s", id))
 		}
 	}
+	return errs.ErrorOrNil()
 }
 
 // Submit multiple ids via function for delayed commit
@@ -127,7 +131,11 @@ func (s *Service) Submit(idsFn func() []string) {
 				for atomic.LoadInt32(&s.term) == 0 && time.Since(req.TS) <= s.commitTTL {
 					time.Sleep(time.Millisecond * 10) // small sleep to relive busy wait but keep reactive for term (close)
 				}
-				s.SubmitAndCommit(req.idsFn)
+				err := s.SubmitAndCommit(req.idsFn)
+				if err != nil {
+					log.Printf("[WARN] image commit error %v", err)
+				}
+
 				atomic.AddInt32(&s.submitCount, -1)
 			}
 			log.Printf("[INFO] image submitter terminated")

--- a/backend/app/store/image/image_test.go
+++ b/backend/app/store/image/image_test.go
@@ -137,9 +137,9 @@ func TestService_Submit(t *testing.T) {
 	store := MockStore{}
 	store.On("Commit", mock.Anything, mock.Anything).Times(5).Return(nil)
 	svc := Service{store: &store, ServiceParams: ServiceParams{ImageAPI: "/blah/", EditDuration: time.Millisecond * 100}}
-	svc.Submit(func() []string { return []string{"id1", "id2", "id3"} })
-	svc.Submit(func() []string { return []string{"id4", "id5"} })
-	svc.Submit(nil)
+	svc.Submit(func() []string { return []string{"id1", "id2", "id3"} }, time.Now())
+	svc.Submit(func() []string { return []string{"id4", "id5"} }, time.Now())
+	svc.Submit(nil, time.Now())
 	store.AssertNumberOfCalls(t, "Commit", 0)
 	time.Sleep(time.Millisecond * 150)
 	store.AssertNumberOfCalls(t, "Commit", 5)
@@ -150,9 +150,9 @@ func TestService_Close(t *testing.T) {
 	store := MockStore{}
 	store.On("Commit", mock.Anything, mock.Anything).Times(5).Return(nil)
 	svc := Service{store: &store, ServiceParams: ServiceParams{ImageAPI: "/blah/", EditDuration: time.Hour * 24}}
-	svc.Submit(func() []string { return []string{"id1", "id2", "id3"} })
-	svc.Submit(func() []string { return []string{"id4", "id5"} })
-	svc.Submit(nil)
+	svc.Submit(func() []string { return []string{"id1", "id2", "id3"} }, time.Now())
+	svc.Submit(func() []string { return []string{"id4", "id5"} }, time.Now())
+	svc.Submit(nil, time.Now())
 	svc.Close(context.TODO())
 	store.AssertNumberOfCalls(t, "Commit", 5)
 }
@@ -161,10 +161,10 @@ func TestService_SubmitDelay(t *testing.T) {
 	store := MockStore{}
 	store.On("Commit", mock.Anything, mock.Anything).Times(5).Return(nil)
 	svc := NewService(&store, ServiceParams{EditDuration: 20 * time.Millisecond})
-	svc.Submit(func() []string { return []string{"id1", "id2", "id3"} })
+	svc.Submit(func() []string { return []string{"id1", "id2", "id3"} }, time.Now())
 	time.Sleep(150 * time.Millisecond) // let first batch to pass TTL
-	svc.Submit(func() []string { return []string{"id4", "id5"} })
-	svc.Submit(nil)
+	svc.Submit(func() []string { return []string{"id4", "id5"} }, time.Now())
+	svc.Submit(nil, time.Now())
 	store.AssertNumberOfCalls(t, "Commit", 3)
 	svc.Close(context.TODO())
 	store.AssertNumberOfCalls(t, "Commit", 5)

--- a/backend/app/store/image/image_test.go
+++ b/backend/app/store/image/image_test.go
@@ -136,13 +136,14 @@ func TestService_Cleanup(t *testing.T) {
 func TestService_Submit(t *testing.T) {
 	store := MockStore{}
 	store.On("Commit", mock.Anything, mock.Anything).Times(7).Return(nil)
-	svc := Service{store: &store, ServiceParams: ServiceParams{ImageAPI: "/blah/", EditDuration: time.Millisecond * 100}}
+	svc := NewService(&store, ServiceParams{ImageAPI: "/blah/", EditDuration: time.Millisecond * 100})
 	svc.Submit(func() []string { return []string{"id1", "id2", "id3"} })
-	svc.SubmitAndCommit(func() []string { return []string{"id4", "id5"} })
+	err := svc.SubmitAndCommit(func() []string { return []string{"id4", "id5"} })
+	assert.NoError(t, err)
 	svc.Submit(func() []string { return []string{"id6", "id7"} })
 	svc.Submit(nil)
 	store.AssertNumberOfCalls(t, "Commit", 2)
-	time.Sleep(time.Millisecond * 150)
+	time.Sleep(time.Millisecond * 175)
 	store.AssertNumberOfCalls(t, "Commit", 7)
 	svc.Close(context.TODO())
 }

--- a/backend/app/store/service/service.go
+++ b/backend/app/store/service/service.go
@@ -101,7 +101,8 @@ func (s *DataStore) Create(comment store.Comment) (commentID string, err error) 
 		comment.PostTitle = title
 	}()
 
-	s.submitImages(comment)
+	defer s.submitImages(comment) // submit images only after creation in Engine
+
 	if e := s.AdminStore.OnEvent(comment.Locator.SiteID, admin.EvCreate); e != nil {
 		log.Printf("[WARN] failed to send create event, %s", e)
 	}

--- a/backend/app/store/service/service_test.go
+++ b/backend/app/store/service/service_test.go
@@ -1336,7 +1336,7 @@ func TestService_submitImages(t *testing.T) {
 	_, err := b.Engine.Create(c) // create directly with engine, doesn't call submitImages
 	assert.NoError(t, err)
 
-	b.submitImages(c.Locator, c.ID)
+	b.submitImages(c)
 	time.Sleep(250 * time.Millisecond)
 	mockStore.AssertNumberOfCalls(t, "Commit", 2)
 }


### PR DESCRIPTION
I tried to import batch of comments via native importer. I notices that importing frozen at 5000 comment, due to size of buffered channel in image service. It was continued after ttl (1.5  edit time) had expired, and stuck again.
So, this PR contains possible solution -- using not current time to check comment edit time expiration before indexing images, but actual comment timestamp.
I am not sure that it is the best solution and maybe some other needs to be considered. For example non-blocking version of submit, of forcing submition for importer.