### PR TITLE
Move telegram token and timeout to a separate CLI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,14 +158,14 @@ _this is the recommended way to run remark42_
 | auth.email.template     | AUTH_EMAIL_TEMPLATE     | none (predefined)        | custom email message template file              |
 | notify.type             | NOTIFY_TYPE             | none                     | type of notification (telegram, slack and/or email) |
 | notify.queue            | NOTIFY_QUEUE            | `100`                    | size of notification queue                      |
-| notify.telegram.token   | NOTIFY_TELEGRAM_TOKEN   |                          | telegram token                                  |
 | notify.telegram.chan    | NOTIFY_TELEGRAM_CHAN    |                          | telegram channel                                |
-| notify.telegram.timeout | NOTIFY_TELEGRAM_TIMEOUT | `5s`                     | telegram timeout                                |
 | notify.slack.token      | NOTIFY_SLACK_TOKEN      |                          | slack token                                     |
 | notify.slack.chan       | NOTIFY_SLACK_CHAN       | `general`                | slack channel                                   |
 | notify.email.fromAddress | NOTIFY_EMAIL_FROM      |                          | from email address                              |
 | notify.email.verification_subj | NOTIFY_EMAIL_VERIFICATION_SUBJ | `Email verification` | verification message subject          |
 | notify.email.notify_admin | NOTIFY_EMAIL_ADMIN    | `false`                  | notify admin on new comments via ADMIN_SHARED_EMAIL |
+| telegram.token          | TELEGRAM_TOKEN          |                          | telegram token (used for auth and telegram notifications) |
+| telegram.timeout        | TELEGRAM_TIMEOUT        | `5s`                     | telegram connection timeout                     |
 | smtp.host               | SMTP_HOST               |                          | SMTP host                                       |
 | smtp.port               | SMTP_PORT               |                          | SMTP port                                       |
 | smtp.username           | SMTP_USERNAME           |                          | SMTP user name                                  |
@@ -226,6 +226,8 @@ trouble with unrecognized command-line options in the future.
 | auth.email.tls     | smtp.tls      | AUTH_EMAIL_TLS     | SMTP_TLS      | `false` | enable TLS     | 1.5.0               |
 | auth.email.timeout | smtp.timeout  | AUTH_EMAIL_TIMEOUT | SMTP_TIMEOUT  | `10s`   | smtp timeout   | 1.5.0               |
 | img-proxy          | image-proxy.http2https | IMG_PROXY | IMAGE_PROXY_HTTP2HTTPS | `false` | enable http->https proxy for images | 1.5.0 |
+| notify.telegram.token | telegram.token | NOTIFY_TELEGRAM_TOKEN | TELEGRAM_TOKEN   | telegram token | 1.9.0               |
+| notify.telegram.timeout | telegram.timeout | NOTIFY_TELEGRAM_TIMEOUT | TELEGRAM_TIMEOUT | telegram timeout | 1.9.0       |
 </details>
 
 ##### Required parameters

--- a/compose-dev-backend.yml
+++ b/compose-dev-backend.yml
@@ -42,7 +42,7 @@ services:
             - AUTH_DEV=true # activate local oauth "dev"
             - ADMIN_SHARED_ID=dev_user # set admin flag for default user on local ouath2
             - NOTIFY_TYPE
-            - NOTIFY_TELEGRAM_TOKEN
+            - TELEGRAM_TOKEN
             - NOTIFY_TELEGRAM_CHAN
             - NOTIFY_EMAIL_FROM
             - ADMIN_SHARED_EMAIL

--- a/docs/latest/telegram.md
+++ b/docs/latest/telegram.md
@@ -4,7 +4,7 @@ title: Telegram
 
 ## Telegram notifications
 
-In order to integrate notifications from remark42 with the [telegram](https://telegram.org), you should make [a channel](https://telegram.org/faq_channels) and obtain a token. This token should be used as `NOTIFY_TELEGRAM_TOKEN`. You also need to set `NOTIFY_TYPE=telegram` and set `NOTIFY_TELEGRAM_CHAN` to your channel.
+In order to integrate notifications from remark42 with the [telegram](https://telegram.org), you should make [a channel](https://telegram.org/faq_channels) and obtain a token. This token should be used as `TELEGRAM_TOKEN`. You also need to set `NOTIFY_TYPE=telegram` and set `NOTIFY_TELEGRAM_CHAN` to your channel.
 
 In order to get token "just talk to [BotFather](https://core.telegram.org/bots#6-botfather)". All you need is to send `/newbot` command, and choose the name for your bot (it must end in `bot`). This is it, you got a token.
 


### PR DESCRIPTION
This simplifies token and timeout reuse for `notify` module (used now) and for `auth` module later (not yet in the code). SMTP credentials are already set up that way.

Part of the work on #707.