### PR TITLE
add ability to set multiple admin emails for notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,10 @@ _this is the recommended way to run remark42_
 | store.bolt.path         | STORE_BOLT_PATH         | `./var`                  | path to data directory                          |
 | store.bolt.timeout      | STORE_BOLT_TIMEOUT      | `30s`                    | boltdb access timeout                           |
 | admin.shared.id         | ADMIN_SHARED_ID         |                          | admin names (list of user ids), _multi_         |
-| admin.shared.email      | ADMIN_SHARED_EMAIL      | `admin@${REMARK_URL}`    | admin email                                     |
+| admin.shared.email      | ADMIN_SHARED_EMAIL      | `admin@${REMARK_URL}`    | admin emails, _multi_                           |
 | backup                  | BACKUP_PATH             | `./var/backup`           | backups location                                |
 | max-back                | MAX_BACKUP_FILES        | `10`                     | max backup files to keep                        |
-| cache.type              | CACHE_TYPE              | `mem`                    | type of cache, `redis_pub_sub` or `mem` or `none`       |
+| cache.type              | CACHE_TYPE              | `mem`                    | type of cache, `redis_pub_sub` or `mem` or `none` |
 | cache.redis_addr        | CACHE_REDIS_ADDR        | `127.0.0.1:6379`         | address of redis PubSub instance, turn `redis_pub_sub` cache on for distributed cache |
 | cache.max.items         | CACHE_MAX_ITEMS         | `1000`                   | max number of cached items, `0` - unlimited     |
 | cache.max.value         | CACHE_MAX_VALUE         | `65536`                  | max size of cached value, `0` - unlimited       |

--- a/backend/app/rest/api/rest.go
+++ b/backend/app/rest/api/rest.go
@@ -51,7 +51,7 @@ type Rest struct {
 	AnonVote        bool
 	WebRoot         string
 	RemarkURL       string
-	AdminEmail      string
+	AdminEmail      []string
 	ReadOnlyAge     int
 	SharedSecret    string
 	ScoreThresholds struct {

--- a/backend/app/rest/api/rest_private.go
+++ b/backend/app/rest/api/rest_private.go
@@ -40,7 +40,7 @@ type private struct {
 	notifyService    *notify.Service
 	authenticator    *auth.Service
 	remarkURL        string
-	adminEmail       string
+	adminEmail       []string
 	anonVote         bool
 	templates        templates.FileReader
 }
@@ -119,13 +119,13 @@ func (s *private) createCommentCtrl(w http.ResponseWriter, r *http.Request) {
 	s.cache.Flush(cache.Flusher(comment.Locator.SiteID).
 		Scopes(comment.Locator.URL, lastCommentsScope, comment.User.ID, comment.Locator.SiteID))
 
-	// user notification
 	if s.notifyService != nil {
+		// user notification
 		s.notifyService.Submit(notify.Request{Comment: finalComment})
-	}
-	// admin notification
-	if s.notifyService != nil && s.adminEmail != "" {
-		s.notifyService.Submit(notify.Request{Comment: finalComment, Email: s.adminEmail, ForAdmin: true})
+		// admin notification
+		for _, adminEmail := range s.adminEmail {
+			s.notifyService.Submit(notify.Request{Comment: finalComment, Email: adminEmail, ForAdmin: true})
+		}
 	}
 
 	log.Printf("[DEBUG] created commend %+v", finalComment)

--- a/backend/app/rest/api/rest_test.go
+++ b/backend/app/rest/api/rest_test.go
@@ -381,7 +381,7 @@ func startupT(t *testing.T) (ts *httptest.Server, srv *Rest, teardown func()) {
 		Cache:      memCache,
 		WebRoot:    tmp,
 		RemarkURL:  "https://demo.remark42.com",
-		AdminEmail: "admin@example.org",
+		AdminEmail: []string{"admin@example.org"},
 		ImageService: image.NewService(&image.FileSystem{
 			Location:   tmp + "/pics-remark42",
 			Partitions: 100,


### PR DESCRIPTION
This is a fix for #756, after this change user would be able to set multiple admin emails and all of them will be used for admin notifications.

That's a simple approach to this problem, a more sophisticated one would be introducing admins per-site, who will receive notifications for their sites. It might be useful for single remark42 instance with multiple different sites, but on the other hand, I think that we might discourage that pattern and force users to run multiple instances of remark42 in separate docker containers if they want to host completely different sites together.