### PR TITLE
Make docker init script chown command verbose

### DIFF
--- a/docker-init.sh
+++ b/docker-init.sh
@@ -9,7 +9,8 @@ if [ -n "${SITE_ID}" ]; then
 fi
 
 if [ -d "/srv/var" ]; then
-  chown -R app:app /srv/var 2>/dev/null
+  echo "changing ownership of /srv/var to app:app (remark42 user inside the container)"
+  chown -R app:app /srv/var || echo "WARNING: /srv/var ownership change failed, if application will fail that might be the reason"
 else
   echo "ERROR: /srv/var doesn't exist, which means that state of the application"
   echo "ERROR: will be lost on container stop or restart."


### PR DESCRIPTION
That change ensures that in a situation like described in #1007, chown doesn't fail silently but carries on with a warning log message, and shows precisely what is wrong in the log. Log after the change:

```
remark42-dev  | changing ownership of /srv/var to app:app (remark42 user inside the container)
remark42-dev  | chown: /srv/var/docker-init.sh: Read-only file system
remark42-dev  | WARNING: /srv/var ownership change failed, if application will fail that might be the reason
remark42-dev  | execute "/srv/remark42 server"
remark42-dev  | remark42 verbose_chmod-adbd73a-20210524T05:22:15
```

