### PR TITLE
Fix email templates path in tests

### DIFF
--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -114,6 +114,9 @@ type ServerCommand struct {
 	} `group:"auth" namespace:"auth" env-namespace:"AUTH"`
 
 	CommonOpts
+
+	emailMsgTemplatePath          string // used only in tests
+	emailVerificationTemplatePath string // used only in tests
 }
 
 // ImageProxyGroup defines options group for image proxy
@@ -855,9 +858,11 @@ func (s *ServerCommand) makeNotify(dataStore *service.DataStore, authenticator *
 			destinations = append(destinations, tg)
 		case "email":
 			emailParams := notify.EmailParams{
-				From:                s.Notify.Email.From,
-				VerificationSubject: s.Notify.Email.VerificationSubject,
-				UnsubscribeURL:      s.RemarkURL + "/email/unsubscribe.html",
+				MsgTemplatePath:          s.emailMsgTemplatePath,
+				VerificationTemplatePath: s.emailVerificationTemplatePath,
+				From:                     s.Notify.Email.From,
+				VerificationSubject:      s.Notify.Email.VerificationSubject,
+				UnsubscribeURL:           s.RemarkURL + "/email/unsubscribe.html",
 				// TODO: uncomment after #560 frontend part is ready and URL is known
 				// SubscribeURL:        s.RemarkURL + "/subscribe.html?token=",
 				TokenGenFn: func(userID, email, site string) (string, error) {

--- a/backend/app/cmd/server_test.go
+++ b/backend/app/cmd/server_test.go
@@ -682,6 +682,8 @@ func prepServerApp(t *testing.T, fn func(o ServerCommand) ServerCommand) (*serve
 	cmd.Admin.Type = "shared"
 	cmd.Admin.Shared.Admins = []string{"id1", "id2"}
 	cmd.RestrictedNames = []string{"umputun", "bobuk"}
+	cmd.emailMsgTemplatePath = "../../templates/email_reply.html.tmpl"
+	cmd.emailVerificationTemplatePath = "../../templates/email_confirmation_subscription.html.tmpl"
 	cmd = fn(cmd)
 
 	os.Remove(cmd.Store.Bolt.Path + "/remark.db")


### PR DESCRIPTION
Before:

```
failed to make notify service, failed to create email notification destination:
can't set templates:
can't read message template:
open email_reply.html.tmpl:
no such file or directory
```

After:

```
make notify, types=[email]
create notifier service, queue size=100, destinations=1
```