### PR TITLE
docs(import): clarify import path for wordpress

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,14 +347,14 @@ All imported comments have an `Imported` field set to `true`.
 ## Initial import from Disqus
 
 1.  Disqus provides export of all comments on your site in a gzipped file. This option is available in your Moderation panel at Disqus Admin > Setup > Export. The export will be sent into a queue and then emailed to the address associated with your account once it's ready. Direct link to export will be something like `https://<siteud>.disqus.com/admin/discussions/export/`. See [importing-exporting](https://help.disqus.com/customer/portal/articles/1104797-importing-exporting) for more details.
-2.  Move this file to your remark42 host within `./var` and unzip, i.e. `gunzip <disqus-export-name>.xml.gz`.
+2.  Move this file to your remark42 host within `./var` and extract, i.e. `gunzip <disqus-export-name>.xml.gz`.
 3.  Run import command - `docker exec -it remark42 import -p disqus -f /srv/var/{disqus-export-name}.xml -s {your site id}`
 
 ## Initial import from WordPress
 
 1. Use [that instruction](https://wordpress.com/support/export/) to export comments to file using standard WordPress functionality.
 2. Move this file to your remark42 host within `./var`
-3. Run import command - `docker exec -it remark42 import -p wordpress -f {wordpress-export-name}.xml -s {your site id}`
+3. Run import command - `docker exec -it remark42 import -p wordpress -f /srv/var/{wordpress-export-name}.xml -s {your site id}`
 
 #### Backup and restore
 


### PR DESCRIPTION
I had trouble understand why I was getting `no such file or directory` errors 🙂 