### PR TITLE
Close the HTTP client body in tests, add lint

### DIFF
--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -34,6 +34,7 @@ linters-settings:
 
 linters:
   enable:
+    - bodyclose
     - megacheck
     - golint
     - govet

--- a/backend/app/rest/api/admin_test.go
+++ b/backend/app/rest/api/admin_test.go
@@ -310,6 +310,7 @@ func TestAdmin_Block(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	body, err = ioutil.ReadAll(resp.Body)
 	assert.NoError(t, err)
+	assert.NoError(t, resp.Body.Close())
 	pi = []store.PostInfo{}
 	err = json.Unmarshal(body, &pi)
 	assert.NoError(t, err)
@@ -660,6 +661,7 @@ func TestAdmin_ExportFile(t *testing.T) {
 
 	ungzReader, err := gzip.NewReader(resp.Body)
 	assert.NoError(t, err)
+	assert.NoError(t, resp.Body.Close())
 	ungzBody, err := ioutil.ReadAll(ungzReader)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, strings.Count(string(ungzBody), "\n"))

--- a/backend/app/rest/api/migrator_test.go
+++ b/backend/app/rest/api/migrator_test.go
@@ -46,6 +46,7 @@ func TestMigrator_Import(t *testing.T) {
 	b, err := ioutil.ReadAll(resp.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, "{\"status\":\"import request accepted\"}\n", string(b))
+	assert.NoError(t, resp.Body.Close())
 
 	waitForMigrationCompletion(t, ts)
 }
@@ -80,6 +81,7 @@ func TestMigrator_ImportForm(t *testing.T) {
 	b, err := ioutil.ReadAll(resp.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, "{\"status\":\"import request accepted\"}\n", string(b))
+	assert.NoError(t, resp.Body.Close())
 
 	waitForMigrationCompletion(t, ts)
 }
@@ -102,6 +104,7 @@ func TestMigrator_ImportFromWP(t *testing.T) {
 	b, err := ioutil.ReadAll(resp.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, "{\"status\":\"import request accepted\"}\n", string(b))
+	assert.NoError(t, resp.Body.Close())
 
 	waitForMigrationCompletion(t, ts)
 }

--- a/backend/app/rest/api/rest_private_test.go
+++ b/backend/app/rest/api/rest_private_test.go
@@ -44,6 +44,7 @@ func TestRest_Create(t *testing.T) {
 	b, err := ioutil.ReadAll(resp.Body)
 	assert.NoError(t, err)
 	require.Equal(t, http.StatusCreated, resp.StatusCode, string(b))
+	assert.NoError(t, resp.Body.Close())
 
 	c := R.JSON{}
 	err = json.Unmarshal(b, &c)
@@ -100,6 +101,7 @@ func TestRest_CreateTooBig(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	b, err := ioutil.ReadAll(resp.Body)
 	assert.NoError(t, err)
+	assert.NoError(t, resp.Body.Close())
 	c := R.JSON{}
 	err = json.Unmarshal(b, &c)
 	assert.NoError(t, err)
@@ -112,6 +114,7 @@ func TestRest_CreateTooBig(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	b, err = ioutil.ReadAll(resp.Body)
 	assert.NoError(t, err)
+	assert.NoError(t, resp.Body.Close())
 	c = R.JSON{}
 	err = json.Unmarshal(b, &c)
 	assert.NoError(t, err)
@@ -131,6 +134,7 @@ func TestRest_CreateWithRestrictedWord(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	b, err := ioutil.ReadAll(resp.Body)
 	assert.NoError(t, err)
+	assert.NoError(t, resp.Body.Close())
 	c := R.JSON{}
 	err = json.Unmarshal(b, &c)
 	assert.NoError(t, err)
@@ -171,6 +175,7 @@ func TestRest_CreateWithLazyImage(t *testing.T) {
 	require.Equal(t, http.StatusCreated, resp.StatusCode)
 	b, err := ioutil.ReadAll(resp.Body)
 	assert.NoError(t, err)
+	assert.NoError(t, resp.Body.Close())
 	c := store.Comment{}
 	err = json.Unmarshal(b, &c)
 	assert.NoError(t, err)
@@ -188,6 +193,7 @@ func TestRest_CreateAndGet(t *testing.T) {
 	require.Equal(t, http.StatusCreated, resp.StatusCode)
 	b, err := ioutil.ReadAll(resp.Body)
 	assert.NoError(t, err)
+	assert.NoError(t, resp.Body.Close())
 	c := R.JSON{}
 	err = json.Unmarshal(b, &c)
 	assert.NoError(t, err)
@@ -233,6 +239,7 @@ func TestRest_Update(t *testing.T) {
 	body, err := ioutil.ReadAll(b.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, 200, b.StatusCode, string(body))
+	assert.NoError(t, b.Body.Close())
 
 	// comments returned by update
 	c2 := store.Comment{}
@@ -267,6 +274,7 @@ func TestRest_UpdateDelete(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	bb, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
+	assert.NoError(t, resp.Body.Close())
 	j := []store.PostInfo{}
 	err = json.Unmarshal(bb, &j)
 	assert.NoError(t, err)
@@ -284,6 +292,7 @@ func TestRest_UpdateDelete(t *testing.T) {
 	body, err := ioutil.ReadAll(b.Body)
 	require.NoError(t, err)
 	assert.Equal(t, 200, b.StatusCode, string(body))
+	assert.NoError(t, b.Body.Close())
 
 	// comments returned by update
 	c2 := store.Comment{}
@@ -308,6 +317,7 @@ func TestRest_UpdateDelete(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	bb, err = ioutil.ReadAll(resp.Body)
 	assert.NoError(t, err)
+	assert.NoError(t, resp.Body.Close())
 	j = []store.PostInfo{}
 	err = json.Unmarshal(bb, &j)
 	require.NoError(t, err)
@@ -384,6 +394,7 @@ func TestRest_UpdateWithRestrictedWords(t *testing.T) {
 	assert.NoError(t, err)
 	body, err := ioutil.ReadAll(b.Body)
 	assert.NoError(t, err)
+	assert.NoError(t, b.Body.Close())
 	c := R.JSON{}
 	err = json.Unmarshal(body, &c)
 	assert.NoError(t, err)
@@ -474,6 +485,7 @@ func TestRest_Vote(t *testing.T) {
 	cr = store.Comment{}
 	err = json.NewDecoder(resp.Body).Decode(&cr)
 	assert.NoError(t, err)
+	assert.NoError(t, resp.Body.Close())
 	assert.Equal(t, -1, cr.Score)
 	assert.Equal(t, 0, cr.Vote, "no vote info for different user")
 	assert.Equal(t, map[string]bool(nil), cr.Votes, "hidden")
@@ -597,6 +609,7 @@ func TestRest_Email(t *testing.T) {
 			require.NoError(t, err)
 			body, err := ioutil.ReadAll(resp.Body)
 			require.NoError(t, err)
+			assert.NoError(t, resp.Body.Close())
 			// read User.Email from the token in the cookie
 			for _, c := range resp.Cookies() {
 				if c.Name == "JWT" {
@@ -837,6 +850,7 @@ func TestRest_UserAllDataManyComments(t *testing.T) {
 
 	ungzReader, err := gzip.NewReader(resp.Body)
 	assert.NoError(t, err)
+	assert.NoError(t, resp.Body.Close())
 	ungzBody, err := ioutil.ReadAll(ungzReader)
 	assert.NoError(t, err)
 	strUngzBody := string(ungzBody)
@@ -995,6 +1009,7 @@ func TestRest_CreateWithPictures(t *testing.T) {
 
 		body, err := ioutil.ReadAll(resp.Body)
 		require.NoError(t, err)
+		assert.NoError(t, resp.Body.Close())
 		m := map[string]string{}
 		err = json.Unmarshal(body, &m)
 		assert.NoError(t, err)
@@ -1014,6 +1029,7 @@ func TestRest_CreateWithPictures(t *testing.T) {
 	assert.NoError(t, err)
 	b, err := ioutil.ReadAll(resp.Body)
 	assert.NoError(t, err)
+	assert.NoError(t, resp.Body.Close())
 	require.Equal(t, http.StatusCreated, resp.StatusCode, string(b))
 
 	for i := range ids {

--- a/backend/app/rest/api/rest_public_test.go
+++ b/backend/app/rest/api/rest_public_test.go
@@ -76,6 +76,7 @@ srv, ts := prep(t)
 }
 </pre>`,
 		string(b))
+	assert.NoError(t, resp.Body.Close())
 }
 
 func TestRest_PreviewCode(t *testing.T) {
@@ -97,6 +98,7 @@ BKT
 	assert.NoError(t, err)
 	assert.Equal(t, `<pre class="chroma"><span class="kd">func</span> <span class="nf">main</span><span class="p">(</span><span class="nx">aa</span> <span class="kt">string</span><span class="p">)</span> <span class="kt">int</span> <span class="p">{</span><span class="k">return</span> <span class="mi">0</span><span class="p">}</span>
 </pre>`, string(b))
+	assert.NoError(t, resp.Body.Close())
 }
 
 func TestRest_Find(t *testing.T) {

--- a/backend/app/rest/api/rest_test.go
+++ b/backend/app/rest/api/rest_test.go
@@ -324,6 +324,7 @@ func TestRest_cacheControl(t *testing.T) {
 			h.ServeHTTP(w, req)
 			resp := w.Result()
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.NoError(t, resp.Body.Close())
 			t.Logf("%+v", resp.Header)
 			assert.Equal(t, `"`+tt.etag+`"`, resp.Header.Get("Etag"))
 			assert.Equal(t, `max-age=`+strconv.Itoa(int(tt.exp.Seconds()))+", no-cache", resp.Header.Get("Cache-Control"))
@@ -354,6 +355,7 @@ func TestRest_frameAncestors(t *testing.T) {
 			h.ServeHTTP(w, req)
 			resp := w.Result()
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.NoError(t, resp.Body.Close())
 			t.Logf("%+v", resp.Header)
 			assert.Equal(t, tt.header, resp.Header.Get("Content-Security-Policy"))
 

--- a/backend/app/rest/proxy/image.go
+++ b/backend/app/rest/proxy/image.go
@@ -153,7 +153,7 @@ func (p Image) downloadImage(ctx context.Context, imgURL string) ([]byte, error)
 		if e != nil {
 			return errors.Wrapf(e, "failed to make request for %s", imgURL)
 		}
-		resp, e = client.Do(req.WithContext(ctx))
+		resp, e = client.Do(req.WithContext(ctx)) //nolint:bodyclose // need a refactor to fix that
 		return e
 	})
 	if err != nil {
@@ -168,5 +168,6 @@ func (p Image) downloadImage(ctx context.Context, imgURL string) ([]byte, error)
 	if err != nil {
 		return nil, errors.Errorf("unable to read image body")
 	}
+	_ = resp.Body.Close()
 	return imgData, nil
 }


### PR DESCRIPTION
Found few places which were not properly closed, so enabled the linter to detect these.