### PR TITLE
add type module while load modern js bundle

### DIFF
--- a/frontend/templates/comments.ejs
+++ b/frontend/templates/comments.ejs
@@ -49,15 +49,15 @@
     </article>
 
     <script>
-      var query = (function() {
+      var query = (function () {
         if (window.location.search.length === 0) return {};
         return window.location.search
           .substr(1)
           .split('&')
-          .map(function(item) {
+          .map(function (item) {
             return item.split('=');
           })
-          .reduce(function(carry, item) {
+          .reduce(function (carry, item) {
             carry[item[0]] = decodeURIComponent(item[1]);
             return carry;
           }, {});
@@ -68,15 +68,21 @@
         var remark_config = {
           site_id: query.site_id,
           host: '<%= htmlWebpackPlugin.options.REMARK_URL %>',
-          url: query.url
+          url: query.url,
         };
-        (function(c) {
-          for(var i = 0; i < c.length; i++){
-            var d = document, s = d.createElement('script');
-            s.src = remark_config.host + '/web/' +c[i] +'.js';
-            (d.head || d.body).appendChild(s);
+        (function (c, d) {
+          var r = d.head || d.body;
+          for (var i = 0; i < c.length; i++) {
+            var s = d.createElement('script');
+            var m = 'noModule' in s;
+            var e = m ? '.mjs' : '.js';
+            m && (s.type = 'module');
+            s.async = true;
+            s.defer = true;
+            s.src = remark_config.host + '/web/' + c[i] + e;
+            r.appendChild(s);
           }
-        })(remark_config.components || ['embed']);
+        })(remark_config.components || ['embed'], document);
       }
     </script>
     <noscript> Please enable JavaScript to view the comments powered by Remark. </noscript>

--- a/frontend/templates/counter.ejs
+++ b/frontend/templates/counter.ejs
@@ -38,25 +38,19 @@
         site_id: 'remark',
         host: '<%= htmlWebpackPlugin.options.REMARK_URL %>',
         url: 'https://remark42.com/demo/',
-        components: ['counter']
+        components: ['counter'],
       };
 
       (function (c, d) {
+        var r = d.head || d.body;
         for (var i = 0; i < c.length; i++) {
           var s = d.createElement('script');
-          var e = '.js';
-          var r = d.head || d.body;
-
-          if ('noModule' in s) {
-            s.type = 'module';
-            e = '.mjs';
-          } else {
-            s.async = true;
-          }
-
+          var m = 'noModule' in s;
+          var e = m ? '.mjs' : '.js';
+          m && (s.type = 'module');
+          s.async = true;
           s.defer = true;
           s.src = remark_config.host + '/web/' + c[i] + e;
-
           r.appendChild(s);
         }
       })(remark_config.components || ['embed'], document);

--- a/frontend/templates/demo.ejs
+++ b/frontend/templates/demo.ejs
@@ -135,20 +135,15 @@
       };
 
       (function (c, d) {
+        var r = d.head || d.body;
         for (var i = 0; i < c.length; i++) {
           var s = d.createElement('script');
-          var e = '.js';
-          var r = d.head || d.body;
-
-          if ('noModule' in s) {
-            s.type = 'module';
-            e = '.mjs';
-          }
-
+          var m = 'noModule' in s;
+          var e = m ? '.mjs' : '.js';
+          m && (s.type = 'module');
           s.async = true;
           s.defer = true;
           s.src = remark_config.host + '/web/' + c[i] + e;
-
           r.appendChild(s);
         }
       })(remark_config.components || ['embed'], document);

--- a/frontend/templates/iframe.ejs
+++ b/frontend/templates/iframe.ejs
@@ -174,10 +174,11 @@
     </script>
     <script>
       (function (d) {
-        const r = d.head || d.body;
-        const s = document.createElement('script');
-
-        s.src = 'noModule' in s ? 'remark.mjs' : 'remark.js';
+        var r = d.head || d.body;
+        var s = d.createElement('script');
+        var m = 'noModule' in s;
+        s.src = 'remark' + (m ? '.mjs' : '.js');
+        m && (s.type = 'module');
         s.async = true;
         s.defer = true;
         r.appendChild(s);

--- a/frontend/templates/last-comments.ejs
+++ b/frontend/templates/last-comments.ejs
@@ -16,7 +16,7 @@
       }
     </style>
     <% if (htmlWebpackPlugin.options.env === 'production') { %>
-      <link rel="stylesheet" href="last-comments.css" />
+    <link rel="stylesheet" href="last-comments.css" />
     <% } %>
   </head>
   <body>
@@ -27,25 +27,19 @@
       var remark_config = {
         site_id: 'remark',
         host: '<%= htmlWebpackPlugin.options.REMARK_URL %>',
-        components: ['last-comments']
+        components: ['last-comments'],
       };
 
       (function (c, d) {
+        var r = d.head || d.body;
         for (var i = 0; i < c.length; i++) {
           var s = d.createElement('script');
-          var e = '.js';
-          var r = d.head || d.body;
-
-          if ('noModule' in s) {
-            s.type = 'module';
-            e = '.mjs';
-          } else {
-            s.async = true;
-          }
-
+          var m = 'noModule' in s;
+          var e = m ? '.mjs' : '.js';
+          m && (s.type = 'module');
+          s.async = true;
           s.defer = true;
           s.src = remark_config.host + '/web/' + c[i] + e;
-
           r.appendChild(s);
         }
       })(remark_config.components || ['embed'], document);


### PR DESCRIPTION
Now we have two requests for the js bundle because we don't add `type="module"` when requesting it.
This PR is fixing it.