### PR TITLE
strip voted_ip from response

### DIFF
--- a/backend/app/rest/api/rest_private_test.go
+++ b/backend/app/rest/api/rest_private_test.go
@@ -409,7 +409,8 @@ func TestRest_Vote(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1, cr.Score)
 	assert.Equal(t, 1, cr.Vote)
-	assert.Equal(t, map[string]bool(nil), cr.Votes)
+	assert.Equal(t, map[string]bool(nil), cr.Votes, "hidden")
+	assert.Equal(t, map[string]store.VotedIPInfo(nil), cr.VotedIPs, "hidden")
 
 	assert.Equal(t, 200, vote(-1), "opposite vote allowed")
 	body, code = getWithDevAuth(t, fmt.Sprintf("%s/api/v1/id/%s?site=remark42&url=https://radio-t.com/blah", ts.URL, id1))
@@ -445,7 +446,8 @@ func TestRest_Vote(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, -1, cr.Score)
 	assert.Equal(t, 0, cr.Vote, "no vote info for not authed user")
-	assert.Equal(t, map[string]bool(nil), cr.Votes)
+	assert.Equal(t, map[string]bool(nil), cr.Votes, "hidden")
+	assert.Equal(t, map[string]store.VotedIPInfo(nil), cr.VotedIPs, "hidden")
 
 	req, err := http.NewRequest("GET",
 		fmt.Sprintf("%s/api/v1/id/%s?site=remark42&url=https://radio-t.com/blah", ts.URL, id1), nil)
@@ -458,7 +460,8 @@ func TestRest_Vote(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, -1, cr.Score)
 	assert.Equal(t, 0, cr.Vote, "no vote info for different user")
-	assert.Equal(t, map[string]bool(nil), cr.Votes)
+	assert.Equal(t, map[string]bool(nil), cr.Votes, "hidden")
+	assert.Equal(t, map[string]store.VotedIPInfo(nil), cr.VotedIPs, "hidden")
 }
 
 func TestRest_AnonVote(t *testing.T) {

--- a/backend/app/rest/api/rest_private_test.go
+++ b/backend/app/rest/api/rest_private_test.go
@@ -514,6 +514,7 @@ func TestRest_AnonVote(t *testing.T) {
 	assert.Equal(t, 1, cr.Score)
 	assert.Equal(t, 1, cr.Vote)
 	assert.Equal(t, map[string]bool(nil), cr.Votes)
+	assert.Equal(t, map[string]store.VotedIPInfo(nil), cr.VotedIPs)
 }
 
 type MockFS struct{}

--- a/backend/app/store/comment.go
+++ b/backend/app/store/comment.go
@@ -83,6 +83,7 @@ func (c *Comment) PrepareUntrusted() {
 	c.ID = ""                 // don't allow user to define ID, force auto-gen
 	c.Timestamp = time.Time{} // reset time, force auto-gen
 	c.Votes = make(map[string]bool)
+	c.VotedIPs = make(map[string]VotedIPInfo)
 	c.Score = 0
 	c.Edit = nil
 	c.Pin = false
@@ -95,6 +96,7 @@ func (c *Comment) SetDeleted(mode DeleteMode) {
 	c.Orig = ""
 	c.Score = 0
 	c.Votes = map[string]bool{}
+	c.VotedIPs = make(map[string]VotedIPInfo)
 	c.Edit = nil
 	c.Deleted = true
 	c.Pin = false

--- a/backend/app/store/comment_test.go
+++ b/backend/app/store/comment_test.go
@@ -78,6 +78,7 @@ func TestComment_PrepareUntrusted(t *testing.T) {
 	assert.Equal(t, time.Time{}, comment.Timestamp)
 	assert.Equal(t, false, comment.Deleted)
 	assert.Equal(t, make(map[string]bool), comment.Votes)
+	assert.Equal(t, make(map[string]VotedIPInfo), comment.VotedIPs)
 	assert.Equal(t, User{ID: "username"}, comment.User)
 
 }
@@ -101,6 +102,7 @@ func TestComment_SetDeleted(t *testing.T) {
 	assert.Equal(t, "", comment.Text)
 	assert.Equal(t, "", comment.Orig)
 	assert.Equal(t, map[string]bool{}, comment.Votes)
+	assert.Equal(t, map[string]VotedIPInfo{}, comment.VotedIPs)
 	assert.Equal(t, 0, comment.Score)
 	assert.True(t, comment.Deleted)
 	assert.Nil(t, comment.Edit)
@@ -127,6 +129,7 @@ func TestComment_SetDeletedHard(t *testing.T) {
 	assert.Equal(t, "", comment.Text)
 	assert.Equal(t, "", comment.Orig)
 	assert.Equal(t, map[string]bool{}, comment.Votes)
+	assert.Equal(t, map[string]VotedIPInfo{}, comment.VotedIPs)
 	assert.Equal(t, 0, comment.Score)
 	assert.True(t, comment.Deleted)
 	assert.Nil(t, comment.Edit)

--- a/backend/app/store/service/service.go
+++ b/backend/app/store/service/service.go
@@ -940,7 +940,8 @@ func (s *DataStore) prepVotes(c store.Comment, user store.User) store.Comment {
 		}
 	}
 
-	c.Votes = nil // hide voters list
+	c.Votes = nil    // hide voters list
+	c.VotedIPs = nil // hide voted ips (hashes)
 	return c
 }
 

--- a/backend/app/store/service/service_test.go
+++ b/backend/app/store/service/service_test.go
@@ -387,7 +387,7 @@ func TestService_VoteAggressive(t *testing.T) {
 
 	// random +1/-1 result should be [0..2]
 	rand.Seed(time.Now().UnixNano())
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < 100; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()


### PR DESCRIPTION
`voted_ip` map was added to comments as a part of #400, however I don't think there is a reason to send it back to UI/API clients. We already strip `votes` map of user on both send and input validation levels and I believe the same should be done for `voted_ip` as well.

Looks like this data not in any use by the official clients, so this PR strips it completely. Pls note - presence of this map in the response doesn't expose anything bad by itself (just a bunch of hashes and time stamps) but may allow some cross-post analysis of votes to figure how the same user voted without exposing the user ID. So, not terrible but still something we may want to prevent.
