### PR TITLE
Update frontend CI

### DIFF
--- a/.github/workflows/ci-frontend-size-limit.yml
+++ b/.github/workflows/ci-frontend-size-limit.yml
@@ -1,11 +1,11 @@
-name: "check js/css bundles file limit"
+name: frontend
+
 on:
   pull_request:
-    branches:
-      - master
     paths:
-      - '.github/workflows/ci-test-frontend.yml'
-      - 'frontend/**/*.{ts,tsx,css}'
+      - '.github/workflows/ci-frontend-size-limit.yml'
+      - 'frontend/**'
+
 jobs:
   size:
     runs-on: ubuntu-latest
@@ -16,4 +16,4 @@ jobs:
       - uses: andresz1/size-limit-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          directory: frontend/
+          directory: frontend

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -1,23 +1,23 @@
-name: test_frontend
+name: frontend
 
 on:
   push:
     branches:
     tags:
     paths:
-      - '.github/workflows/ci-test-frontend.yml'
+      - '.github/workflows/ci-frontend.yml'
       - 'frontend/**'
   pull_request:
     paths:
-      - '.github/workflows/ci-test-frontend.yml'
+      - '.github/workflows/ci-frontend.yml'
       - 'frontend/**'
 
 jobs:
-  frontend-check:
+  check-transtations:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12.16]
+        node: [14.15]
 
     steps:
       - uses: actions/checkout@v2
@@ -35,14 +35,39 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - run: npx run-p check
+      - run: npm run check:translation
         working-directory: ./frontend
 
-  frontend-lint:
+  check-typescript:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12.16]
+        node: [14.15]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+
+      - run: npm ci --loglevel warn
+        working-directory: ./frontend
+
+      - uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/frontend/node_modules/.cache
+          key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - run: npm run check:types
+        working-directory: ./frontend
+
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [14.15]
 
     steps:
       - uses: actions/checkout@v2
@@ -56,11 +81,11 @@ jobs:
       - run: npx run-p lint
         working-directory: ./frontend
 
-  frontend-test:
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12.16]
+        node: [14.15]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
- Fix `size-limit` action
- `size-limit` has its own file because has a different trigger
- Rename `ci-test-frontend` -> `ci-frontend` because it's doing more than just tests
- Separate typescript type check and translations for more atomic and informative error in case of fail
- All frontend actions grouped under `frontend` label
- Update node to lastest LTS