### PR TITLE
fix oauth view text color

### DIFF
--- a/frontend/app/components/auth/auth.module.css
+++ b/frontend/app/components/auth/auth.module.css
@@ -1,11 +1,7 @@
 .root {
   position: relative;
   z-index: 1;
-  color: var(--color34);
-}
-
-:global(.dark) .root {
-  color: var(--color16);
+  color: rgb(var(--secondary-text-color));
 }
 
 .buttonArrow {

--- a/frontend/app/components/auth/components/oauth.module.css
+++ b/frontend/app/components/auth/components/oauth.module.css
@@ -27,6 +27,7 @@
 
   &::after {
     display: inline-block;
+    color: rgb(var(--secondary-text-color));
   }
 
   &:hover {


### PR DESCRIPTION
- change title color
- change labels color when  2 OAuth providers are used

<details>
<summary>Before</summary>

<img width="290" alt="CleanShot 2021-05-18 at 15 54 44@2x" src="https://user-images.githubusercontent.com/2330682/118655176-f4620d00-b7f1-11eb-901b-3403bfcb6fb9.png">
<img width="305" alt="CleanShot 2021-05-18 at 15 54 50@2x" src="https://user-images.githubusercontent.com/2330682/118655185-f5933a00-b7f1-11eb-8fdd-61883861b5db.png">
</details>

<details>
<summary>After</summary>

<img width="301" alt="CleanShot 2021-05-18 at 15 58 08@2x" src="https://user-images.githubusercontent.com/2330682/118655235-0348bf80-b7f2-11eb-83b0-e23a05c8f400.png">
<img width="290" alt="CleanShot 2021-05-18 at 15 58 00@2x" src="https://user-images.githubusercontent.com/2330682/118655242-0479ec80-b7f2-11eb-86b4-b92ac09616b7.png">

</details>