### PR TITLE
Fix collapsing comments iframe

### DIFF
--- a/frontend/app/embed.ts
+++ b/frontend/app/embed.ts
@@ -17,11 +17,13 @@ function createFrame({
   host,
   query,
   height,
+  margin = '-6px',
   __colors__ = {},
 }: {
   host: string;
   query: string;
   height?: string;
+  margin?: string;
   __colors__?: Record<string, string>;
 }) {
   const iframe = document.createElement('iframe');
@@ -38,7 +40,7 @@ function createFrame({
   iframe.setAttribute('verticalscrolling', 'no');
   iframe.setAttribute(
     'style',
-    'width: 1px !important; min-width: 100% !important; border: none !important; overflow: hidden !important; margin: -6px;'
+    `width: 1px !important; min-width: 100% !important; border: none !important; overflow: hidden !important; margin: ${margin};`
   );
 
   if (height) {
@@ -200,7 +202,7 @@ function createInstance(config: typeof window.remark_config) {
       const queryUserInfo = `${query}&page=user-info&&id=${user.id}&name=${user.name}&picture=${
         user.picture || ''
       }&isDefaultPicture=${user.isDefaultPicture || 0}`;
-      const iframe = createFrame({ host: BASE_URL, query: queryUserInfo, height: '100%' });
+      const iframe = createFrame({ host: BASE_URL, query: queryUserInfo, height: '100%', margin: '0' });
       this.node.appendChild(iframe);
       this.iframe = iframe;
       this.node.appendChild(this.closeEl);

--- a/frontend/templates/iframe.ejs
+++ b/frontend/templates/iframe.ejs
@@ -36,6 +36,7 @@
     <style>
       html,
       body {
+        height: 100%;
         margin: 0;
         padding: 0;
         -webkit-font-smoothing: antialiased;
@@ -43,6 +44,7 @@
       }
 
       body {
+        height: 100%;
         padding: 6px;
       }
 
@@ -109,7 +111,7 @@
       }
     </style>
     <% if (htmlWebpackPlugin.options.env === 'production') { %>
-    	<link rel="stylesheet" href="remark.css" />
+    <link rel="stylesheet" href="remark.css" />
     <% } %>
   </head>
   <body>


### PR DESCRIPTION
**Problem**
When clicking on a username and show a user's info main iframe with comments collapses.

**Bug**
Somehow after add `padding: 6px` on `body` it lost height.

**Solve**
Just add 100% of height on HTML and body.

Do not add `margin` to iframe with user info.