### PR TITLE
Make docker-compose build static to a external folder

### DIFF
--- a/site/Dockerfile.build
+++ b/site/Dockerfile.build
@@ -1,0 +1,12 @@
+FROM node:16-alpine as build
+
+WORKDIR /site
+COPY ./package.json /site
+COPY ./yarn.lock /site
+RUN yarn --frozen-lockfile
+COPY . /site
+RUN yarn build
+RUN ls -la /site
+
+
+

--- a/site/README.md
+++ b/site/README.md
@@ -41,4 +41,11 @@ Then serve files from `./build` with your favorite server
 docker-compose up --build server
 ```
 
+### New docker compose file
+
+```shell
+docker-compose -f docker-compose-build.yml up --build build
+docker-compose -f docker-compose-build.yml up --build livereload
+```
+
 Then head to http://localhost:8080

--- a/site/docker-compose-build.yml
+++ b/site/docker-compose-build.yml
@@ -1,0 +1,32 @@
+version: '2'
+services:
+  build:
+    image: remark42-site-build
+    build: 
+      context: .
+      dockerfile: Dockerfile.build
+    command: yarn build
+
+    volumes:
+      - ./build:/site/build
+      
+  livereload:
+    image: remark42-site-build
+    build: 
+      context: .
+      dockerfile: Dockerfile.build
+    command: yarn dev:11ty
+
+    logging:
+      driver: json-file
+      options:
+        max-size: '10m'
+        max-file: '5'
+    
+    ports:
+      - '3001:3001'
+      - '8080:8080'
+
+    volumes:
+      - ./src:/site/src
+      - ./build:/site/build


### PR DESCRIPTION
Some fix for https://github.com/umputun/remark42/issues/1178 it looks lite Dockerfile and docker-compose.yml can't generate static to a folder. Site source generated in Dockerfile stored in /srv/ folder looks like for some production reasons. And this container can't be used for development. 

I add my version how it should work for development actually it is only a draft.  