### PR TITLE
Allow cross site requests

### DIFF
--- a/backend/vendor/github.com/go-pkgz/auth/token/jwt.go
+++ b/backend/vendor/github.com/go-pkgz/auth/token/jwt.go
@@ -238,11 +238,11 @@ func (j *Service) Set(w http.ResponseWriter, claims Claims) (Claims, error) {
 	}
 
 	jwtCookie := http.Cookie{Name: j.JWTCookieName, Value: tokenString, HttpOnly: true, Path: "/",
-		MaxAge: cookieExpiration, Secure: j.SecureCookies}
+		MaxAge: cookieExpiration, Secure: j.SecureCookies, SameSite: http.SameSiteNoneMode,}
 	http.SetCookie(w, &jwtCookie)
 
 	xsrfCookie := http.Cookie{Name: j.XSRFCookieName, Value: claims.Id, HttpOnly: false, Path: "/",
-		MaxAge: cookieExpiration, Secure: j.SecureCookies}
+		MaxAge: cookieExpiration, Secure: j.SecureCookies, SameSite: http.SameSiteNoneMode,}
 	http.SetCookie(w, &xsrfCookie)
 
 	return claims, nil


### PR DESCRIPTION
We want to allow cross site requests if comments are hosted on different domain/subdomain.

Details on the setting: https://golang.org/pkg/net/http/#SameSite

Change as proposed in #784