### PR TITLE
Rollback readme till release

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,16 @@ Add this snippet to the bottom of web page:
                                    // but your users won't have interface for subscription
   };
 </script>
-<script>!function(e,n){for(var o=0;o<e.length;o++){var r=n.createElement("script"),c=".js",d=n.head||n.body;"noModule"in r?(r.type="module",c=".mjs"):r.async=!0,r.defer=!0,r.src=remark_config.host+"/web/"+e[o]+c,d.appendChild(r)}}(remark_config.components||["embed"],document);</script>
+<script>
+  (function(c) {
+    for(var i = 0; i < c.length; i++){
+      var d = document, s = d.createElement('script');
+      s.src = remark_config.host + '/web/' +c[i] +'.js';
+      s.defer = true;
+      (d.head || d.body).appendChild(s);
+    }
+  })(remark_config.components || ['embed']);
+</script>
 ```
 
 And then add this node in the place where you want to see Remark42 widget:


### PR DESCRIPTION
I put back the old code snippet because the new one could work only with master version.
By the way, the old snippet will work with the new remark version just fine.