### PR TITLE
Don't set X-XSRF-TOKEN when the user isn't logged in

### DIFF
--- a/frontend/app/common/fetcher.test.ts
+++ b/frontend/app/common/fetcher.test.ts
@@ -4,7 +4,7 @@ jest.mock('./settings', () => ({
 
 import { RequestError } from 'utils/errorUtils';
 import { API_BASE, BASE_URL } from './constants.config';
-import { apiFetcher, authFetcher, adminFetcher, JWT_HEADER, XSRF_HEADER } from './fetcher';
+import { apiFetcher, authFetcher, adminFetcher, JWT_HEADER } from './fetcher';
 
 type FetchImplementaitonProps = {
   status?: number;
@@ -31,7 +31,7 @@ function mockFetch({ headers = {}, data = {}, ...props }: FetchImplementaitonPro
 }
 
 describe('fetcher', () => {
-  const headers = { [XSRF_HEADER]: '' };
+  const headers = {};
   const apiUri = '/anything';
   const apiUrl = `${BASE_URL}${API_BASE}/anything?site=remark`;
 

--- a/frontend/app/common/fetcher.ts
+++ b/frontend/app/common/fetcher.ts
@@ -45,7 +45,13 @@ const createFetcher = (baseUrl: string = ''): Methods => {
     if (activeJwtToken) {
       headers[JWT_HEADER] = activeJwtToken;
     }
-    headers[XSRF_HEADER] = getCookie(XSRF_COOKIE) || '';
+
+    // An HTTP header cannot be empty.
+    // Although some webservers allow this (nginx, Apache), others answer 400 Bad Request (lighttpd).
+    const xsrfToken = getCookie(XSRF_COOKIE);
+    if (xsrfToken !== undefined) {
+      headers[XSRF_HEADER] = xsrfToken;
+    }
 
     if (body instanceof FormData) {
       // Shouldn't add any kind of `Content-Type` if we send `FormData`


### PR DESCRIPTION
An HTTP header cannot be empty, and although some webservers allow this (nginx, Apache), others answer 400 Bad Request (lighttpd), preventing the widget from loading.

I'm not sure this is the most elegant way to do it, that's why this is marked as a draft.