### PR TITLE
Admin edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ _this is the recommended way to run remark42_
 | restricted-words        | RESTRICTED_WORDS        |                          | words banned in comments (can use `*`), _multi_ |
 | restricted-names        | RESTRICTED_NAMES        |                          | names prohibited to use by the user, _multi_    |
 | edit-time               | EDIT_TIME               | `5m`                     | edit window                                     |
+| admin-edit              | ADMIN_EDIT              | `false`                  | unlimited edit for admins                       |
 | read-age                | READONLY_AGE            |                          | read-only age of comments, days                 |
 | image-proxy.http2https  |  IMAGE_PROXY_HTTP2HTTPS | `false`                  | enable http->https proxy for images             |
 | image-proxy.cache-external | IMAGE_PROXY_CACHE_EXTERNAL | `false`            | enable caching external images to current image storage |

--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -68,6 +68,7 @@ type ServerCommand struct {
 	PositiveScore    bool          `long:"positive-score" env:"POSITIVE_SCORE" description:"enable positive score only"`
 	ReadOnlyAge      int           `long:"read-age" env:"READONLY_AGE" default:"0" description:"read-only age of comments, days"`
 	EditDuration     time.Duration `long:"edit-time" env:"EDIT_TIME" default:"5m" description:"edit window"`
+	AdminEdit        bool          `long:"admin-edit" env:"ADMIN_EDIT" description:"unlimited edit for admins"`
 	Port             int           `long:"port" env:"REMARK_PORT" default:"8080" description:"port"`
 	WebRoot          string        `long:"web-root" env:"REMARK_WEB_ROOT" default:"./web" description:"web root directory"`
 	UpdateLimit      float64       `long:"update-limit" env:"UPDATE_LIMIT" default:"0.5" description:"updates/sec limit"`
@@ -355,6 +356,7 @@ func (s *ServerCommand) newServerApp() (*serverApp, error) {
 	dataService := &service.DataStore{
 		Engine:                 storeEngine,
 		EditDuration:           s.EditDuration,
+		AdminEdits:             s.AdminEdit,
 		AdminStore:             adminStore,
 		MaxCommentSize:         s.MaxCommentSize,
 		MaxVotes:               s.MaxVotes,

--- a/backend/app/rest/api/rest.go
+++ b/backend/app/rest/api/rest.go
@@ -404,6 +404,7 @@ func (s *Rest) configCtrl(w http.ResponseWriter, r *http.Request) {
 	cnf := struct {
 		Version            string   `json:"version"`
 		EditDuration       int      `json:"edit_duration"`
+		AdminEdit          bool     `json:"admin_edit"`
 		MaxCommentSize     int      `json:"max_comment_size"`
 		Admins             []string `json:"admins"`
 		AdminEmail         string   `json:"admin_email"`
@@ -421,6 +422,7 @@ func (s *Rest) configCtrl(w http.ResponseWriter, r *http.Request) {
 	}{
 		Version:            s.Version,
 		EditDuration:       int(s.DataService.EditDuration.Seconds()),
+		AdminEdit:          s.DataService.AdminEdits,
 		MaxCommentSize:     s.DataService.MaxCommentSize,
 		Admins:             admins,
 		AdminEmail:         emails,

--- a/backend/app/rest/api/rest_private.go
+++ b/backend/app/rest/api/rest_private.go
@@ -166,6 +166,7 @@ func (s *private) updateCommentCtrl(w http.ResponseWriter, r *http.Request) {
 		Orig:    edit.Text,
 		Summary: edit.Summary,
 		Delete:  edit.Delete,
+		Admin:   user.Admin,
 	}
 
 	res, err := s.dataService.EditComment(locator, id, editReq)

--- a/backend/app/rest/api/rest_public_test.go
+++ b/backend/app/rest/api/rest_public_test.go
@@ -550,6 +550,7 @@ func TestRest_Config(t *testing.T) {
 	assert.Equal(t, 10.0, j["readonly_age"])
 	assert.Equal(t, 10000.0, j["max_image_size"])
 	assert.Equal(t, true, j["emoji_enabled"].(bool))
+	assert.Equal(t, false, j["admin_edit"].(bool))
 }
 
 func TestRest_Info(t *testing.T) {

--- a/backend/app/store/service/service.go
+++ b/backend/app/store/service/service.go
@@ -462,7 +462,7 @@ func (s *DataStore) EditComment(locator store.Locator, commentID string, req Edi
 		return comment, err
 	}
 
-	if err = editAllowed(comment); err != nil {
+	if err := editAllowed(comment); err != nil {
 		return comment, err
 	}
 

--- a/backend/app/store/service/service.go
+++ b/backend/app/store/service/service.go
@@ -457,12 +457,11 @@ func (s *DataStore) EditComment(locator store.Locator, commentID string, req Edi
 		return nil
 	}
 
-	comment, err = s.Engine.Get(engine.GetRequest{Locator: locator, CommentID: commentID})
-	if err != nil {
+	if comment, err = s.Engine.Get(engine.GetRequest{Locator: locator, CommentID: commentID}); err != nil {
 		return comment, err
 	}
 
-	if err := editAllowed(comment); err != nil {
+	if err = editAllowed(comment); err != nil { //nolint gocritic
 		return comment, err
 	}
 


### PR DESCRIPTION
Adds backend support for #946. New param `--admin-edit` (env: ADMIN_EDIT) disables both edit window and "has replies" check for admin's comments.



