### PR TITLE
copy init script earlier than we change /srv owner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,12 +71,12 @@ RUN chmod +x /entrypoint.sh /usr/local/bin/backup /usr/local/bin/restore /usr/lo
 COPY --from=build-backend /build/backend/remark42 /srv/remark42
 COPY --from=build-backend /build/backend/templates /srv
 COPY --from=build-frontend /srv/frontend/public/ /srv/web
+COPY docker-init.sh /srv/init.sh
 RUN chown -R app:app /srv
 RUN ln -s /srv/remark42 /usr/bin/remark42
 
 EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=3s CMD curl --fail http://localhost:8080/ping || exit 1
 
-COPY docker-init.sh /srv/init.sh
 RUN chmod +x /srv/init.sh
 CMD ["/srv/remark42", "server"]


### PR DESCRIPTION
That would prevent the [entrypoint script](https://github.com/umputun/baseimage/blob/master/base.alpine/files/init.sh) failure on init.sh while running as "app" and not "root".

Resolves error reported in #1007.