### PR TITLE
Fix empty username check for Disqus migrator

### DIFF
--- a/backend/app/migrator/disqus.go
+++ b/backend/app/migrator/disqus.go
@@ -137,7 +137,7 @@ func (d *Disqus) convert(r io.Reader, siteID string) (ch chan store.Comment) {
 						ParentID:  comment.Pid.Val,
 						Imported:  true,
 					}
-					if c.User.ID == "disqus_" { // empty comment.AuthorUserName from disqus
+					if len(comment.AuthorUserName) == 0 { // empty comment.AuthorUserName from disqus
 						c.User.ID = "disqus_" + c.User.Name
 					}
 					if c.ID == "" { // no comment.UID

--- a/backend/app/migrator/disqus.go
+++ b/backend/app/migrator/disqus.go
@@ -137,7 +137,7 @@ func (d *Disqus) convert(r io.Reader, siteID string) (ch chan store.Comment) {
 						ParentID:  comment.Pid.Val,
 						Imported:  true,
 					}
-					if len(comment.AuthorUserName) == 0 { // empty comment.AuthorUserName from disqus
+					if comment.AuthorUserName == "" { // empty comment.AuthorUserName from disqus
 						c.User.ID = "disqus_" + c.User.Name
 					}
 					if c.ID == "" { // no comment.UID

--- a/backend/app/migrator/disqus_test.go
+++ b/backend/app/migrator/disqus_test.go
@@ -41,6 +41,10 @@ func TestDisqus_Import(t *testing.T) {
 	assert.Equal(t, "2ba6b71dbf9750ae3356cce14cac6c1b1962747c", c.User.IP)
 	assert.True(t, c.Imported)
 
+	c = last[1] // get comment with empty username
+	assert.Equal(t, "No Username", c.User.Name)
+	assert.Equal(t, "disqus_No Username", c.User.ID)
+
 	posts, err := dataStore.List("test", 0, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(posts), "2 posts")
@@ -171,10 +175,9 @@ var xmlTestDisqus = `<?xml version="1.0" encoding="utf-8"?>
 		<isDeleted>false</isDeleted>
 		<isSpam>false</isSpam>
 		<author>
-			<email>dmitri.noname@gmail.com</email>
-			<name>Dmitry Noname</name>
+			<email>john.nousername@gmail.com</email>
+			<name>No Username</name>
 			<isAnonymous>false</isAnonymous>
-			<username>google-74b9e7568ef6860e93862c5d77590123</username>
 		</author>
 		<ipAddress>89.89.89.139</ipAddress>
 		<thread dsq:id="247918464"/>

--- a/backend/app/store/user.go
+++ b/backend/app/store/user.go
@@ -50,7 +50,7 @@ func EncodeID(id string) string {
 func hashWithFallback(h hash.Hash, val string) string {
 
 	if reValidSha.MatchString(val) {
-		return val // already hashed or empty
+		return val // already hashed
 	}
 
 	if _, err := io.WriteString(h, val); err != nil {

--- a/backend/app/store/user.go
+++ b/backend/app/store/user.go
@@ -48,8 +48,9 @@ func EncodeID(id string) string {
 
 // hashWithFallback tries to has val with hash.Hash and fallback to crc if needed
 func hashWithFallback(h hash.Hash, val string) string {
-	if len(val) == 0 || reValidSha.MatchString(val) {
-		return val // empty or already hashed
+
+	if reValidSha.MatchString(val) {
+		return val // already hashed or empty
 	}
 
 	if _, err := io.WriteString(h, val); err != nil {

--- a/backend/app/store/user.go
+++ b/backend/app/store/user.go
@@ -48,9 +48,8 @@ func EncodeID(id string) string {
 
 // hashWithFallback tries to has val with hash.Hash and fallback to crc if needed
 func hashWithFallback(h hash.Hash, val string) string {
-
-	if reValidSha.MatchString(val) {
-		return val // already hashed or empty
+	if len(val) == 0 || reValidSha.MatchString(val) {
+		return val // empty or already hashed
 	}
 
 	if _, err := io.WriteString(h, val); err != nil {


### PR DESCRIPTION
I found a bug while importing comments from Disqus.

It generates `comment.User.ID` from author's username. 
https://github.com/umputun/remark42/blob/3628467367277be356fd56d4590ca1740a121cd7/backend/app/migrator/disqus.go#L130-L134

If author's username is empty (`c.User.ID == "disqus_"`), it uses author's name for user ID. It assumes `store.EncodeID` returns empty string for empty username.
https://github.com/umputun/remark42/blob/3628467367277be356fd56d4590ca1740a121cd7/backend/app/migrator/disqus.go#L140-L142

But `store.EncodeID` returns `da39a3ee5e6b4b0d3255bfef95601890afd80709` for empty string.
https://github.com/umputun/remark42/blob/3628467367277be356fd56d4590ca1740a121cd7/backend/app/store/user.go#L52-L54

`reValidSha.MatchString(val)` doesn't return `true` for empty values. Example: https://play.golang.org/p/b8CZt6gR4X7

As I understand from the `// already hashed or empty` comment, it expects to return for empty values too.

As a result, all authors from Disqus -who don't have username- have user id `disqus_da39a3ee5e6b4b0d3255bfef95601890afd80709`.
So all comments link to one author.

