### PR TITLE
Separate notify.SubmitVerification from notify.Submit

### DIFF
--- a/backend/app/notify/telegram.go
+++ b/backend/app/notify/telegram.go
@@ -28,7 +28,6 @@ const telegramAPIPrefix = "https://api.telegram.org/bot"
 
 // NewTelegram makes telegram bot for notifications
 func NewTelegram(token, channelID string, timeout time.Duration, api string) (*Telegram, error) {
-
 	if _, err := strconv.ParseInt(channelID, 10, 64); err != nil {
 		channelID = "@" + channelID // if channelID not a number enforce @ prefix
 	}
@@ -86,10 +85,6 @@ func NewTelegram(token, channelID string, timeout time.Duration, api string) (*T
 
 // Send to telegram channel
 func (t *Telegram) Send(ctx context.Context, req Request) error {
-	if req.Comment.ID == "" {
-		// verification request received, send nothing
-		return nil
-	}
 	if req.ForAdmin {
 		// request for administrator received, do nothing with it
 		// as we already sent message on request without this flag set
@@ -149,6 +144,11 @@ func (t *Telegram) Send(ctx context.Context, req Request) error {
 	if err = json.NewDecoder(resp.Body).Decode(&tgResp); err != nil {
 		return errors.Wrap(err, "can't decode telegram response")
 	}
+	return nil
+}
+
+// SendVerification is not implemented for telegram
+func (t *Telegram) SendVerification(_ context.Context, _ VerificationRequest) error {
 	return nil
 }
 

--- a/backend/app/notify/telegram_test.go
+++ b/backend/app/notify/telegram_test.go
@@ -78,7 +78,18 @@ func TestTelegram_Send(t *testing.T) {
 	assert.Contains(t, err.Error(), "unexpected telegram status code 404", "send on broken tg")
 
 	assert.Equal(t, "telegram: @remark_test", tb.String())
-	require.NoError(t, tb.Send(context.TODO(), Request{}), "Empty Comment doesn't send anything")
+}
+
+func TestTelegram_SendVerification(t *testing.T) {
+	ts := mockTelegramServer()
+	defer ts.Close()
+
+	tb, err := NewTelegram("good-token", "remark_test", 2*time.Second, ts.URL+"/")
+	assert.NoError(t, err)
+	assert.NotNil(t, tb)
+
+	err = tb.SendVerification(context.TODO(), VerificationRequest{})
+	assert.NoError(t, err)
 }
 
 func mockTelegramServer() *httptest.Server {

--- a/backend/app/rest/api/rest_private.go
+++ b/backend/app/rest/api/rest_private.go
@@ -296,14 +296,12 @@ func (s *private) sendEmailConfirmationCtrl(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	s.notifyService.Submit(
-		notify.Request{
-			Email: address,
-			Verification: notify.VerificationMetadata{
-				SiteID: siteID,
-				User:   user.Name,
-				Token:  tkn,
-			},
+	s.notifyService.SubmitVerification(
+		notify.VerificationRequest{
+			SiteID: siteID,
+			User:   user.Name,
+			Email:  address,
+			Token:  tkn,
 		},
 	)
 

--- a/backend/app/rest/api/rest_private_test.go
+++ b/backend/app/rest/api/rest_private_test.go
@@ -655,9 +655,9 @@ func TestRest_EmailNotification(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
 	// wait for mock notification Submit to kick off
 	time.Sleep(time.Millisecond * 30)
-	require.Equal(t, 5, len(mockDestination.Get()))
-	require.NotEmpty(t, mockDestination.Get()[4].Verification)
-	verificationToken := mockDestination.Get()[4].Verification.Token
+	require.Equal(t, 1, len(mockDestination.GetVerify()))
+	assert.Equal(t, "good@example.com", mockDestination.GetVerify()[0].Email)
+	verificationToken := mockDestination.GetVerify()[0].Token
 
 	// verify email
 	req, err = http.NewRequest(http.MethodPost, ts.URL+fmt.Sprintf("/api/v1/email/confirm?site=remark42&tkn=%s", verificationToken), nil)
@@ -703,8 +703,9 @@ func TestRest_EmailNotification(t *testing.T) {
 	require.Equal(t, http.StatusCreated, resp.StatusCode, string(body))
 	// wait for mock notification Submit to kick off
 	time.Sleep(time.Millisecond * 30)
-	require.Equal(t, 7, len(mockDestination.Get()))
-	assert.Equal(t, "good@example.com", mockDestination.Get()[5].Email)
+	require.Equal(t, 6, len(mockDestination.Get()))
+	assert.Equal(t, "good@example.com", mockDestination.Get()[4].Email)
+	assert.Equal(t, "admin@example.org", mockDestination.Get()[5].Email)
 
 	// delete user's email
 	req, err = http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/email?site=remark42", nil)
@@ -733,8 +734,8 @@ func TestRest_EmailNotification(t *testing.T) {
 	require.Equal(t, http.StatusCreated, resp.StatusCode, string(body))
 	// wait for mock notification Submit to kick off
 	time.Sleep(time.Millisecond * 30)
-	require.Equal(t, 9, len(mockDestination.Get()))
-	assert.Empty(t, mockDestination.Get()[7].Email)
+	require.Equal(t, 8, len(mockDestination.Get()))
+	assert.Empty(t, mockDestination.Get()[6].Email)
 }
 
 func TestRest_UserAllData(t *testing.T) {


### PR DESCRIPTION
This is the first step towards recursive email notifications implementation in #758. I figured out that the current `notify.Request` contains two different use cases and API would be much more clear if they would be separated into their own methods.

This PR creates `notify.SubmitVerification` and `notify.Destination.SendVerification` which moves verification metadata away from `notify.Request`.