### PR TITLE
Fix NPE when sending message to detached frame

### DIFF
--- a/frontend/app/embed.ts
+++ b/frontend/app/embed.ts
@@ -300,17 +300,21 @@ function createInstance(config: typeof window.remark_config) {
   }
 
   function postTitleToIframe(title: string) {
-    iframe.contentWindow!.postMessage(JSON.stringify({ title }), '*');
+    if (iframe.contentWindow) {
+      iframe.contentWindow.postMessage(JSON.stringify({ title }), '*');
+    }
   }
 
   function postClickOutsideToIframe(e: MouseEvent) {
-    if (!iframe.contains(e.target as Node)) {
-      iframe.contentWindow!.postMessage(JSON.stringify({ clickOutside: true }), '*');
+    if (iframe.contentWindow && !iframe.contains(e.target as Node)) {
+      iframe.contentWindow.postMessage(JSON.stringify({ clickOutside: true }), '*');
     }
   }
 
   function changeTheme(theme: Theme) {
-    iframe.contentWindow!.postMessage(JSON.stringify({ theme }), '*');
+    if (iframe.contentWindow) {
+      iframe.contentWindow.postMessage(JSON.stringify({ theme }), '*');
+    }
   }
 
   function destroy() {
@@ -324,6 +328,9 @@ function createInstance(config: typeof window.remark_config) {
 
     if (titleObserver) {
       titleObserver.disconnect();
+      // Allow browser to drop observer and iframe captured in callback
+      // to prevent attempts to send messages to detached frame
+      titleObserver = null;
     }
 
     iframe.remove();


### PR DESCRIPTION
This patch fixes NPE from #722, tested in Firefox 85 an Edge 88 (Chromium).

The idea is to manually set `titleObserver = null` in `destroy()` and allow browser's GC to drop the observer, it's callback and captured iframe. Function `postTitleToIframe` is not called after destroy call, but I've also added null checks for functions which send messages to iframe window.