### PR TITLE
Fix formatting for telegram reply notifications

### DIFF
--- a/backend/app/notify/telegram.go
+++ b/backend/app/notify/telegram.go
@@ -153,7 +153,7 @@ func buildMessage(req Request) ([]byte, error) {
 	msg += fmt.Sprintf("\n\n%s", telegramSupportedHTML(req.Comment.Text))
 
 	if req.Comment.ParentID != "" {
-		msg += fmt.Sprintf("\n\n \"_%s_\"", telegramSupportedHTML(req.parent.Text))
+		msg += fmt.Sprintf("\n\n\"<i>%s</i>\"", telegramSupportedHTML(req.parent.Text))
 	}
 
 	if req.Comment.PostTitle != "" {
@@ -168,14 +168,14 @@ func buildMessage(req Request) ([]byte, error) {
 	return b, nil
 }
 
-// returns HTML with only tags allowed in Telegram HTML message payload
+// returns HTML with only tags allowed in Telegram HTML message payload, also trims ending newlines
 // https://core.telegram.org/bots/api#html-style
 func telegramSupportedHTML(htmlText string) string {
 	p := bluemonday.NewPolicy()
 	p.AllowElements("b", "strong", "i", "em", "u", "ins", "s", "strike", "del", "a", "code", "pre")
 	p.AllowAttrs("href").OnElements("a")
 	p.AllowAttrs("class").OnElements("code")
-	return p.Sanitize(htmlText)
+	return strings.TrimRight(p.Sanitize(htmlText), "\n")
 }
 
 // returns text sanitized of symbols not allowed inside other HTML tags in Telegram HTML message payload

--- a/backend/app/notify/telegram_test.go
+++ b/backend/app/notify/telegram_test.go
@@ -163,7 +163,7 @@ func TestTelegram_Send(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, `{"text":"\u003ca href=\"http://example.org/#remark42__comment-999\"\u003efrom\u003c/a\u003e -\u003e \u003ca href=\"http://example.org/#remark42__comment-\"\u003eto\u003c/a\u003e\n\n`+
 		`some text\n\n`+
-		` \"_some parent text with a \u003ca href=\"http://example.org\"\u003elink\u003c/a\u003e and special text:\u0026amp; \u0026lt; \u0026gt; \u0026amp;_\"\n\n`+
+		`\"\u003ci\u003esome parent text with a \u003ca href=\"http://example.org\"\u003elink\u003c/a\u003e and special text:\u0026amp; \u0026lt; \u0026gt; \u0026amp;\u003c/i\u003e\"\n\n`+
 		`↦  \u003ca href=\"http://example.org/\"\u003e[test title]\u003c/a\u003e","parse_mode":"HTML"}`,
 		string(res))
 }


### PR DESCRIPTION
Real comments:

<img width="312" alt="image" src="https://user-images.githubusercontent.com/712534/146716726-b116c161-d627-4129-b366-9e7e5e1bce4d.png">


Notification in Telegram before this PR:

<img width="143" alt="image" src="https://user-images.githubusercontent.com/712534/146716675-4bc17c76-e097-49ae-a819-a9b52c6a8330.png">

Notification in Telegram after this PR:

<img width="152" alt="image" src="https://user-images.githubusercontent.com/712534/146716692-23c3c23e-0585-4551-b4a2-a12379f54271.png">
