### PR TITLE
Multiple notify module improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ compose-private-backend.yml
 compose-private-frontend.yml
 compose-private.yml
 /backend/_example/*/vendor
+http-client.env.json

--- a/backend/app/notify/telegram_test.go
+++ b/backend/app/notify/telegram_test.go
@@ -28,7 +28,7 @@ func TestTelegram_New(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, tb)
 	assert.Equal(t, tb.Timeout, time.Second*5)
-	assert.Equal(t, "@remark_test", tb.AdminChannelID, "@ added")
+	assert.Equal(t, "remark_test", tb.AdminChannelID, "@ added")
 
 	st := time.Now()
 	_, err = NewTelegram(TelegramParams{
@@ -54,7 +54,7 @@ func TestTelegram_New(t *testing.T) {
 		Timeout:        2 * time.Second,
 		apiPrefix:      ts.URL + "/",
 	})
-	assert.EqualError(t, err, "unexpected telegram status code 404")
+	assert.EqualError(t, err, "unexpected telegram API status code 404")
 
 	_, err = NewTelegram(TelegramParams{
 		AdminChannelID: "remark_test",
@@ -95,9 +95,9 @@ func TestTelegram_Send(t *testing.T) {
 	defer ts.Close()
 
 	tb, err := NewTelegram(TelegramParams{
-		AdminChannelID: "remark_test",
-		Token:          "good-token",
-		apiPrefix:      ts.URL + "/",
+		AdminChannelID:    "remark_test",
+		Token:             "good-token",
+		apiPrefix:         ts.URL + "/",
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, tb)
@@ -126,9 +126,9 @@ func TestTelegram_Send(t *testing.T) {
 	assert.Error(t, err, "should fail")
 	err = tb.Send(context.TODO(), Request{Comment: c, parent: cp})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unexpected telegram status code 404", "send on broken tg")
+	assert.Contains(t, err.Error(), "unexpected telegram API status code 404", "send on broken tg")
 
-	assert.Equal(t, "telegram: @remark_test", tb.String())
+	assert.Equal(t, "telegram with admin notifications to remark_test", tb.String())
 
 	// bad API URL
 	tb.apiPrefix = "http://non-existent"
@@ -210,7 +210,7 @@ func Test_escapeTitle(t *testing.T) {
 	for i, tt := range tbl {
 		tt := tt
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			assert.Equal(t, tt.out, escapeTitle(tt.inp))
+			assert.Equal(t, tt.out, escapeText(tt.inp))
 		})
 	}
 

--- a/backend/templates/email_confirmation_login.html.tmpl
+++ b/backend/templates/email_confirmation_login.html.tmpl
@@ -10,7 +10,7 @@
 	<p style="position: relative; max-width: 20em; margin: 0 auto 1em auto; line-height: 1.4em;">Confirmation for <b>{{.User}}</b> on site <b>{{.Site}}</b></p>
 	<div style="background-color: #eee; max-width: 20em; margin: 0 auto; border-radius: 0.4em; padding: 0.5em;">
 		<p style="position: relative; margin: 0 0 0.5em 0;">TOKEN</p>
-		<p style="position: relative; font-size: 0.7em; opacity: 0.8;"><i>Copy and paste this text into “token” field on comments page</i></p>
+		<p style="position: relative; font-size: 0.7em; opacity: 0.8;"><i>Please copy and paste this text into “token” field on comments page to login</i></p>
 		<p style="position: relative; font-family: monospace; background-color: #fff; margin: 0; padding: 0.5em; word-break: break-all; text-align: left; border-radius: 0.2em; -webkit-user-select: all; user-select: all;">{{.Token}}</p>
 	</div>
 	<p style="position: relative; margin-top: 2em; font-size: 0.8em; opacity: 0.8;"><i>Sent to {{.Address}}</i></p>

--- a/backend/templates/email_confirmation_subscription.html.tmpl
+++ b/backend/templates/email_confirmation_subscription.html.tmpl
@@ -15,7 +15,7 @@
 		{{- end }}
 		<div style="background-color: #eee; max-width: 20em; margin: 0 auto; border-radius: 0.4em; padding: 0.5em;">
 			<p style="position: relative; margin: 0 0 0.5em 0;color:#000!important;">TOKEN</p>
-			<p style="position: relative; font-size: 0.7em; opacity: 0.8;"><i style="color:#000!important;">Copy and paste this text into “token” field on comments page</i></p>
+			<p style="position: relative; font-size: 0.7em; opacity: 0.8;"><i style="color:#000!important;">Please copy and paste this text into “token” field on comments page to confirm subscription</i></p>
 			<p style="position: relative; font-family: monospace; background-color: #fff; margin: 0; padding: 0.5em; word-break: break-all; text-align: left; border-radius: 0.2em; -webkit-user-select: all; user-select: all;">{{.Token}}</p>
 		</div>
 		<p style="position: relative; margin-top: 2em; font-size: 0.8em; opacity: 0.8;"><i style="color:#000!important;">Sent to {{.Email}}</i></p>


### PR DESCRIPTION
A couple of changes to telegram notifications and error handling code, email text improvements, ignore IntelliJ Idea rest requests variables file.

Reply notification text, now more consistent with the email notification, and the same which will be used for user notifications. Before:
<img width="726" alt="image" src="https://user-images.githubusercontent.com/712534/121825098-f4e6aa00-ccb0-11eb-91b0-b180c6532636.png">
After:
<img width="720" alt="image" src="https://user-images.githubusercontent.com/712534/121824001-3b380b00-cca9-11eb-85c8-fceb2b985375.png">

Part of #1029 is not strictly tied to the telegram user notifications, and I wanted to merge separately.