### PR TITLE
Clarify notify.Email implementation and notify logic

### DIFF
--- a/backend/app/notify/email_test.go
+++ b/backend/app/notify/email_test.go
@@ -114,7 +114,10 @@ func TestEmailSendErrors(t *testing.T) {
 	e.msgTmpl, err = template.New("test").Parse("{{.Test}}")
 	assert.NoError(t, err)
 	assert.EqualError(t, e.Send(context.Background(), Request{Comment: store.Comment{ID: "999"}, parent: store.Comment{User: store.User{ID: "test"}}, Emails: []string{"bad@example.org"}}),
-		"error executing template to build comment reply message: template: test:1:2: executing \"test\" at <.Test>: can't evaluate field Test in type notify.msgTmplData")
+		"1 error occurred:\n\t* problem sending user email notification to \"bad@example.org\": " +
+		"error executing template to build comment reply message: " +
+		"template: test:1:2: executing \"test\" at <.Test>: " +
+		"can't evaluate field Test in type notify.msgTmplData\n\n")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -123,7 +126,8 @@ func TestEmailSendErrors(t *testing.T) {
 
 	e.smtp = &fakeTestSMTP{}
 	assert.EqualError(t, e.Send(context.Background(), Request{Comment: store.Comment{ID: "999"}, parent: store.Comment{User: store.User{ID: "error"}}, Emails: []string{"bad@example.org"}}),
-		"error creating token for unsubscribe link: token generation error")
+		"1 error occurred:\n\t* problem sending user email notification to \"bad@example.org\":" +
+		" error creating token for unsubscribe link: token generation error\n\n")
 }
 
 func TestEmailSend_ExitConditions(t *testing.T) {

--- a/backend/app/notify/notify.go
+++ b/backend/app/notify/notify.go
@@ -37,7 +37,7 @@ type Store interface {
 	GetUserEmail(siteID string, userID string) (string, error)
 }
 
-// Request notification either about comment
+// Request notification for a Comment
 type Request struct {
 	Comment     store.Comment
 	parent      store.Comment

--- a/backend/app/notify/telegram.go
+++ b/backend/app/notify/telegram.go
@@ -85,11 +85,6 @@ func NewTelegram(token, channelID string, timeout time.Duration, api string) (*T
 
 // Send to telegram channel
 func (t *Telegram) Send(ctx context.Context, req Request) error {
-	if req.ForAdmin {
-		// request for administrator received, do nothing with it
-		// as we already sent message on request without this flag set
-		return nil
-	}
 	client := http.Client{Timeout: telegramTimeOut}
 	log.Printf("[DEBUG] send telegram notification to %s, comment id %s", t.channelID, req.Comment.ID)
 

--- a/backend/app/rest/api/rest_private.go
+++ b/backend/app/rest/api/rest_private.go
@@ -120,12 +120,12 @@ func (s *private) createCommentCtrl(w http.ResponseWriter, r *http.Request) {
 		Scopes(comment.Locator.URL, lastCommentsScope, comment.User.ID, comment.Locator.SiteID))
 
 	if s.notifyService != nil {
-		// user notification
-		s.notifyService.Submit(notify.Request{Comment: finalComment})
-		// admin notification
-		for _, adminEmail := range s.adminEmail {
-			s.notifyService.Submit(notify.Request{Comment: finalComment, Email: adminEmail, ForAdmin: true})
-		}
+		s.notifyService.Submit(
+			notify.Request{
+				Comment:     finalComment,
+				AdminEmails: s.adminEmail,
+			},
+		)
 	}
 
 	log.Printf("[DEBUG] created commend %+v", finalComment)

--- a/backend/app/rest/api/rest_private_test.go
+++ b/backend/app/rest/api/rest_private_test.go
@@ -618,9 +618,9 @@ func TestRest_EmailNotification(t *testing.T) {
 	require.NoError(t, render.DecodeJSON(strings.NewReader(string(body)), &parentComment))
 	// wait for mock notification Submit to kick off
 	time.Sleep(time.Millisecond * 30)
-	require.Equal(t, 2, len(mockDestination.Get()))
-	assert.Empty(t, mockDestination.Get()[0].Email)
-	assert.Equal(t, "admin@example.org", mockDestination.Get()[1].Email)
+	require.Equal(t, 1, len(mockDestination.Get()))
+	assert.Empty(t, mockDestination.Get()[0].Emails)
+	assert.Equal(t, []string{"admin@example.org"}, mockDestination.Get()[0].AdminEmails)
 
 	// create child comment from another user, email notification only to admin expected
 	req, err = http.NewRequest("POST", ts.URL+"/api/v1/comment", strings.NewReader(fmt.Sprintf(
@@ -630,7 +630,7 @@ func TestRest_EmailNotification(t *testing.T) {
 	"locator":{"url": "https://radio-t.com/blah1",
 	"site": "remark42"}}`, parentComment.ID)))
 	assert.NoError(t, err)
-	req.Header.Add("X-JWT", devToken)
+	req.Header.Add("X-JWT", anonToken)
 	resp, err = client.Do(req)
 	assert.NoError(t, err)
 	body, err = ioutil.ReadAll(resp.Body)
@@ -639,9 +639,9 @@ func TestRest_EmailNotification(t *testing.T) {
 	require.Equal(t, http.StatusCreated, resp.StatusCode, string(body))
 	// wait for mock notification Submit to kick off
 	time.Sleep(time.Millisecond * 30)
-	require.Equal(t, 4, len(mockDestination.Get()))
-	assert.Empty(t, mockDestination.Get()[2].Email)
-	assert.Equal(t, "admin@example.org", mockDestination.Get()[3].Email)
+	require.Equal(t, 2, len(mockDestination.Get()))
+	assert.Empty(t, mockDestination.Get()[1].Emails)
+	assert.Equal(t, []string{"admin@example.org"}, mockDestination.Get()[1].AdminEmails)
 
 	// send confirmation token for email
 	req, err = http.NewRequest(http.MethodPost, ts.URL+"/api/v1/email/subscribe?site=remark42&address=good@example.com", nil)
@@ -694,7 +694,7 @@ func TestRest_EmailNotification(t *testing.T) {
 	"locator":{"url": "https://radio-t.com/blah1",
 	"site": "remark42"}}`, parentComment.ID)))
 	assert.NoError(t, err)
-	req.Header.Add("X-JWT", devToken)
+	req.Header.Add("X-JWT", anonToken)
 	resp, err = client.Do(req)
 	assert.NoError(t, err)
 	body, err = ioutil.ReadAll(resp.Body)
@@ -703,9 +703,9 @@ func TestRest_EmailNotification(t *testing.T) {
 	require.Equal(t, http.StatusCreated, resp.StatusCode, string(body))
 	// wait for mock notification Submit to kick off
 	time.Sleep(time.Millisecond * 30)
-	require.Equal(t, 6, len(mockDestination.Get()))
-	assert.Equal(t, "good@example.com", mockDestination.Get()[4].Email)
-	assert.Equal(t, "admin@example.org", mockDestination.Get()[5].Email)
+	require.Equal(t, 3, len(mockDestination.Get()))
+	assert.Equal(t, []string{"good@example.com"}, mockDestination.Get()[2].Emails)
+	assert.Equal(t, []string{"admin@example.org"}, mockDestination.Get()[2].AdminEmails)
 
 	// delete user's email
 	req, err = http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/email?site=remark42", nil)
@@ -734,8 +734,9 @@ func TestRest_EmailNotification(t *testing.T) {
 	require.Equal(t, http.StatusCreated, resp.StatusCode, string(body))
 	// wait for mock notification Submit to kick off
 	time.Sleep(time.Millisecond * 30)
-	require.Equal(t, 8, len(mockDestination.Get()))
-	assert.Empty(t, mockDestination.Get()[6].Email)
+	require.Equal(t, 4, len(mockDestination.Get()))
+	assert.Empty(t, mockDestination.Get()[3].Emails)
+	assert.Equal(t, []string{"admin@example.org"}, mockDestination.Get()[3].AdminEmails)
 }
 
 func TestRest_UserAllData(t *testing.T) {


### PR DESCRIPTION
This PR moves more email notification logic from `notify.Submit` callers and `notify.Submit` itself into `Email.Send`. In particular, it starts handling user and admin email notifications in a single `Email.Send` to hide this logic from `notify.Submit`. As a tradeoff, I had to move email user verification logic to `notify.getNotificationEmails`, as I'll need it there for recursive notifications.

The new logic flow is extensively tested with existing tests as well as the newly created one.

Also, this PR hides user email from error and logs messages about canceled context and adds a test for covering default template settings.