### PR TITLE
Fixed build for usage without subdomain

### DIFF
--- a/docker-init.sh
+++ b/docker-init.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 echo "prepare environment"
 # replace BASE_URL constant by REMARK_URL
-sed -i "s|https://demo.remark42.com|${REMARK_URL}|g" /srv/web/*.js
+sed -i "s|https://demo.remark42.com|${REMARK_URL}|g" /srv/web/*.{js,html}
 
 if [ -d "/srv/var" ]; then
   chown -R app:app /srv/var 2>/dev/null

--- a/docker-init.sh
+++ b/docker-init.sh
@@ -3,6 +3,11 @@ echo "prepare environment"
 # replace BASE_URL constant by REMARK_URL
 sed -i "s|https://demo.remark42.com|${REMARK_URL}|g" /srv/web/*.{js,html}
 
+if [ -n "${SITE_ID}" ]; then
+  #replace "site_id: 'remark'" by SITE_ID
+  se -i "s|'remark'|'${SITE_ID}'|g" /srv/web/*.html
+fi
+
 if [ -d "/srv/var" ]; then
   chown -R app:app /srv/var 2>/dev/null
 else

--- a/frontend/comments.ejs
+++ b/frontend/comments.ejs
@@ -68,7 +68,7 @@
 
         var remark_config = {
           site_id: query.site_id,
-          host: '<%= REMARK_URL %>' || window.location.origin,
+          host: '<%= REMARK_URL %>' ,
           url: query.url
         };
 

--- a/frontend/comments.ejs
+++ b/frontend/comments.ejs
@@ -68,7 +68,7 @@
 
         var remark_config = {
           site_id: query.site_id,
-          host: window.location.origin,
+          host: '<%= REMARK_URL %>' || window.location.origin,
           url: query.url
         };
 

--- a/frontend/comments.ejs
+++ b/frontend/comments.ejs
@@ -68,7 +68,7 @@
 
         var remark_config = {
           site_id: query.site_id,
-          host: '<%= REMARK_URL %>' ,
+          host: '<%= htmlWebpackPlugin.options.remarkUrl %>',
           url: query.url
         };
 

--- a/frontend/counter.ejs
+++ b/frontend/counter.ejs
@@ -39,7 +39,7 @@
   <script>
     var remark_config = {
       site_id: 'remark',
-      host: '<%= REMARK_URL %>' || window.location.origin,
+      host: '<%= REMARK_URL %>',
       url: 'https://remark42.com/demo/',
       components: ['counter']
     };

--- a/frontend/counter.ejs
+++ b/frontend/counter.ejs
@@ -39,7 +39,7 @@
   <script>
     var remark_config = {
       site_id: 'remark',
-      host: window.location.origin,
+      host: '<%= REMARK_URL %>' || window.location.origin,
       url: 'https://remark42.com/demo/',
       components: ['counter']
     };

--- a/frontend/counter.ejs
+++ b/frontend/counter.ejs
@@ -39,7 +39,7 @@
   <script>
     var remark_config = {
       site_id: 'remark',
-      host: '<%= REMARK_URL %>',
+      host: '<%= htmlWebpackPlugin.options.remarkUrl %>',
       url: 'https://remark42.com/demo/',
       components: ['counter']
     };

--- a/frontend/index.ejs
+++ b/frontend/index.ejs
@@ -123,7 +123,7 @@
 
       var remark_config = {
         site_id: 'remark',
-        host: window.location.origin,
+        host: '<%= REMARK_URL %>' || window.location.origin,
         url: 'https://remark42.com/demo/',
         components: ['embed', 'counter'],
         // __colors__: {

--- a/frontend/index.ejs
+++ b/frontend/index.ejs
@@ -123,7 +123,7 @@
 
       var remark_config = {
         site_id: 'remark',
-        host: '<%= REMARK_URL %>' || window.location.origin,
+        host: '<%= REMARK_URL %>',
         url: 'https://remark42.com/demo/',
         components: ['embed', 'counter'],
         // __colors__: {

--- a/frontend/index.ejs
+++ b/frontend/index.ejs
@@ -123,7 +123,7 @@
 
       var remark_config = {
         site_id: 'remark',
-        host: '<%= REMARK_URL %>',
+        host: '<%= htmlWebpackPlugin.options.remarkUrl %>',
         url: 'https://remark42.com/demo/',
         components: ['embed', 'counter'],
         // __colors__: {

--- a/frontend/last-comments.ejs
+++ b/frontend/last-comments.ejs
@@ -25,7 +25,7 @@
     <script>
       var remark_config = {
         site_id: 'remark',
-        host: '<%= REMARK_URL %>',
+        host: '<%= htmlWebpackPlugin.options.remarkUrl %>',
         components: ['last-comments']
       };
 

--- a/frontend/last-comments.ejs
+++ b/frontend/last-comments.ejs
@@ -25,7 +25,7 @@
     <script>
       var remark_config = {
         site_id: 'remark',
-        host: window.location.origin,
+        host: '<%= REMARK_URL %>' || window.location.origin,
         components: ['last-comments']
       };
 

--- a/frontend/last-comments.ejs
+++ b/frontend/last-comments.ejs
@@ -25,7 +25,7 @@
     <script>
       var remark_config = {
         site_id: 'remark',
-        host: '<%= REMARK_URL %>' || window.location.origin,
+        host: '<%= REMARK_URL %>',
         components: ['last-comments']
       };
 

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -180,21 +180,33 @@ module.exports = () => ({
     new Html({
       template: path.resolve(__dirname, 'index.ejs'),
       inject: false,
+      templateParameters: {
+        REMARK_URL: remarkUrl,
+      },
     }),
     new Html({
       template: path.resolve(__dirname, 'counter.ejs'),
       filename: 'counter.html',
       inject: false,
+      templateParameters: {
+        REMARK_URL: remarkUrl,
+      },
     }),
     new Html({
       template: path.resolve(__dirname, 'last-comments.ejs'),
       filename: 'last-comments.html',
       inject: false,
+      templateParameters: {
+        REMARK_URL: remarkUrl,
+      },
     }),
     new Html({
       template: path.resolve(__dirname, 'comments.ejs'),
       filename: 'comments.html',
       inject: false,
+      templateParameters: {
+        REMARK_URL: remarkUrl,
+      },
     }),
     new MiniCssExtractPlugin({
       filename: '[name].css',

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -180,33 +180,25 @@ module.exports = () => ({
     new Html({
       template: path.resolve(__dirname, 'index.ejs'),
       inject: false,
-      templateParameters: {
-        REMARK_URL: remarkUrl,
-      },
+      remarkUrl,
     }),
     new Html({
       template: path.resolve(__dirname, 'counter.ejs'),
       filename: 'counter.html',
       inject: false,
-      templateParameters: {
-        REMARK_URL: remarkUrl,
-      },
+      remarkUrl,
     }),
     new Html({
       template: path.resolve(__dirname, 'last-comments.ejs'),
       filename: 'last-comments.html',
       inject: false,
-      templateParameters: {
-        REMARK_URL: remarkUrl,
-      },
+      remarkUrl,
     }),
     new Html({
       template: path.resolve(__dirname, 'comments.ejs'),
       filename: 'comments.html',
       inject: false,
-      templateParameters: {
-        REMARK_URL: remarkUrl,
-      },
+      remarkUrl,
     }),
     new MiniCssExtractPlugin({
       filename: '[name].css',


### PR DESCRIPTION
I installed remark42 in the easiest way from the docker. Configured nginx to use app without subdomain. It works okay for comments but widgets not working as expected. Widgets use it own config with host as window.location.origin which returns the fqdn only.

This can be fixed on server side by multiple sed commands in container like this `docker exec -it remark42 sed -i "s|host: window.location.origin|host: 'https://b.sattellite.me/comments/'|g" /srv/web/last-comments.html`

I prepared fix to code for exclude this problem in future:

  - Replaced host value from window.location.origin to "REMARK_URL" || window.location.origin.
  - Changed init script for container to replace forced `site_id` by 'remark' to environment SITE_ID.