### PR TITLE
add optional frame-ancestors (Content-Security-Policy) for the list of hosts passed by user

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ _this is the recommended way to run remark42_
 | emoji                   | EMOJI                   | `false`                  | enable emoji support                            |
 | simple-view             | SIMPLE_VIEW             | `false`                  | minimized UI with basic info only               |
 | proxy-cors              | PROXY_CORS              | `false`                  | disable internal CORS and delegate it to proxy  |
+| allowed-hosts           | ALLOWED_HOSTS              enable all              | limit hosts/sources allowed to embed comments   |
 | port                    | REMARK_PORT             | `8080`                   | web server port                                 |
 | web-root                | REMARK_WEB_ROOT         | `./web`                  | web server root directory                       |
 | update-limit            | UPDATE_LIMIT            | `0.5`                    | updates/sec limit                               |

--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -75,6 +75,7 @@ type ServerCommand struct {
 	EnableEmoji      bool          `long:"emoji" env:"EMOJI" description:"enable emoji"`
 	SimpleView       bool          `long:"simpler-view" env:"SIMPLE_VIEW" description:"minimal comment editor mode"`
 	ProxyCORS        bool          `long:"proxy-cors" env:"PROXY_CORS" description:"disable internal CORS and delegate it to proxy"`
+	AllowedHosts     []string      `long:"allowed-hosts" env:"ALLOWED_HOSTS" description:"limit hosts/sources allowed to embed comments"`
 
 	Auth struct {
 		TTL struct {
@@ -443,6 +444,7 @@ func (s *ServerCommand) newServerApp() (*serverApp, error) {
 		AnonVote:           s.AnonymousVote && s.RestrictVoteIP,
 		SimpleView:         s.SimpleView,
 		ProxyCORS:          s.ProxyCORS,
+		AllowedAncestors:   s.AllowedHosts,
 		SendJWTHeader:      s.Auth.TTL.SendJWTHeader,
 	}
 


### PR DESCRIPTION
This PR adds `--allowed-hosts` (env:"ALLOWED_HOSTS") enforcing  frame-ancestors Content-Security-Policy to limit which sites can include remark42 in any kind of frame. Related to https://github.com/umputun/remark42/issues/836

For more details about frame-ancestors see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors