### PR TITLE
Fix non-HTTPS site link on the privacy page

### DIFF
--- a/site/src/pages/privacy.md
+++ b/site/src/pages/privacy.md
@@ -4,10 +4,10 @@ permalink: privacy/index.html
 title: Privacy Policy
 ---
 
-Umputun operates the website remark42.com, which provides the SERVICE. This page is used to inform website visitors regarding
+Umputun operates the website [remark42.com](https://remark42.com), which provides the SERVICE. This page is used to inform website visitors regarding
 our policies with the collection, use, and disclosure of Personal Information if anyone decided to use our Service. If you choose to use our Service, then you agree to the collection and use of information in relation with this policy. The Personal Information that we collect are used for providing and improving the Service. We will not use or share your information with anyone except as described in this Privacy Policy.
 
-The terms used in this Privacy Policy have the same meanings as in our Terms and Conditions, which is accessible at https://remark42.com, unless otherwise defined in this Privacy Policy.
+The terms used in this Privacy Policy have the same meanings as in our Terms and Conditions, which is accessible at [https://remark42.com](https://remark42.com), unless otherwise defined in this Privacy Policy.
 
 ### Information Collection and Use
 


### PR DESCRIPTION
The second part of #1154 resolution, https://remark42.com/privacy/ has an HTTP link before this PR is merged because it's not defined as a link explicitly.