### PR TITLE
fix flapping notify drops test, clarify debug logs

### DIFF
--- a/backend/app/notify/notify_mock.go
+++ b/backend/app/notify/notify_mock.go
@@ -40,9 +40,9 @@ func (m *MockDest) SendVerification(ctx context.Context, v VerificationRequest) 
 	select {
 	case <-time.After(10 * time.Millisecond):
 		m.verificationData = append(m.verificationData, v)
-		log.Printf("sent %s -> %d", v.User, m.id)
+		log.Printf("sent verification %s -> %d", v.User, m.id)
 	case <-ctx.Done():
-		log.Printf("ctx closed %d", m.id)
+		log.Printf("verification ctx closed %d", m.id)
 		m.closed = true
 	}
 	return nil

--- a/backend/app/notify/notify_test.go
+++ b/backend/app/notify/notify_test.go
@@ -54,7 +54,7 @@ func TestService_WithDrops(t *testing.T) {
 	s.Submit(Request{Comment: store.Comment{ID: "101"}})
 	time.Sleep(time.Millisecond * 11)
 	s.Submit(Request{Comment: store.Comment{ID: "102"}})
-	time.Sleep(time.Millisecond * 11)
+	time.Sleep(time.Millisecond * 21)
 	s.Close()
 
 	s.Submit(Request{Comment: store.Comment{ID: "111"}}) // safe to send after close
@@ -77,7 +77,7 @@ func TestService_SubmitVerificationWithDrops(t *testing.T) {
 	s.SubmitVerification(VerificationRequest{})
 	time.Sleep(time.Millisecond * 11)
 	s.SubmitVerification(VerificationRequest{})
-	time.Sleep(time.Millisecond * 11)
+	time.Sleep(time.Millisecond * 21)
 	s.Close()
 
 	s.SubmitVerification(VerificationRequest{}) // safe to send after close


### PR DESCRIPTION
Started flapping in Go 1.16 for unknown reasons, something became quicker or slower and timings became off. This gives more time for test to pass.