### PR TITLE
patreon auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Remark42 is a self-hosted, lightweight and simple (yet functional) comment engine, which doesn't spy on users. It can be embedded into blogs, articles, or any other place where readers add comments.
 
-* Social login via Google, Twitter, Facebook, Microsoft, GitHub, Yandex and Telegram
+* Social login via Google, Twitter, Facebook, Microsoft, GitHub, Yandex, Patreon and Telegram
 * Login via email
 * Optional anonymous access
 * Multi-level nested comments with both tree and plain presentations
@@ -53,6 +53,7 @@ For admin screenshots see [Admin UI wiki](https://github.com/umputun/remark42/wi
         - [Telegram Auth Provider](#telegram-auth-provider)
         - [Twitter Auth provider](#twitter-auth-provider)
         - [Yandex Auth provider](#yandex-auth-provider)
+        - [Patreon Auth provider](#patreon-auth-provider)
         - [Anonymous Auth provider](#anonymous-auth-provider)
       - [Initial import from Disqus](#initial-import-from-disqus)
       - [Initial import from WordPress](#initial-import-from-wordpress)
@@ -150,6 +151,8 @@ _this is the recommended way to run Remark42_
 | auth.github.csec        | AUTH_GITHUB_CSEC        |                          | GitHub OAuth client secret                      |
 | auth.twitter.cid        | AUTH_TWITTER_CID        |                          | Twitter Consumer API Key                        |
 | auth.twitter.csec       | AUTH_TWITTER_CSEC       |                          | Twitter Consumer API Secret key                 |
+| auth.patreon.cid        | AUTH_PATREON_CID        |                          | Patreon OAuth Client ID                         |
+| auth.patreon.csec       | AUTH_PATREON_CSEC       |                          | Patreon OAuth Client Secret                     |
 | auth.telegram           | AUTH_TELEGRAM           |                          | Enable Telegram auth (telegram.token must be present) |
 | auth.yandex.cid         | AUTH_YANDEX_CID         |                          | Yandex OAuth client ID                          |
 | auth.yandex.csec        | AUTH_YANDEX_CSEC        |                          | Yandex OAuth client secret                      |
@@ -209,6 +212,7 @@ _this is the recommended way to run Remark42_
 | port                    | REMARK_PORT             | `8080`                   | web server port                                 |
 | web-root                | REMARK_WEB_ROOT         | `./web`                  | web server root directory                       |
 | update-limit            | UPDATE_LIMIT            | `0.5`                    | updates/sec limit                               |
+| subscribers-only        | SUBSCRIBERS_ONLY        | `false`                  | enable commenting only for Patreon subscribers  |
 | admin-passwd            | ADMIN_PASSWD            | none (disabled)          | password for `admin` basic auth                 |
 | dbg                     | DEBUG                   | `false`                  | debug mode                                      |
 
@@ -343,6 +347,12 @@ _instructions for Google OAuth2 setup borrowed from [oauth2_proxy](https://githu
 6. Take note of the **ID** and **Password**
 
 For more details refer to [Yandex OAuth](https://yandex.com/dev/oauth/doc/dg/concepts/about.html) and [Yandex.Passport](https://yandex.com/dev/passport/doc/dg/index.html) API documentation.
+
+##### Patreon Auth provider
+1. Create a new Patreon client https://www.patreon.com/portal/registration/register-clients
+2. Fill **App Name**, **Description**
+3. In the field **Redirect URIs** enter the correct URI constructed as domain + `/auth/patreon/callback`, i.e. `https://example.mysite.com/auth/patreon/callback`
+4. Expand client details, take a note of the **Client ID** and **Client Secret**. Those will be used as `AUTH_PATREON_CID` and `AUTH_PATREON_CSEC`
 
 ##### Anonymous Auth provider
 
@@ -662,6 +672,7 @@ type User struct {
     Admin    bool   `json:"admin"`
     Blocked  bool   `json:"block"`
     Verified bool   `json:"verified"`
+    PaidSub  bool   `json:"paid_sub"` // is paid Patreon subscriber
 }
 ```
 
@@ -760,18 +771,19 @@ type PostInfo struct {
 
 ```go
 type Config struct {
-    Version        string   `json:"version"`
-    EditDuration   int      `json:"edit_duration"`
-    MaxCommentSize int      `json:"max_comment_size"`
-    Admins         []string `json:"admins"`
-    AdminEmail     string   `json:"admin_email"`
-    Auth           []string `json:"auth_providers"`
-    LowScore       int      `json:"low_score"`
-    CriticalScore  int      `json:"critical_score"`
-    PositiveScore  bool     `json:"positive_score"`
-    ReadOnlyAge    int      `json:"readonly_age"`
-    MaxImageSize   int      `json:"max_image_size"`
-    EmojiEnabled   bool     `json:"emoji_enabled"`
+    Version         string   `json:"version"`
+    EditDuration    int      `json:"edit_duration"`
+    MaxCommentSize  int      `json:"max_comment_size"`
+    Admins          []string `json:"admins"`
+    AdminEmail      string   `json:"admin_email"`
+    Auth            []string `json:"auth_providers"`
+    LowScore        int      `json:"low_score"`
+    CriticalScore   int      `json:"critical_score"`
+    PositiveScore   bool     `json:"positive_score"`
+    ReadOnlyAge     int      `json:"readonly_age"`
+    MaxImageSize    int      `json:"max_image_size"`
+    EmojiEnabled    bool     `json:"emoji_enabled"`
+    SubscribersOnly bool     `json:"subscribers_only"` // enable commenting only for Patreon subscribers
 }
 ```
 

--- a/backend/app/cmd/server_test.go
+++ b/backend/app/cmd/server_test.go
@@ -78,7 +78,7 @@ func TestServerApp_DevMode(t *testing.T) {
 	waitForHTTPServerStart(port)
 
 	providers := app.restSrv.Authenticator.Providers()
-	require.Equal(t, 8+1, len(providers), "extra auth provider")
+	require.Equal(t, 9+1, len(providers), "extra auth provider")
 	assert.Equal(t, "dev", providers[len(providers)-2].Name(), "dev auth provider")
 	// send ping
 	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/api/v1/ping", port))
@@ -105,7 +105,7 @@ func TestServerApp_AnonMode(t *testing.T) {
 	waitForHTTPServerStart(port)
 
 	providers := app.restSrv.Authenticator.Providers()
-	require.Equal(t, 8+1, len(providers), "extra auth provider for anon")
+	require.Equal(t, 9+1, len(providers), "extra auth provider for anon")
 	assert.Equal(t, "anonymous", providers[len(providers)-1].Name(), "anon auth provider")
 
 	// send ping
@@ -694,6 +694,7 @@ func prepServerApp(t *testing.T, fn func(o ServerCommand) ServerCommand) (*serve
 	cmd.Auth.Yandex.CSEC, cmd.Auth.Yandex.CID = "csec", "cid"
 	cmd.Auth.Microsoft.CSEC, cmd.Auth.Microsoft.CID = "csec", "cid"
 	cmd.Auth.Twitter.CSEC, cmd.Auth.Twitter.CID = "csec", "cid"
+	cmd.Auth.Patreon.CSEC, cmd.Auth.Patreon.CID = "csec", "cid"
 	cmd.Auth.Telegram = true
 	cmd.Telegram.Token = "token"
 	cmd.Auth.Email.Enable = true

--- a/backend/app/rest/user.go
+++ b/backend/app/rest/user.go
@@ -36,6 +36,7 @@ func GetUserInfo(r *http.Request) (user store.User, err error) {
 		Verified: u.BoolAttr("verified"),
 		Blocked:  u.BoolAttr("blocked"),
 		SiteID:   u.Audience,
+		PaidSub:  u.IsPaidSub(),
 	}, nil
 }
 
@@ -62,6 +63,7 @@ func SetUserInfo(r *http.Request, user store.User) *http.Request {
 		},
 	}
 	u.SetAdmin(user.Admin)
+	u.SetPaidSub(user.PaidSub)
 
 	return token.SetUserInfo(r, u)
 }

--- a/backend/app/store/user.go
+++ b/backend/app/store/user.go
@@ -24,6 +24,7 @@ type User struct {
 	Verified          bool   `json:"verified,omitempty"`
 	EmailSubscription bool   `json:"email_subscription,omitempty"`
 	SiteID            string `json:"site_id,omitempty"`
+	PaidSub           bool   `json:"paid_sub,omitempty"`
 }
 
 var reValidSha = regexp.MustCompile("^[a-fA-F0-9]{40}$")

--- a/compose-dev-backend.yml
+++ b/compose-dev-backend.yml
@@ -67,5 +67,7 @@ services:
       - AUTH_FACEBOOK_CSEC=1111
       - AUTH_TWITTER_CID=1111
       - AUTH_TWITTER_CSEC=1111
+      - AUTH_PATREON_CID=1111
+      - AUTH_PATREON_CSEC=1111
     volumes:
       - ./var:/srv/var

--- a/frontend/app/common/types.ts
+++ b/frontend/app/common/types.ts
@@ -95,7 +95,7 @@ export interface Tree {
   info: PostInfo;
 }
 
-export type OAuthProvider = 'facebook' | 'twitter' | 'google' | 'yandex' | 'github' | 'microsoft' | 'dev';
+export type OAuthProvider = 'facebook' | 'twitter' | 'google' | 'yandex' | 'github' | 'microsoft' | 'patreon' | 'dev';
 export type FormProvider = 'email' | 'anonymous';
 export type Provider = OAuthProvider | FormProvider;
 

--- a/frontend/app/components/auth/components/assets/patreon.svg
+++ b/frontend/app/components/auth/components/assets/patreon.svg
@@ -1,0 +1,1 @@
+<svg width="21" height="21" fill="#FF424D" xmlns="http://www.w3.org/2000/svg"><path d="M2 1h3v19H2z"/><circle cx="14" cy="8" r="7"/></svg>

--- a/frontend/app/components/auth/components/oauth.consts.ts
+++ b/frontend/app/components/auth/components/oauth.consts.ts
@@ -1,6 +1,7 @@
 export const OAUTH_DATA = {
   facebook: require('./assets/facebook.svg').default as string,
   twitter: require('./assets/twitter.svg').default as string,
+  patreon: require('./assets/patreon.svg').default as string,
   google: require('./assets/google.svg').default as string,
   microsoft: require('./assets/microsoft.svg').default as string,
   yandex: require('./assets/yandex.svg').default as string,

--- a/site/src/docs/configuration/authorization/index.md
+++ b/site/src/docs/configuration/authorization/index.md
@@ -73,6 +73,12 @@ _instructions for Google OAuth2 setup borrowed from [oauth2_proxy](https://githu
 
 For more details refer to [Yandex OAuth](https://yandex.com/dev/oauth/doc/dg/concepts/about.html) and [Yandex.Passport](https://yandex.com/dev/passport/doc/dg/index.html) API documentation.
 
+### Patreon Auth provider
+1. Create a new Patreon client https://www.patreon.com/portal/registration/register-clients
+2. Fill **App Name**, **Description**
+3. In the field **Redirect URIs** enter the correct URI constructed as domain + `/auth/patreon/callback`, i.e. `https://example.mysite.com/auth/patreon/callback`
+4. Expand client details, take a note of the **Client ID** and **Client Secret**. Those will be used as `AUTH_PATREON_CID` and `AUTH_PATREON_CSEC`
+
 ## Anonymous Auth Provider
 
 Optionally, anonymous access can be turned on. In this case, an extra `anonymous` provider will allow logins without any social login with any name satisfying 2 conditions:

--- a/site/src/docs/contributing/api/index.md
+++ b/site/src/docs/contributing/api/index.md
@@ -15,6 +15,7 @@ type User struct {
     Admin    bool   `json:"admin"`
     Blocked  bool   `json:"block"`
     Verified bool   `json:"verified"`
+    PaidSub  bool   `json:"paid_sub"` // is paid Patreon subscriber
 }
 ```
 
@@ -113,18 +114,19 @@ type PostInfo struct {
 
 ```go
 type Config struct {
-    Version        string   `json:"version"`
-    EditDuration   int      `json:"edit_duration"`
-    MaxCommentSize int      `json:"max_comment_size"`
-    Admins         []string `json:"admins"`
-    AdminEmail     string   `json:"admin_email"`
-    Auth           []string `json:"auth_providers"`
-    LowScore       int      `json:"low_score"`
-    CriticalScore  int      `json:"critical_score"`
-    PositiveScore  bool     `json:"positive_score"`
-    ReadOnlyAge    int      `json:"readonly_age"`
-    MaxImageSize   int      `json:"max_image_size"`
-    EmojiEnabled   bool     `json:"emoji_enabled"`
+    Version         string   `json:"version"`
+    EditDuration    int      `json:"edit_duration"`
+    MaxCommentSize  int      `json:"max_comment_size"`
+    Admins          []string `json:"admins"`
+    AdminEmail      string   `json:"admin_email"`
+    Auth            []string `json:"auth_providers"`
+    LowScore        int      `json:"low_score"`
+    CriticalScore   int      `json:"critical_score"`
+    PositiveScore   bool     `json:"positive_score"`
+    ReadOnlyAge     int      `json:"readonly_age"`
+    MaxImageSize    int      `json:"max_image_size"`
+    EmojiEnabled    bool     `json:"emoji_enabled"`
+    SubscribersOnly bool     `json:"subscribers_only"` // enable commenting only for Patreon subscribers
 }
 ```
 

--- a/site/src/pages/index.md
+++ b/site/src/pages/index.md
@@ -8,7 +8,7 @@ title: Remark42 – Privacy focused lightweight commenting engine
 
 Remark42 gives you opportunity to have self-hosted, lightweight, and simple (yet functional) comment engine, which doesn't spy on users. It can be embedded into blogs, articles or any other place where readers add comments.
 
-* Social login via Google, Twitter, Facebook, Microsoft, GitHub, Yandex and Telegram
+* Social login via Google, Twitter, Facebook, Microsoft, GitHub, Yandex, Patreon and Telegram
 * Login via email
 * Optional anonymous access
 * Multi-level nested comments with both tree and plain presentations


### PR DESCRIPTION
Partially closes #1125 

Backend:
- Env vars, docs
-  `store.User` new field `PaidSub`
- `subscribers-only` env var & appropriate middleware

Frontend:
- Add new auth type
- Icon asset from [Patreon branding page](https://www.patreon.com/brand)

Need to implement on frontend:
- Subscriber highlighting
- Disable `Send` button for non-subs