### PR TITLE
Validate image existence before post or preview

### DIFF
--- a/backend/app/rest/api/rest_public.go
+++ b/backend/app/rest/api/rest_public.go
@@ -132,6 +132,21 @@ func (s *public) previewCommentCtrl(w http.ResponseWriter, r *http.Request) {
 
 	comment = s.commentFormatter.Format(comment)
 	comment.Sanitize()
+
+	// check if images are valid
+	imgIds, err := s.imageService.ExtractPictures(comment.Text)
+	if err != nil {
+		rest.SendErrorJSON(w, r, http.StatusBadRequest, err, "can't extract pictures from comment text", rest.ErrCommentValidation)
+		return
+	}
+	for _, id := range imgIds {
+		_, err = s.imageService.Load(id)
+		if err != nil {
+			rest.SendErrorJSON(w, r, http.StatusBadRequest, err, "can't load picture from the comment", rest.ErrImgNotFound)
+			return
+		}
+	}
+
 	render.HTML(w, r, comment.Text)
 }
 

--- a/backend/app/rest/api/rest_test.go
+++ b/backend/app/rest/api/rest_test.go
@@ -402,6 +402,8 @@ func startupT(t *testing.T) (ts *httptest.Server, srv *Rest, teardown func()) {
 		RestrictedWordsMatcher: restrictedWordsMatcher,
 	}
 
+	remarkURL := "https://demo.remark42.com"
+
 	srv = &Rest{
 		DataService: dataStore,
 		Authenticator: auth.NewService(auth.Opts{
@@ -411,13 +413,15 @@ func startupT(t *testing.T) (ts *httptest.Server, srv *Rest, teardown func()) {
 		}),
 		Cache:     memCache,
 		WebRoot:   tmp,
-		RemarkURL: "https://demo.remark42.com",
+		RemarkURL: remarkURL,
 		ImageService: image.NewService(&image.FileSystem{
 			Location:   tmp + "/pics-remark42",
 			Partitions: 100,
 			Staging:    tmp + "/pics-remark42/staging",
 		}, image.ServiceParams{
 			EditDuration: 100 * time.Millisecond,
+			ImageAPI:     remarkURL + "/api/v1/picture/",
+			ProxyAPI:     remarkURL + "/api/v1/img",
 			MaxSize:      10000,
 		}),
 		ImageProxy:       &proxy.Image{},

--- a/backend/app/rest/httperrors.go
+++ b/backend/app/rest/httperrors.go
@@ -39,6 +39,7 @@ const (
 	ErrActionRejected       = 17 // general error for rejected actions
 	ErrAssetNotFound        = 18 // requested file not found
 	ErrCommentRestrictWords = 19 // restricted words in a comment
+	ErrImgNotFound          = 20 // posted image not found in the storage
 )
 
 // errTmplData store data for error message

--- a/backend/app/store/image/image.go
+++ b/backend/app/store/image/image.go
@@ -148,6 +148,8 @@ func (s *Service) Submit(idsFn func() []string) {
 }
 
 // ExtractPictures gets list of images from the doc html and convert from urls to ids, i.e. user/pic.png
+// It doesn't return possible errors parsing the cached images, and will try to return as many parsed ids
+// as possible instead.
 func (s *Service) ExtractPictures(commentHTML string) (ids []string, err error) {
 
 	doc, err := goquery.NewDocumentFromReader(strings.NewReader(commentHTML))


### PR DESCRIPTION
That should cover the case when an image is posted after it cleaned up or the URL is altered by mistake: in case image belongs to this site, it should be working at the time of preview or comment post.