### PR TITLE
make TestService_UserReplies more robust

### DIFF
--- a/backend/app/main_test.go
+++ b/backend/app/main_test.go
@@ -99,7 +99,7 @@ func TestMain_WithWebhook(t *testing.T) {
 	finished := make(chan struct{})
 	go func() {
 		main()
-		assert.Eventuallyf(t, func() bool {
+		assert.Eventually(t, func() bool {
 			return atomic.LoadInt32(&webhookSent) == int32(1)
 		}, time.Second, 100*time.Millisecond, "webhook was not sent")
 		close(finished)

--- a/backend/app/store/service/service_test.go
+++ b/backend/app/store/service/service_test.go
@@ -1048,7 +1048,7 @@ func TestService_UserReplies(t *testing.T) {
 	_, err = b.Create(c4)
 	require.NoError(t, err)
 
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 	_, err = b.Create(c5)
 	require.NoError(t, err)
 
@@ -1057,10 +1057,12 @@ func TestService_UserReplies(t *testing.T) {
 	require.Equal(t, 3, len(cc), "3 replies to u1")
 	assert.Equal(t, "developer one u1", u)
 
-	cc, u, err = b.UserReplies("radio-t", "u1", 10, time.Millisecond*199)
-	assert.NoError(t, err)
-	require.Equal(t, 1, len(cc), "1 reply to u1 in last 200ms")
-	assert.Equal(t, "developer one u1", u)
+	assert.Eventually(t, func() bool {
+		cc, u, err = b.UserReplies("radio-t", "u1", 10, time.Millisecond*199)
+		require.NoError(t, err)
+		require.Equal(t, "developer one u1", u)
+		return len(cc) == 1
+	}, 300*time.Millisecond, 30*time.Millisecond, "1 reply to u1 in the last 200ms")
 
 	cc, u, err = b.UserReplies("radio-t", "u2", 10, time.Hour)
 	assert.NoError(t, err)


### PR DESCRIPTION
It flaps (see #380), and with this change, it will have more time to get the expected output in the flaky GitHub Actions environment.

The latest example of false positive: [link](https://github.com/umputun/remark42/pull/1121/checks?check_run_id=3512621950#step:6:49).