### PR TITLE
Fix saving comment to LS

### DIFF
--- a/frontend/app/common/local-storage.ts
+++ b/frontend/app/common/local-storage.ts
@@ -46,9 +46,9 @@ export function setJsonItem<T = unknown>(key: string, data: T) {
   }
 }
 
-export function updateJsonItem<T extends {}>(key: string, value: (data: T) => T): void;
-export function updateJsonItem<T extends {}>(key: string, value: T): void;
-export function updateJsonItem<T extends unknown[]>(key: string, value: T): void;
+export function updateJsonItem<T = Record<string, unknown>>(key: string, value: (data: T) => T): void;
+export function updateJsonItem<T = Record<string, unknown>>(key: string, value: T): void;
+export function updateJsonItem<T = unknown[]>(key: string, value: T): void;
 export function updateJsonItem<T>(key: string, value: T) {
   const savedData = getJsonItem<T>(key);
 


### PR DESCRIPTION
**The problem**
When local storage is empty and we try to upload an image and send a form shows an error but the comment saves.

**Why**
Comment saves to local storage on edit.
When a user uploads an image comment doesn't save in local storage.
On send, we are trying to remove a saved comment from local storage but it's empty.
`delete data[....]` when data is `null`

**Solve**
* save comment after image upload
* do not affect error messages by saving to LS mechanism
* don't try to clear empty local storage