### PR TITLE
Add UserDetailTelegram support

### DIFF
--- a/backend/_example/memory_store/accessor/data.go
+++ b/backend/_example/memory_store/accessor/data.go
@@ -285,7 +285,7 @@ func (m *MemData) ListFlags(req engine.FlagRequest) (res []interface{}, err erro
 // and all site's details listing under the same function (and not to extend engine interface by two separate functions).
 func (m *MemData) UserDetail(req engine.UserDetailRequest) ([]engine.UserDetailEntry, error) {
 	switch req.Detail {
-	case engine.UserEmail:
+	case engine.UserEmail, engine.UserTelegram:
 		if req.UserID == "" {
 			return nil, errors.New("userid cannot be empty in request for single detail")
 		}
@@ -443,6 +443,8 @@ func (m *MemData) getUserDetail(req engine.UserDetailRequest) ([]engine.UserDeta
 		switch req.Detail {
 		case engine.UserEmail:
 			return []engine.UserDetailEntry{{UserID: req.UserID, Email: meta.Details.Email}}, nil
+		case engine.UserTelegram:
+			return []engine.UserDetailEntry{{UserID: req.UserID, Telegram: meta.Details.Telegram}}, nil
 		}
 	}
 
@@ -473,6 +475,10 @@ func (m *MemData) setUserDetail(req engine.UserDetailRequest) ([]engine.UserDeta
 		entry.Details.Email = req.Update
 		m.metaUsers[req.UserID] = entry
 		return []engine.UserDetailEntry{{UserID: req.UserID, Email: req.Update}}, nil
+	case engine.UserTelegram:
+		entry.Details.Telegram = req.Update
+		m.metaUsers[req.UserID] = entry
+		return []engine.UserDetailEntry{{UserID: req.UserID, Telegram: req.Update}}, nil
 	}
 
 	return []engine.UserDetailEntry{}, nil
@@ -509,6 +515,8 @@ func (m *MemData) deleteUserDetail(locator store.Locator, userID string, userDet
 	switch userDetail {
 	case engine.UserEmail:
 		entry.Details.Email = ""
+	case engine.UserTelegram:
+		entry.Details.Telegram = ""
 	case engine.AllUserDetails:
 		entry.Details = engine.UserDetailEntry{UserID: userID}
 	}

--- a/backend/_example/memory_store/accessor/image_test.go
+++ b/backend/_example/memory_store/accessor/image_test.go
@@ -58,6 +58,8 @@ func TestMemImage_LoadAfterSave(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, gopher, img)
 
+	svc.ResetCleanupTimer(id)
+
 	err = svc.Commit(id)
 	assert.NoError(t, err)
 

--- a/backend/app/rest/api/admin.go
+++ b/backend/app/rest/api/admin.go
@@ -111,9 +111,9 @@ func (a *admin) deleteMeRequestCtrl(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = a.dataService.DeleteUserDetail(claims.Audience, claims.User.ID, engine.UserEmail); err != nil {
+	if err = a.dataService.DeleteUserDetail(claims.Audience, claims.User.ID, engine.AllUserDetails); err != nil {
 		code := parseError(err, rest.ErrInternal)
-		rest.SendErrorJSON(w, r, http.StatusBadRequest, err, "can't delete email for user", code)
+		rest.SendErrorJSON(w, r, http.StatusBadRequest, err, "can't delete user details for user", code)
 		return
 	}
 

--- a/backend/app/store/engine/bolt.go
+++ b/backend/app/store/engine/bolt.go
@@ -211,7 +211,7 @@ func (b *BoltDB) Flag(req FlagRequest) (val bool, err error) {
 // and all site's details listing under the same function (and not to extend interface by two separate functions).
 func (b *BoltDB) UserDetail(req UserDetailRequest) ([]UserDetailEntry, error) {
 	switch req.Detail {
-	case UserEmail:
+	case UserEmail, UserTelegram:
 		if req.UserID == "" {
 			return nil, errors.New("userid cannot be empty in request for single detail")
 		}
@@ -668,6 +668,8 @@ func (b *BoltDB) getUserDetail(req UserDetailRequest) (result []UserDetailEntry,
 			switch req.Detail {
 			case UserEmail:
 				result = []UserDetailEntry{{UserID: req.UserID, Email: entry.Email}}
+			case UserTelegram:
+				result = []UserDetailEntry{{UserID: req.UserID, Telegram: entry.Telegram}}
 			}
 		}
 		return nil
@@ -708,6 +710,8 @@ func (b *BoltDB) setUserDetail(req UserDetailRequest) (result []UserDetailEntry,
 	switch req.Detail {
 	case UserEmail:
 		entry.Email = req.Update
+	case UserTelegram:
+		entry.Telegram = req.Update
 	}
 
 	err = bdb.Update(func(tx *bolt.Tx) error {
@@ -765,6 +769,8 @@ func (b *BoltDB) deleteUserDetail(bdb *bolt.DB, userID string, userDetail UserDe
 	switch userDetail {
 	case UserEmail:
 		entry.Email = ""
+	case UserTelegram:
+		entry.Telegram = ""
 	case AllUserDetails:
 		entry = UserDetailEntry{UserID: userID}
 	}

--- a/backend/app/store/engine/bolt_test.go
+++ b/backend/app/store/engine/bolt_test.go
@@ -641,6 +641,10 @@ func TestBoltDB_UserDetail(t *testing.T) {
 	}{
 		{req: UserDetailRequest{Locator: store.Locator{SiteID: "radio-t"}, UserID: "u1", Detail: UserEmail},
 			expected: []UserDetailEntry{{UserID: "u1", Email: "test@example.com"}}},
+		{req: UserDetailRequest{Locator: store.Locator{SiteID: "radio-t"}, Detail: UserEmail},
+			error: "userid cannot be empty in request for single detail"},
+		{req: UserDetailRequest{Locator: store.Locator{SiteID: "radio-t"}, Detail: AllUserDetails, UserID: "u1"},
+			error: "unsupported request with userdetail all"},
 		{req: UserDetailRequest{Locator: store.Locator{SiteID: "bad"}, UserID: "u1", Detail: UserEmail},
 			error: `site "bad" not found`},
 		{req: UserDetailRequest{Locator: store.Locator{SiteID: "radio-t"}, UserID: "u1xyz", Detail: UserEmail}},

--- a/backend/app/store/engine/engine.go
+++ b/backend/app/store/engine/engine.go
@@ -91,6 +91,8 @@ const (
 const (
 	// UserEmail is a user email
 	UserEmail = UserDetail("email")
+	// UserTelegram is a user telegram
+	UserTelegram = UserDetail("telegram")
 	// AllUserDetails used for listing and deletion requests
 	AllUserDetails = UserDetail("all")
 )
@@ -109,8 +111,9 @@ type UserDetail string
 
 // UserDetailEntry contains single user details entry
 type UserDetailEntry struct {
-	UserID string `json:"user_id"`         // duplicate user's id to use this structure not only embedded but separately
-	Email  string `json:"email,omitempty"` // UserEmail
+	UserID   string `json:"user_id"`            // duplicate user's id to use this structure not only embedded but separately
+	Email    string `json:"email,omitempty"`    // UserEmail
+	Telegram string `json:"telegram,omitempty"` // UserTelegram
 }
 
 // UserDetailRequest is the input for both get/set for details, like email

--- a/backend/app/store/service/service.go
+++ b/backend/app/store/service/service.go
@@ -194,6 +194,39 @@ func (s *DataStore) SetUserEmail(siteID, userID, value string) (string, error) {
 	return "", nil
 }
 
+// GetUserTelegram gets user telegram
+func (s *DataStore) GetUserTelegram(siteID, userID string) (string, error) {
+	res, err := s.Engine.UserDetail(engine.UserDetailRequest{
+		Detail:  engine.UserTelegram,
+		Locator: store.Locator{SiteID: siteID},
+		UserID:  userID,
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(res) == 1 {
+		return res[0].Telegram, nil
+	}
+	return "", nil
+}
+
+// SetUserTelegram sets user telegram
+func (s *DataStore) SetUserTelegram(siteID, userID, value string) (string, error) {
+	res, err := s.Engine.UserDetail(engine.UserDetailRequest{
+		Detail:  engine.UserTelegram,
+		Locator: store.Locator{SiteID: siteID},
+		UserID:  userID,
+		Update:  value,
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(res) == 1 {
+		return res[0].Telegram, nil
+	}
+	return "", nil
+}
+
 // DeleteUserDetail deletes user detail
 func (s *DataStore) DeleteUserDetail(siteID, userID string, detail engine.UserDetail) error {
 	return s.Engine.Delete(engine.DeleteRequest{

--- a/backend/app/store/service/service_test.go
+++ b/backend/app/store/service/service_test.go
@@ -908,18 +908,29 @@ func TestService_UserDetailsOperations(t *testing.T) {
 	result, err := b.SetUserEmail("radio-t", "u1", "test@example.com")
 	assert.NoError(t, err, "No error inserting entry expected")
 	assert.Equal(t, "test@example.com", result)
+	result, err = b.SetUserTelegram("radio-t", "u1", "test@example.com")
+	assert.NoError(t, err, "No error inserting entry expected")
+	assert.Equal(t, "test@example.com", result)
 
 	// read valid entry back
 	result, err = b.GetUserEmail("radio-t", "u1")
+	assert.NoError(t, err, "No error reading entry expected")
+	assert.Equal(t, "test@example.com", result)
+	result, err = b.GetUserTelegram("radio-t", "u1")
 	assert.NoError(t, err, "No error reading entry expected")
 	assert.Equal(t, "test@example.com", result)
 
 	// delete existing entry
 	err = b.DeleteUserDetail("radio-t", "u1", engine.UserEmail)
 	assert.NoError(t, err, "No error deleting entry expected")
+	err = b.DeleteUserDetail("radio-t", "u1", engine.UserTelegram)
+	assert.NoError(t, err, "No error deleting entry expected")
 
 	// read deleted entry
 	result, err = b.GetUserEmail("radio-t", "u1")
+	assert.NoError(t, err, "No error reading entry expected")
+	assert.Empty(t, result)
+	result, err = b.GetUserTelegram("radio-t", "u1")
 	assert.NoError(t, err, "No error reading entry expected")
 	assert.Empty(t, result)
 
@@ -927,9 +938,15 @@ func TestService_UserDetailsOperations(t *testing.T) {
 	result, err = b.SetUserEmail("bad-site", "u3", "does_not_matter@example.com")
 	assert.Error(t, err, "Site not found")
 	assert.Empty(t, result)
+	result, err = b.SetUserTelegram("bad-site", "u3", "does_not_matter@example.com")
+	assert.Error(t, err, "Site not found")
+	assert.Empty(t, result)
 
 	// read entry with invalid site_id
 	result, err = b.GetUserEmail("bad-site", "u3")
+	assert.Error(t, err, "Site not found")
+	assert.Empty(t, result)
+	result, err = b.GetUserTelegram("bad-site", "u3")
 	assert.Error(t, err, "Site not found")
 	assert.Empty(t, result)
 }
@@ -1370,7 +1387,7 @@ func TestService_submitImages(t *testing.T) {
 
 	b.submitImages(c)
 	mockStore.AssertNumberOfCalls(t, "ResetCleanupTimer", 2)
-	time.Sleep(b.EditDuration + 100 * time.Millisecond)
+	time.Sleep(b.EditDuration + 100*time.Millisecond)
 	mockStore.AssertNumberOfCalls(t, "Commit", 2)
 }
 
@@ -1415,7 +1432,7 @@ func TestService_ResubmitStagingImages(t *testing.T) {
 	mockStore.On("Commit", "dev_user/bqf122eq9r8ad657n3ng").Once().Return(nil)
 	mockStore.On("Commit", "dev_user/bqf321eq9r8ad657n3ng").Once().Return(nil)
 	mockStore.On("Commit", "cached_images/12318fbd4c55e9d177b8b5ae197bc89c5afd8e07-a41fcb00643f28d700504256ec81cbf2e1aac53e").Once().Return(nil)
-	time.Sleep(b.EditDuration + time.Millisecond * 100)
+	time.Sleep(b.EditDuration + time.Millisecond*100)
 
 	mockStore.AssertNumberOfCalls(t, "Info", 1)
 	mockStore.AssertNumberOfCalls(t, "Commit", 3)


### PR DESCRIPTION
For telegram notifications we'll need to get a telegram user ID from the user and store and retrieve it later, this PR adds support for that user details and improves a bunch of tests in affected modules.

All newly added code is tested.