### PR TITLE
Enable telegram notify trough writing bot a message

### DIFF
--- a/backend/app/notify/notify.go
+++ b/backend/app/notify/notify.go
@@ -51,11 +51,10 @@ type Request struct {
 
 // VerificationRequest notification for user
 type VerificationRequest struct {
-	SiteID   string
-	User     string
-	Email    string // if set, send email only
-	Telegram string // if set, send telegram only
-	Token    string
+	SiteID string
+	User   string
+	Email  string // if set, send email only
+	Token  string
 }
 
 const defaultQueueSize = 100

--- a/backend/app/notify/telegram.go
+++ b/backend/app/notify/telegram.go
@@ -7,8 +7,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	neturl "net/url"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -21,10 +24,11 @@ import (
 
 // TelegramParams contain settings for telegram notifications
 type TelegramParams struct {
-	AdminChannelID    string        // unique identifier for the target chat or username of the target channel (in the format @channelusername)
-	Token             string        // token for telegram bot API interactions
-	Timeout           time.Duration // http client timeout
-	UserNotifications bool          // flag which enables user notifications
+	AdminChannelID       string        // unique identifier for the target chat or username of the target channel (in the format @channelusername)
+	Token                string        // token for telegram bot API interactions
+	Timeout              time.Duration // http client timeout
+	UserNotifications    bool          // flag which enables user notifications
+	ErrorMsg, SuccessMsg string        // messages for successful and unsuccessful subscription requests to bot
 
 	apiPrefix string // changed only in tests
 }
@@ -33,13 +37,32 @@ type TelegramParams struct {
 type Telegram struct {
 	TelegramParams
 
-	username string // bot username
+	// Identifier of the first update to be requested.
+	// Should be equal to LastSeenUpdateID + 1
+	// See https://core.telegram.org/bots/api#getupdates
+	updateOffset           int
+	apiPollInterval        time.Duration // interval to check updates from Telegram API and answer to users
+	expiredCleanupInterval time.Duration // interval to check and clean up expired notification requests
+	username               string        // bot username
+	run                    int32         // non-zero if Run goroutine has started
+	requests               struct {
+		sync.RWMutex
+		data map[string]tgAuthRequest
+	}
 }
 
 // telegramMsg is used to send message trough Telegram bot API
 type telegramMsg struct {
 	Text      string `json:"text"`
 	ParseMode string `json:"parse_mode,omitempty"`
+}
+
+type tgAuthRequest struct {
+	confirmed  bool // whether login request has been confirmed and user info set
+	expires    time.Time
+	telegramID string
+	user       string
+	site       string
 }
 
 // TelegramBotInfo structure contains information about telegram bot, which is used from whole telegram API response
@@ -49,6 +72,8 @@ type TelegramBotInfo struct {
 
 const telegramTimeOut = 5000 * time.Millisecond
 const telegramAPIPrefix = "https://api.telegram.org/bot"
+const tgPollInterval = time.Second * 5
+const tgCleanupInterval = time.Minute * 5
 
 // NewTelegram makes telegram bot for notifications
 func NewTelegram(params TelegramParams) (*Telegram, error) {
@@ -60,6 +85,8 @@ func NewTelegram(params TelegramParams) (*Telegram, error) {
 	if res.Timeout == 0 {
 		res.Timeout = telegramTimeOut
 	}
+	res.apiPollInterval = tgPollInterval
+	res.expiredCleanupInterval = tgCleanupInterval
 	log.Printf("[DEBUG] create new telegram notifier for api=%s, timeout=%s", res.apiPrefix, res.Timeout)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -70,6 +97,8 @@ func NewTelegram(params TelegramParams) (*Telegram, error) {
 		return nil, errors.Wrapf(err, "can't retrieve bot info from Telegram API")
 	}
 	res.username = botInfo.Username
+
+	res.requests.data = make(map[string]tgAuthRequest)
 
 	return &res, nil
 }
@@ -108,7 +137,7 @@ func (t *Telegram) sendMessage(ctx context.Context, b []byte, chatID string) err
 	}
 
 	url := fmt.Sprintf("sendMessage?chat_id=%s&disable_web_page_preview=true", chatID)
-	return t.request(ctx, url, b, &struct{}{})
+	return t.Request(ctx, url, b, &struct{}{})
 }
 
 // buildMessage generates message for generic notification about new comment
@@ -159,44 +188,133 @@ func escapeTelegramText(text string) string {
 	return text
 }
 
-// SendVerification sends user verification message to the specified user
-func (t *Telegram) SendVerification(ctx context.Context, req VerificationRequest) error {
-	if req.Telegram == "" {
-		// this means we can't send this request via Telegram
-		return nil
-	}
-	select {
-	case <-ctx.Done():
-		return errors.Errorf("sending message to %q aborted due to canceled context", req.User)
-	default:
-	}
-
-	log.Printf("[DEBUG] send verification via %s, user %s", t, req.User)
-	msg, err := t.buildVerificationMessage(req.User, req.Token, req.SiteID)
-	if err != nil {
-		return err
-	}
-
-	return t.sendMessage(ctx, msg, req.Telegram)
+// SendVerification is not needed for telegram
+func (t *Telegram) SendVerification(_ context.Context, _ VerificationRequest) error {
+	return nil
 }
 
-// buildVerificationMessage generates verification telegram message based on given input
-func (t *Telegram) buildVerificationMessage(user, token, site string) ([]byte, error) {
-	result := fmt.Sprintf("Confirmation for <i>%s</i> on site %s\n"+
-		"Please copy and paste this text into “token” field on comments page to confirm subscription:\n\n\n"+
-		"<pre>%s</pre>",
-		escapeTelegramText(user), escapeTelegramText(site), escapeTelegramText(token))
-	body := telegramMsg{Text: result, ParseMode: "HTML"}
-	b, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-	return b, nil
+// TelegramUpdate contains update information, which is used from whole telegram API response
+type TelegramUpdate struct {
+	Result []struct {
+		UpdateID int `json:"update_id"`
+		Message  struct {
+			Chat struct {
+				ID   int    `json:"id"`
+				Name string `json:"first_name"`
+				Type string `json:"type"`
+			} `json:"chat"`
+			Text string `json:"text"`
+		} `json:"message"`
+	} `json:"result"`
 }
 
 // GetBotUsername returns bot username
 func (t *Telegram) GetBotUsername() string {
 	return t.username
+}
+
+// AddToken adds token
+func (t *Telegram) AddToken(token, user, site string, expires time.Time) {
+	t.requests.Lock()
+	t.requests.data[token] = tgAuthRequest{
+		expires: expires,
+		user:    user,
+		site:    site,
+	}
+	t.requests.Unlock()
+}
+
+// CheckToken verifies incoming token, returns the user address if it's confirmed and empty string otherwise
+func (t *Telegram) CheckToken(token, user string) (telegram, site string, err error) {
+	t.requests.RLock()
+	authRequest, ok := t.requests.data[token]
+	t.requests.RUnlock()
+
+	if !ok {
+		return "", "", errors.New("request is not found")
+	}
+
+	if time.Now().After(authRequest.expires) {
+		t.requests.Lock()
+		delete(t.requests.data, token)
+		t.requests.Unlock()
+		return "", "", errors.New("request expired")
+	}
+
+	if !authRequest.confirmed {
+		return "", "", errors.New("request is not verified yet")
+	}
+
+	if authRequest.user != user {
+		return "", "", errors.New("user does not match original requester")
+	}
+
+	// Delete request
+	t.requests.Lock()
+	delete(t.requests.data, token)
+	t.requests.Unlock()
+
+	return authRequest.telegramID, authRequest.site, nil
+}
+
+// Run starts processing login requests sent in Telegram, required for user notifications to work
+// Blocks caller
+func (t *Telegram) Run(ctx context.Context) {
+	atomic.AddInt32(&t.run, 1)
+	processUpdatedTicker := time.NewTicker(t.apiPollInterval)
+	cleanupTicker := time.NewTicker(t.expiredCleanupInterval)
+
+	for {
+		select {
+		case <-ctx.Done():
+			processUpdatedTicker.Stop()
+			cleanupTicker.Stop()
+			atomic.AddInt32(&t.run, -1)
+			return
+		case <-processUpdatedTicker.C:
+			updates, err := t.getUpdates(ctx)
+			if err != nil {
+				log.Printf("[WARN] Error while getting telegram updates: %v", err)
+				continue
+			}
+			t.processUpdates(ctx, updates)
+		case <-cleanupTicker.C:
+			now := time.Now()
+			t.requests.Lock()
+			for key, req := range t.requests.data {
+				if now.After(req.expires) {
+					delete(t.requests.data, key)
+				}
+			}
+			t.requests.Unlock()
+		}
+	}
+}
+
+// ProcessUpdate is alternative to Run, it processes provided plain text update from Telegram
+// so that caller could get updates and send it not only there but to multiple sources
+func (t *Telegram) ProcessUpdate(ctx context.Context, textUpdate string) error {
+	if atomic.LoadInt32(&t.run) != 0 {
+		return errors.New("Run goroutine should not be used with ProcessUpdate")
+	}
+	defer func() {
+		// as Run goroutine is not running, clean up old requests on each update
+		// even if we hit json decode error
+		now := time.Now()
+		t.requests.Lock()
+		for key, req := range t.requests.data {
+			if now.After(req.expires) {
+				delete(t.requests.data, key)
+			}
+		}
+		t.requests.Unlock()
+	}()
+	var updates TelegramUpdate
+	if err := json.Unmarshal([]byte(textUpdate), &updates); err != nil {
+		return errors.Wrap(err, "failed to decode provided telegram update")
+	}
+	t.processUpdates(ctx, &updates)
+	return nil
 }
 
 func (t *Telegram) String() string {
@@ -210,13 +328,81 @@ func (t *Telegram) String() string {
 	return result
 }
 
+// getUpdates fetches incoming updates
+func (t *Telegram) getUpdates(ctx context.Context) (*TelegramUpdate, error) {
+	url := `getUpdates?allowed_updates=["message"]`
+	if t.updateOffset != 0 {
+		url += fmt.Sprintf("&offset=%d", t.updateOffset)
+	}
+
+	var result TelegramUpdate
+
+	err := t.Request(ctx, url, nil, &result)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to fetch updates")
+	}
+
+	for _, u := range result.Result {
+		if u.UpdateID >= t.updateOffset {
+			t.updateOffset = u.UpdateID + 1
+		}
+	}
+
+	return &result, nil
+}
+
+// processUpdates processes a batch of updates from telegram servers
+func (t *Telegram) processUpdates(ctx context.Context, updates *TelegramUpdate) {
+	for _, update := range updates.Result {
+		if update.Message.Chat.Type != "private" {
+			continue
+		}
+
+		if !strings.HasPrefix(update.Message.Text, "/start ") {
+			continue
+		}
+
+		token := strings.TrimPrefix(update.Message.Text, "/start ")
+
+		t.requests.RLock()
+		authRequest, ok := t.requests.data[token]
+		if !ok { // No such token
+			t.requests.RUnlock()
+			if t.ErrorMsg != "" {
+				if err := t.sendText(ctx, update.Message.Chat.ID, t.ErrorMsg); err != nil {
+					log.Printf("[WARN] failed to notify telegram peer: %v", err)
+				}
+			}
+			continue
+		}
+		t.requests.RUnlock()
+
+		authRequest.confirmed = true
+		authRequest.telegramID = strconv.Itoa(update.Message.Chat.ID)
+
+		t.requests.Lock()
+		t.requests.data[token] = authRequest
+		t.requests.Unlock()
+
+		if err := t.sendText(ctx, update.Message.Chat.ID, t.SuccessMsg); err != nil {
+			log.Printf("[ERROR] failed to notify telegram peer: %v", err)
+		}
+	}
+}
+
+// sendText sends a plain text message to telegram peer
+func (t *Telegram) sendText(ctx context.Context, recipientID int, msg string) error {
+	url := fmt.Sprintf("sendMessage?chat_id=%d&text=%s", recipientID, neturl.PathEscape(msg))
+	return t.Request(ctx, url, nil, &struct{}{})
+}
+
 // botInfo returns info about configured bot
 func (t *Telegram) botInfo(ctx context.Context) (*TelegramBotInfo, error) {
 	var resp = struct {
 		Result *TelegramBotInfo `json:"result"`
 	}{}
 
-	err := t.request(ctx, "getMe", nil, &resp)
+	err := t.Request(ctx, "getMe", nil, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +413,8 @@ func (t *Telegram) botInfo(ctx context.Context) (*TelegramBotInfo, error) {
 	return resp.Result, nil
 }
 
-func (t *Telegram) request(ctx context.Context, method string, b []byte, data interface{}) error {
+// Request makes a request to the Telegram API and return the result
+func (t *Telegram) Request(ctx context.Context, method string, b []byte, data interface{}) error {
 	return repeater.NewDefault(3, time.Millisecond*250).Do(ctx, func() error {
 		url := fmt.Sprintf("%s%s/%s", t.apiPrefix, t.Token, method)
 

--- a/backend/app/providers/telegram.go
+++ b/backend/app/providers/telegram.go
@@ -1,0 +1,72 @@
+package providers
+
+// Both Telegram auth and notifications need to receive messages received by Telegram bot in the loop,
+// and below is the implementation of such loop which dispatched received events to both receivers,
+// so that they could work at the same time.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	log "github.com/go-pkgz/lgr"
+
+	"github.com/umputun/remark42/backend/app/notify"
+)
+
+type tgRequester interface {
+	Request(ctx context.Context, method string, b []byte, data interface{}) error
+}
+
+// TGUpdatesReceiver used to dispatch telegram updates to multiple receivers
+type TGUpdatesReceiver interface {
+	fmt.Stringer
+	ProcessUpdate(ctx context.Context, textUpdate string) error
+}
+
+// DispatchTelegramUpdates dispatches telegram updates to provided list of receivers
+// Blocks caller
+func DispatchTelegramUpdates(ctx context.Context, requester tgRequester, receivers []TGUpdatesReceiver, period time.Duration) {
+	// Identifier of the first update to be requested.
+	// Should be equal to LastSeenUpdateID + 1
+	// See https://core.telegram.org/bots/api#getupdates
+	var updateOffset int
+
+	processUpdatedTicker := time.NewTicker(period)
+	for {
+		select {
+		case <-ctx.Done():
+			processUpdatedTicker.Stop()
+			return
+		case <-processUpdatedTicker.C:
+			url := `getUpdates?allowed_updates=["message"]`
+			if updateOffset != 0 {
+				url += fmt.Sprintf("&offset=%d", updateOffset)
+			}
+
+			var update notify.TelegramUpdate
+
+			err := requester.Request(ctx, url, nil, &update)
+			if err != nil {
+				log.Printf("[WARN] failed to fetch updates: %v", err)
+				continue
+			}
+
+			for _, u := range update.Result {
+				if u.UpdateID >= updateOffset {
+					updateOffset = u.UpdateID + 1
+				}
+			}
+
+			if raw, err := json.Marshal(update); err == nil {
+				for _, r := range receivers {
+					e := r.ProcessUpdate(ctx, string(raw))
+					if e != nil {
+						log.Printf("[ERROR] failure from destination %s on processing telegram update %v", r, e)
+					}
+				}
+			}
+		}
+	}
+}

--- a/backend/app/providers/telegram_test.go
+++ b/backend/app/providers/telegram_test.go
@@ -1,0 +1,72 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/umputun/remark42/backend/app/notify"
+)
+
+func TestDispatchTelegramUpdates(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	poolPeriod := time.Millisecond * 100
+	go DispatchTelegramUpdates(ctx, &mockTGRequester{t: t}, []TGUpdatesReceiver{&mockTGUpdatesReceiver{t: t}}, poolPeriod)
+	time.Sleep(poolPeriod * 3)
+	cancel()
+	time.Sleep(poolPeriod)
+}
+
+const getUpdatesResp = `{
+  "ok": true,
+  "result": [
+     {
+        "update_id": 998,
+        "message": {
+           "chat": {
+              "type": "group"
+           }
+        }
+     }
+]
+}`
+
+type mockTGRequester struct {
+	hit int
+	t   *testing.T
+}
+
+func (m *mockTGRequester) Request(_ context.Context, _ string, _ []byte, data interface{}) error {
+	if m.hit < 2 {
+		m.hit++
+		assert.NoError(m.t, json.Unmarshal([]byte(getUpdatesResp), data))
+		return nil
+	}
+	return errors.New("test error")
+}
+
+type mockTGUpdatesReceiver struct {
+	t   *testing.T
+	hit int
+}
+
+func (m *mockTGUpdatesReceiver) String() string {
+	return "mock updater"
+}
+
+func (m *mockTGUpdatesReceiver) ProcessUpdate(_ context.Context, textUpdate string) error {
+	var result notify.TelegramUpdate
+	err := json.Unmarshal([]byte(textUpdate), &result)
+	assert.NoError(m.t, err)
+	if m.hit < 2 {
+		assert.NotNil(m.t, result.Result)
+		m.hit++
+		return nil
+	}
+	assert.Nil(m.t, result.Result)
+	return errors.New("test error")
+}

--- a/backend/app/rest/api/rest.go
+++ b/backend/app/rest/api/rest.go
@@ -44,6 +44,7 @@ type Rest struct {
 	CommentFormatter *store.CommentFormatter
 	Migrator         *Migrator
 	NotifyService    *notify.Service
+	TelegramService  telegramService
 	ImageService     *image.Service
 
 	AnonVote        bool
@@ -324,8 +325,7 @@ func (s *Rest) routes() chi.Router {
 			rauth.With(rejectAnonUser).Post("/email/subscribe", s.privRest.sendEmailConfirmationCtrl)
 			rauth.With(rejectAnonUser).Post("/email/confirm", s.privRest.setConfirmedEmailCtrl)
 			rauth.With(rejectAnonUser).Delete("/email", s.privRest.deleteEmailCtrl)
-			rauth.With(rejectAnonUser).Post("/telegram/subscribe", s.privRest.sendTelegramConfirmationCtrl)
-			rauth.With(rejectAnonUser).Post("/telegram/confirm", s.privRest.setConfirmedTelegramCtrl)
+			rauth.With(rejectAnonUser).Get("/telegram/subscribe", s.privRest.telegramSubscribeCtrl)
 			rauth.With(rejectAnonUser).Delete("/telegram", s.privRest.deleteTelegramCtrl)
 		})
 
@@ -374,6 +374,7 @@ func (s *Rest) controllerGroups() (public, private, admin, rss) {
 		readOnlyAge:      s.ReadOnlyAge,
 		authenticator:    s.Authenticator,
 		notifyService:    s.NotifyService,
+		telegramService:  s.TelegramService,
 		remarkURL:        s.RemarkURL,
 		anonVote:         s.AnonVote,
 		templates:        templates.NewFS(),

--- a/backend/remark.rest
+++ b/backend/remark.rest
@@ -134,12 +134,13 @@ X-JWT: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJyZW1hcmsiLCJleHAiOjE5NzYw
 DELETE {{host}}/api/v1/email?site={{site}}
 X-JWT: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJyZW1hcmsiLCJleHAiOjE5NzYwNTY3NTYsImp0aSI6IjJlOGJmMTE5OTI0MjQxMDRjYjFhZGRlODllMWYwNGFiMTg4YWZjMzQiLCJpYXQiOjE1NzYwNTY0NTYsImlzcyI6InJlbWFyazQyIiwidXNlciI6eyJuYW1lIjoiZGV2X3VzZXIiLCJpZCI6ImRldl91c2VyIiwicGljdHVyZSI6Imh0dHA6Ly8xMjcuMC4wLjE6ODA4MC9hcGkvdjEvYXZhdGFyL2NjZmEyYWJkMDE2Njc2MDViNGUxZmM0ZmNiOTFiMWUxYWYzMjMyNDAuaW1hZ2UiLCJhdHRycyI6eyJhZG1pbiI6dHJ1ZSwiYmxvY2tlZCI6ZmFsc2V9fX0.6Qt5s2enBMRC-Jmsua01yViVYI95Dx6BPBMaNjj36d4
 
-### send confirmation token for current user to specified telegram. auth token for dev user for secret=12345.
-POST {{host}}/api/v1/telegram/subscribe?site={{site}}&address={{telegram}}
+### get information for sending confirmation token for current user. auth token for dev user for secret=12345.
+### After you'll get the response, construct link with it and open it: https://t.me/<bot>?start=<token>
+GET {{host}}/api/v1/telegram/subscribe?site={{site}}
 X-JWT: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJyZW1hcmsiLCJleHAiOjE5NzYwNTY3NTYsImp0aSI6IjJlOGJmMTE5OTI0MjQxMDRjYjFhZGRlODllMWYwNGFiMTg4YWZjMzQiLCJpYXQiOjE1NzYwNTY0NTYsImlzcyI6InJlbWFyazQyIiwidXNlciI6eyJuYW1lIjoiZGV2X3VzZXIiLCJpZCI6ImRldl91c2VyIiwicGljdHVyZSI6Imh0dHA6Ly8xMjcuMC4wLjE6ODA4MC9hcGkvdjEvYXZhdGFyL2NjZmEyYWJkMDE2Njc2MDViNGUxZmM0ZmNiOTFiMWUxYWYzMjMyNDAuaW1hZ2UiLCJhdHRycyI6eyJhZG1pbiI6dHJ1ZSwiYmxvY2tlZCI6ZmFsc2V9fX0.6Qt5s2enBMRC-Jmsua01yViVYI95Dx6BPBMaNjj36d4
 
-### add telegram for notifications for current user via token from telegram. auth token for dev user for secret=12345.
-POST {{host}}/api/v1/telegram/confirm?site={{site}}&tkn={{token}}
+### verify telegram notifications for current user via token obtained in the previous step, after talking to bot. auth token for dev user for secret=12345.
+GET {{host}}/api/v1/telegram/subscribe?tkn={{token}}
 X-JWT: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJyZW1hcmsiLCJleHAiOjE5NzYwNTY3NTYsImp0aSI6IjJlOGJmMTE5OTI0MjQxMDRjYjFhZGRlODllMWYwNGFiMTg4YWZjMzQiLCJpYXQiOjE1NzYwNTY0NTYsImlzcyI6InJlbWFyazQyIiwidXNlciI6eyJuYW1lIjoiZGV2X3VzZXIiLCJpZCI6ImRldl91c2VyIiwicGljdHVyZSI6Imh0dHA6Ly8xMjcuMC4wLjE6ODA4MC9hcGkvdjEvYXZhdGFyL2NjZmEyYWJkMDE2Njc2MDViNGUxZmM0ZmNiOTFiMWUxYWYzMjMyNDAuaW1hZ2UiLCJhdHRycyI6eyJhZG1pbiI6dHJ1ZSwiYmxvY2tlZCI6ZmFsc2V9fX0.6Qt5s2enBMRC-Jmsua01yViVYI95Dx6BPBMaNjj36d4
 
 ### delete current user telegram. auth token for dev user for secret=12345.


### PR DESCRIPTION
Previously it was done through writing bot first, clicking a button, copying the token, and pasting it into the web interface.

The new flow is way simpler: click the link to write bot a message, then click the "Check" button in the web UI and you got notifications enabled.

Unsolved problems:
- [ ] auth is not listening to the same Telegram updates