### PR TITLE
clarify telegram channel ID param and documentation

### DIFF
--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -218,7 +218,7 @@ type NotifyGroup struct {
 	Admins    []string `long:"admins" env:"ADMINS" description:"types of admin notifications" choice:"none" choice:"telegram" choice:"email" choice:"slack" choice:"webhook" default:"none" env-delim:","`                     //nolint
 	QueueSize int      `long:"queue" env:"QUEUE" description:"size of notification queue" default:"100"`
 	Telegram  struct {
-		Channel string        `long:"chan" env:"CHAN" description:"telegram channel for admin notifications"`
+		Channel string        `long:"chan" env:"CHAN" description:"ID of telegram channel for admin notifications"`
 		API     string        `long:"api" env:"API" default:"https://api.telegram.org/bot" description:"[deprecated, not used] telegram api prefix"`
 		Token   string        `long:"token" env:"TOKEN" description:"[deprecated, use --telegram.token] telegram token"`
 		Timeout time.Duration `long:"timeout" env:"TIMEOUT" default:"5s" description:"[deprecated, use --telegram.timeout] telegram timeout"`

--- a/site/src/docs/configuration/notifications/index.md
+++ b/site/src/docs/configuration/notifications/index.md
@@ -47,7 +47,9 @@ If all goes fine, you should be able to see the following message on your Slack 
 In order to integrate notifications about any comment on your sites with remark42 with [telegram](https://telegram.org)
 
 1. Set `NOTIFY_ADMINS=telegram`
-1. Make [a channel](https://telegram.org/faq_channels) and add it to remark42 configuration as `NOTIFY_TELEGRAM_CHAN`
+1. Make [a channel](https://telegram.org/faq_channels) and add it's ID to remark42 configuration as `NOTIFY_TELEGRAM_CHAN`
+    * To obtain public channel ID, forward any message from it to [@JsonDumpBot](https://t.me/JsonDumpBot): look for `id` in `forward_from_chat`.
+    * If you want to use private channel or chat, use [these instructions](https://github.com/GabrielRF/telegram-id) to obtain the ID.
 1. Get a token according to the instruction below and add it to the configuration as well
 
 ### Getting token for Telegram

--- a/site/src/docs/configuration/parameters/index.md
+++ b/site/src/docs/configuration/parameters/index.md
@@ -91,7 +91,7 @@ services:
 | notify.users            | NOTIFY_USERS            | none                     | type of user notifications (Telegram, email)    |
 | notify.admins           | NOTIFY_ADMINS           | none                     | type of admin notifications (Telegram, Slack, webhook and/or email) |
 | notify.queue            | NOTIFY_QUEUE            | `100`                    | size of notification queue                      |
-| notify.telegram.chan    | NOTIFY_TELEGRAM_CHAN    |                          | Telegram channel                                |
+| notify.telegram.chan    | NOTIFY_TELEGRAM_CHAN    |                          | ID of telegram channel for admin notifications  |
 | notify.slack.token      | NOTIFY_SLACK_TOKEN      |                          | Slack token                                     |
 | notify.slack.chan       | NOTIFY_SLACK_CHAN       | `general`                | Slack channel                                   |
 | notify.webhook.url      | NOTIFY_WEBHOOK_URL      |                          | Webhook notification URL                        |


### PR DESCRIPTION
Clarification based on [this](https://github.com/umputun/remark42/issues/1189#issuecomment-994672256) discussion.

This PR syncs CLI and documentation parameter descriptions and added clarification to the documentation on how to obtain the ID.