### PR TITLE
Do not issue deprecation warning on notify.type by default

### DIFF
--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -354,7 +354,9 @@ func (s *ServerCommand) HandleDeprecatedFlags() (result []DeprecatedFlag) {
 		s.ImageProxy.HTTP2HTTPS = s.LegacyImageProxy
 		result = append(result, DeprecatedFlag{Old: "img-proxy", New: "image-proxy.http2https", Version: "1.5"})
 	}
-	if len(s.Notify.Type) != 0 && (len(s.Notify.Users) != 0 || len(s.Notify.Admins) != 0) {
+	if len(s.Notify.Type) != 0 && // explicitly empty, would likely never happen due to "none" default
+		!(len(s.Notify.Type) == 1 && contains("none", s.Notify.Type)) && // ignore default, "none" notify type
+		(len(s.Notify.Users) != 0 || len(s.Notify.Admins) != 0) { // new notify param(s) are used, safe to ignore the old one
 		s.handleDeprecatedNotifications()
 		result = append(result, DeprecatedFlag{Old: "notify.type", New: "notify.(users|admins)", Version: "1.9"})
 	}

--- a/backend/app/cmd/server_test.go
+++ b/backend/app/cmd/server_test.go
@@ -410,6 +410,7 @@ func TestServerApp_DeprecatedArgs(t *testing.T) {
 	p := flags.NewParser(&s, flags.Default)
 	args := []string{
 		"test",
+		"--notify.type=telegram",
 		"--auth.email.host=smtp.example.org",
 		"--auth.email.port=666",
 		"--auth.email.tls",


### PR DESCRIPTION
Default configuration for notify.type is "none", and prior to this change, it was issuing the deprecation warning which was not intended behavior.

Fixes #1191.