### PR TITLE
make classnames short

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7479,6 +7479,12 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
+    "incstr": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/incstr/-/incstr-1.2.3.tgz",
+      "integrity": "sha512-ySi29Lzdc3QnB1LzZgRf5kl59m5tPucNagrAyJJ9rWz4+Pa6IxAHSNyUHYvEvaj6QPwWAY2/thi3Rxt45qi3HQ==",
+      "dev": true
+    },
     "indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -88,6 +88,7 @@
     "html-webpack-plugin": "^5.2.0",
     "husky": "^4.3.6",
     "identity-obj-proxy": "^3.0.0",
+    "incstr": "^1.2.3",
     "jest": "^26.6.3",
     "jest-fetch-mock": "^3.0.3",
     "jest-localstorage-mock": "^2.4.6",


### PR DESCRIPTION
I've got the idea [here](https://www.freecodecamp.org/news/reducing-css-bundle-size-70-by-cutting-the-class-names-and-using-scope-isolation-625440de600b/) and reimplemented it in our project in favor of reducing JS and CSS bundle size as well.

UPD. When we fully migrate on CSS Modules size of JS and CSS should drop due to using this shorting mechanism.