### PR TITLE
corrected path in docker command to import comments from disqus

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ All imported comments has `Imported` field set to `true`.
 
 1.  Disqus provides an export of all comments on your site in a g-zipped file. This is found in your Moderation panel at Disqus Admin > Setup > Export. The export will be sent into a queue and then emailed to the address associated with your account once it's ready. Direct link to export will be something like `https://<siteud>.disqus.com/admin/discussions/export/`. See [importing-exporting](https://help.disqus.com/customer/portal/articles/1104797-importing-exporting) for more details.
 2.  Move this file to your remark42 host within `./var` and unzip, i.e. `gunzip <disqus-export-name>.xml.gz`.
-3.  Run import command - `docker exec -it remark42 import -p disqus -f {disqus-export-name}.xml -s {your site id}`
+3.  Run import command - `docker exec -it remark42 import -p disqus -f /srv/var/{disqus-export-name}.xml -s {your site id}`
 
 #### Initial import from WordPress
 


### PR DESCRIPTION
When importing a file with comments in Disqus format, the correct path of that file for is `/srv/var/{disqus-export-name}.xml`. This should be made clear in the command template.

Signed-off-by: Michael Picht <mipi@fsfe.org>