### PR TITLE
Encode e-mail subject to support non-ASCII chars

### DIFF
--- a/backend/app/notify/email.go
+++ b/backend/app/notify/email.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	"mime"
 	"mime/quotedprintable"
 	"net"
 	"net/smtp"
@@ -303,7 +304,7 @@ func (e *Email) buildMessage(subject, body, to, contentType, unsubscribeLink str
 	}
 	message = addHeader(message, "From", e.From)
 	message = addHeader(message, "To", to)
-	message = addHeader(message, "Subject", subject)
+	message = addHeader(message, "Subject", mime.BEncoding.Encode("utf-8", subject))
 	message = addHeader(message, "Content-Transfer-Encoding", "quoted-printable")
 
 	if contentType != "" {

--- a/backend/app/notify/email_test.go
+++ b/backend/app/notify/email_test.go
@@ -287,7 +287,7 @@ Date: `)
 	// send email to both user and admin, without parent set
 	email.AdminEmails = []string{"admin@example.org"}
 	req = Request{
-		Comment: store.Comment{ID: "999", User: store.User{ID: "1", Name: "test_user"}, PostTitle: "test_title"},
+		Comment: store.Comment{ID: "999", User: store.User{ID: "1", Name: "test_user"}, PostTitle: "Привет"},
 		Emails:  []string{"test@example.org"},
 	}
 	assert.NoError(t, email.Send(context.TODO(), req))

--- a/backend/app/notify/email_test.go
+++ b/backend/app/notify/email_test.go
@@ -266,10 +266,6 @@ func TestEmail_SendWithUnicodeInSubject(t *testing.T) {
 		parent:  store.Comment{ID: "1", User: store.User{ID: "999", Name: "parent_user"}},
 		Emails:  []string{"test@example.org"},
 	}
-	assert.NoError(t, email.Send(context.TODO(), req))
-	assert.Equal(t, "from@example.org", fakeSMTP.readMail())
-	assert.Equal(t, 1, fakeSMTP.readQuitCount())
-	assert.Equal(t, "test@example.org", fakeSMTP.readRcpt())
 	// test buildMessageFromRequest separately for message text
 	res, err := email.buildMessageFromRequest(req, req.Emails[0], false)
 	assert.NoError(t, err)
@@ -282,27 +278,6 @@ MIME-version: 1.0
 Content-Type: text/html; charset="UTF-8"
 List-Unsubscribe-Post: List-Unsubscribe=One-Click
 List-Unsubscribe: <https://remark42.com/api/v1/email/unsubscribe?site=&tkn=token>
-Date: `)
-
-	// send email to both user and admin, without parent set
-	email.AdminEmails = []string{"admin@example.org"}
-	req = Request{
-		Comment: store.Comment{ID: "999", User: store.User{ID: "1", Name: "test_user"}, PostTitle: "Привет"},
-		Emails:  []string{"test@example.org"},
-	}
-	assert.NoError(t, email.Send(context.TODO(), req))
-	assert.Equal(t, "from@example.org", fakeSMTP.readMail())
-	assert.Equal(t, 3, fakeSMTP.readQuitCount(), "plus two emails: one for user and one for admin")
-	assert.Equal(t, "admin@example.org", fakeSMTP.readRcpt())
-	res, err = email.buildMessageFromRequest(req, email.AdminEmails[0], true)
-	assert.NoError(t, err)
-	// `=?utf-8?b?TmV3IGNvbW1lbnQgdG8geW91ciBzaXRlIGZvciAi0J/RgNC40LLQtdGCIg==?=` -> `New comment to your site for "Привет"` in base64 + required prefix and suffix
-	assert.Contains(t, res, `From: from@example.org
-To: admin@example.org
-Subject: =?utf-8?b?TmV3IGNvbW1lbnQgdG8geW91ciBzaXRlIGZvciAi0J/RgNC40LLQtdGCIg==?=
-Content-Transfer-Encoding: quoted-printable
-MIME-version: 1.0
-Content-Type: text/html; charset="UTF-8"
 Date: `)
 }
 


### PR DESCRIPTION
Add base64-encoding to email `Subject:` header value to allow non-ASCII characters, according to RFC2047. Current implementation produces invalid messages when e.g. page title contains Cyrillic letters. 