### PR TITLE
Update fetcher and add good coverage to it

### DIFF
--- a/frontend/app/__mocks__/headers.ts
+++ b/frontend/app/__mocks__/headers.ts
@@ -1,6 +1,20 @@
 global.Headers = class HeadersMock extends Headers implements Headers {
   private headers = new Map();
 
+  constructor(headers?: HeadersInit) {
+    super(headers);
+
+    if (typeof headers === 'object' && headers !== null) {
+      const entries = Object.entries(headers) as [string, string][];
+
+      if (entries.length > 0) {
+        entries.forEach(([k, v]) => {
+          this.append(k, v);
+        });
+      }
+    }
+  }
+
   append(key: string, value: string) {
     this.headers.set(key, value);
   }

--- a/frontend/app/common/constants.ts
+++ b/frontend/app/common/constants.ts
@@ -33,11 +33,7 @@ export const LS_SORT_KEY = '__remarkSort';
 /** localstorage key for email of logged in user */
 export const LS_EMAIL_KEY = '__remarkEmail';
 
-/** Header name for jwt token */
-export const HEADER_X_JWT = 'X-JWT';
-
 export const THEMES: Theme[] = ['light', 'dark'];
-
 export const IS_MOBILE = /Android|webOS|iPhone|iPad|iPod|Opera Mini|Windows Phone/i.test(navigator.userAgent);
 
 /**

--- a/frontend/app/common/fetcher.test.ts
+++ b/frontend/app/common/fetcher.test.ts
@@ -1,73 +1,213 @@
-import fetcher from './fetcher';
+import { RequestError } from 'utils/errorUtils';
+import { API_BASE, BASE_URL } from './constants.config';
+import fetcher, { JWT_HEADER, XSRF_HEADER } from './fetcher';
+
+type FetchImplementaitonProps = {
+  status?: number;
+  headers?: Record<string, string>;
+  json?: () => Promise<unknown>;
+  text?: () => Promise<unknown>;
+  data?: unknown;
+};
+
+function mockFetch({ headers = {}, data = {}, ...props }: FetchImplementaitonProps = {}) {
+  window.fetch = jest.fn().mockImplementation(() => {
+    return {
+      status: 200,
+      headers: new Headers(headers),
+      async json() {
+        return data;
+      },
+      async text() {
+        return JSON.stringify(data);
+      },
+      ...props,
+    };
+  });
+}
 
 describe('fetcher', () => {
-  describe('errors', () => {
+  const headers = { [XSRF_HEADER]: '' };
+
+  describe('methods', () => {
+    it('should send GET request', async () => {
+      expect.assertions(1);
+
+      mockFetch();
+      await fetcher.get('/auth');
+
+      expect(window.fetch).toHaveBeenCalledWith(`${BASE_URL}/auth`, { method: 'get', headers });
+    });
+    it('should send POST request', async () => {
+      expect.assertions(1);
+
+      mockFetch();
+      await fetcher.post('/auth');
+
+      expect(window.fetch).toHaveBeenCalledWith(`${BASE_URL}/auth`, { method: 'post', headers });
+    });
+    it('should send PUT request', async () => {
+      expect.assertions(1);
+
+      mockFetch();
+      await fetcher.put('/auth');
+
+      expect(window.fetch).toHaveBeenCalledWith(`${BASE_URL}/auth`, { method: 'put', headers });
+    });
+    it('should send DELETE request', async () => {
+      expect.assertions(1);
+
+      mockFetch();
+      await fetcher.delete('/auth');
+
+      expect(window.fetch).toHaveBeenCalledWith(`${BASE_URL}/auth`, { method: 'delete', headers });
+    });
+  });
+
+  describe('endpoint formation', () => {
+    it("shouldn't add API_BASE for requests to auth endpoints", async () => {
+      expect.assertions(1);
+
+      mockFetch();
+      await fetcher.post('/auth/google/login');
+
+      expect(window.fetch).toHaveBeenCalledWith(`${BASE_URL}/auth/google/login`, { method: 'post', headers });
+    });
+
+    it('should add API_BASE for requests to auth endpoints', async () => {
+      expect.assertions(1);
+
+      mockFetch();
+      await fetcher.post('/comments');
+
+      expect(window.fetch).toHaveBeenCalledWith(`${BASE_URL}${API_BASE}/comments`, { method: 'post', headers });
+    });
+  });
+
+  describe('headers', () => {
+    it('should set active token and than clean it on unauthorized respose', async () => {
+      expect.assertions(4);
+
+      const headersWithJwt = { [JWT_HEADER]: 'token', ...headers };
+      // Set token to `activeJwtToken`
+      mockFetch({ headers: headersWithJwt });
+      await fetcher.get('/comments');
+
+      expect(window.fetch).toHaveBeenCalled();
+
+      // Check if `activeJwtToken` saved and clean
+      mockFetch({ headers, status: 401 });
+      await fetcher
+        .get('/comments')
+        .then(() => {
+          throw Error('Fetcher shoud throw error on 401 responce');
+        })
+        .catch((e) => {
+          expect(e.message).toBe('Not authorized.');
+        });
+
+      expect(window.fetch).toHaveBeenCalledWith(`${BASE_URL}${API_BASE}/comments`, {
+        method: 'get',
+        headers: headersWithJwt,
+      });
+
+      // Check if `activeJwtToken` was cleaned
+      mockFetch({ headers });
+      await fetcher.get('/comments', { headers });
+
+      expect(window.fetch).toHaveBeenCalledWith(`${BASE_URL}${API_BASE}/comments`, { method: 'get', headers });
+    });
+  });
+
+  describe('send data', () => {
+    it('should send JSON', async () => {
+      expect.assertions(1);
+
+      const json = { text: 'text' };
+      const headersWithContentType = { ...headers, 'Content-Type': 'application/json' };
+
+      mockFetch();
+      await fetcher.post('/comment', { json });
+
+      expect(window.fetch).toBeCalledWith(`${BASE_URL}${API_BASE}/comment`, {
+        method: 'post',
+        headers: headersWithContentType,
+        body: JSON.stringify(json),
+      });
+    });
+    it('should send form data', async () => {
+      expect.assertions(1);
+
+      const headersWithMultipartData = { ...headers, 'Content-Type': 'multipart/form-data' };
+      const body = new FormData();
+
+      mockFetch();
+      await fetcher.post('/comment', { body, headers: headersWithMultipartData });
+
+      expect(window.fetch).toHaveBeenCalledWith(`${BASE_URL}${API_BASE}/comment`, {
+        method: 'post',
+        body,
+        headers: headersWithMultipartData,
+      });
+    });
+  });
+
+  describe('request errors', () => {
     it('should throw json on api json response with >= 400 status code', async () => {
-      const response = {
+      expect.assertions(1);
+
+      const data = {
         code: 2,
         error: 'you just cant',
         details: 'you just cant at all',
       };
-      window.fetch = jest.fn().mockImplementation(async () => ({
-        status: 400,
-        headers: new Headers(),
-        json: async () => response,
-        text: async () => JSON.stringify(response),
-      }));
 
-      return fetcher
-        .get('/api/some')
-        .then((data) => {
-          throw new Error('Request should be failed');
-        })
-        .catch((e) => {
-          expect(e.code).toBe(2);
-          expect(e.error).toBe('you just cant');
-          expect(e.details).toBe('you just cant at all');
-        });
+      mockFetch({ status: 400, data });
+
+      await expect(fetcher.get('/anything')).rejects.toEqual(data);
     });
+
+    it('should throw error on api json response with >= 400 status code and bad json from server', async () => {
+      expect.assertions(1);
+
+      const data = ']{{"code: 2';
+
+      mockFetch({ status: 400, data });
+
+      await expect(fetcher.get('/anything')).rejects.toEqual(data);
+    });
+
     it('should throw special error object on 401 status', async () => {
+      expect.assertions(1);
+
       const response = '<html>unauthorized nginx response</html>';
-      window.fetch = jest.fn().mockImplementation(async () => ({
+
+      mockFetch({
         status: 401,
-        headers: new Headers(),
-        json: async () => {
+        json() {
           throw new Error('json parse error');
         },
-        text: async () => response,
-      }));
+        async text() {
+          return response;
+        },
+      });
 
-      return fetcher
-        .get('/api/some')
-        .then((data) => {
-          throw new Error('Request should be failed');
-        })
-        .catch((e) => {
-          expect(e.code).toBe(401);
-          expect(e.error).toBe('Not authorized.');
-        });
+      await expect(fetcher.get('/anything')).rejects.toEqual(new RequestError('Not authorized.', 401));
     });
     it('should throw "Something went wrong." object on unknown status', async () => {
-      window.fetch = jest.fn().mockImplementation(async () => ({
+      expect.assertions(1);
+
+      mockFetch({
         status: 400,
-        headers: new Headers(),
-        async json() {
+        json() {
           throw new Error('json parse error');
         },
         async text() {
           return 'you given me something wrong';
         },
-      }));
+      });
 
-      return fetcher
-        .get({ url: '/api/some', logError: false })
-        .then((data) => {
-          throw new Error('Request should be failed');
-        })
-        .catch((e) => {
-          expect(e.code).toBe(0);
-          expect(e.error).toBe('Something went wrong.');
-        });
+      await expect(fetcher.get('/anything')).rejects.toEqual(new RequestError('Something went wrong.', 0));
     });
   });
 });

--- a/frontend/app/utils/errorUtils.ts
+++ b/frontend/app/utils/errorUtils.ts
@@ -181,10 +181,6 @@ export const httpErrorMap = new Map([
   [429, httpMessages.toManyRequest],
 ]);
 
-export function isFailedFetch(e?: Error): boolean {
-  return Boolean(e && e.message && e.message === `Failed to fetch`);
-}
-
 export type FetcherError =
   | string
   | {


### PR DESCRIPTION
Changes to `fetcher` that was started in #844 
I would like to separate these changes to their own PR and don't mix auth updates with updates.

- Simplified params
- Encode all query params
- Test coverage


- [ ] Check all requests
- [ ] Thinking about change variation of arguments for `fetcher[method]` because we are using `RequestInit` only one time for image uploading