### PR TITLE
Remove ability to set telegram API, clarify telegram notify params

### DIFF
--- a/backend/app/main.go
+++ b/backend/app/main.go
@@ -46,8 +46,11 @@ func main() {
 			Revision:     revision,
 		})
 		for _, entry := range c.HandleDeprecatedFlags() {
-			log.Printf("[WARN] --%s is deprecated since v%s and will be removed in the future, please use --%s instead",
-				entry.Old, entry.Version, entry.New)
+			deprecationNote := fmt.Sprintf("[WARN] --%s is deprecated since v%s and will be removed in the future", entry.Old, entry.Version)
+			if entry.New != "" {
+				deprecationNote += fmt.Sprintf(", please use --%s instead", entry.New)
+			}
+			log.Print(deprecationNote)
 		}
 		err := c.Execute(args)
 		if err != nil {


### PR DESCRIPTION
As discussed off-GitHub, remove the ability to set Telegram API (as it's used only in tests) and notify parameters passed as structure in the same way we do with Email notifications now.