### PR TITLE
Fix Dockerfile build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,6 @@ RUN \
     if [ -z "$DRONE" ] ; then echo "runs outside of drone" && version="$(/script/git-rev.sh)" ; \
     else version=${DRONE_TAG}${DRONE_BRANCH}${DRONE_PULL_REQUEST}-${DRONE_COMMIT:0:7}-$(date +%Y%m%d-%H:%M:%S) ; fi && \
     echo "version=$version" && \
-    statik --src=/build/backend/templates --dest=/build/backend/app -p templates -ns templates -f && \
-    ls -la /build/backend/app/templates/statik.go && \
     go build -o remark42 -ldflags "-X main.revision=${version} -s -w" ./app
 
 FROM node:12.16-alpine as build-frontend-deps
@@ -71,6 +69,7 @@ ADD backend/scripts/import.sh /usr/local/bin/import
 RUN chmod +x /entrypoint.sh /usr/local/bin/backup /usr/local/bin/restore /usr/local/bin/import
 
 COPY --from=build-backend /build/backend/remark42 /srv/remark42
+COPY --from=build-backend /build/backend/templates /srv
 COPY --from=build-frontend /srv/frontend/public/ /srv/web
 RUN chown -R app:app /srv
 RUN ln -s /srv/remark42 /usr/bin/remark42

--- a/Dockerfile.artifacts
+++ b/Dockerfile.artifacts
@@ -1,4 +1,4 @@
-FROM node:10.11-alpine as build-frontend-deps
+FROM node:12.16-alpine as build-frontend-deps
 
 ARG CI
 ARG DRONE
@@ -13,7 +13,7 @@ ADD frontend/package.json /srv/frontend/package.json
 ADD frontend/package-lock.json /srv/frontend/package-lock.json
 RUN cd /srv/frontend && CI=true npm ci
 
-FROM node:10.11-alpine as build-frontend
+FROM node:12.16-alpine as build-frontend
 
 ARG CI
 ARG NODE_ENV=production
@@ -26,12 +26,10 @@ RUN cd /srv/frontend && \
     npm run build && \
     rm -rf ./node_modules
 
-FROM umputun/baseimage:buildgo as build-backend
+FROM umputun/baseimage:buildgo-latest as build-backend
 
 ARG GITHUB_TOKEN
 ENV SKIP_BACKEND_TEST=true
-
-RUN go get github.com/rakyll/statik
 
 WORKDIR /build/backend
 ADD backend /build/backend

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -1,4 +1,5 @@
 run:
+  timeout: 5m
   output:
     format: tab
   skip-dirs:
@@ -74,4 +75,4 @@ issues:
   exclude-use-default: false
 
 service:
-  golangci-lint-version: 1.23.x
+  golangci-lint-version: 1.31.x

--- a/backend/app/notify/email.go
+++ b/backend/app/notify/email.go
@@ -379,6 +379,7 @@ func (s *emailClient) Create(params SMTPParams) (smtpClient, error) {
 		tlsConf := &tls.Config{
 			InsecureSkipVerify: false,
 			ServerName:         params.Host,
+			MinVersion:         tls.VersionTLS12,
 		}
 		conn, err := tls.Dial("tcp", srvAddress, tlsConf)
 		if err != nil {

--- a/backend/app/templates/templates.go
+++ b/backend/app/templates/templates.go
@@ -32,7 +32,7 @@ func NewFS() *FS {
 // ReadFile depends on statik achieve exists
 func (f *FS) ReadFile(path string) ([]byte, error) {
 	if f.statik != nil {
-		return fs.ReadFile(f.statik, filepath.Join("/", path))
+		return fs.ReadFile(f.statik, filepath.Join("/", path)) //nolint:gocritic // root folder is a requirement for statik
 	}
-	return ioutil.ReadFile(filepath.Join("./", filepath.Clean(path)))
+	return ioutil.ReadFile(filepath.Clean(path))
 }


### PR DESCRIPTION
- fix `go test -race` build problem discovered in #788
- set minimum version of TLS for the backend email client to 1.2 (gosec requirement)
- remove unnecessary filepath.Join from the backend templates (gocritic mentioned that it doesn't make sense)
- increase golangci-lint timeout from default 1m to 5m