### PR TITLE
Protect anonymous comments from being changed by other users

### DIFF
--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -911,6 +911,8 @@ func (s *ServerCommand) addAuthProviders(authenticator *auth.Service) error {
 			}
 			return true, nil
 		}),
+			// Custom user ID generator, used to distinguish anonymous users with the same login
+			// coming from different IPs
 			func(user string, r *http.Request) string {
 				return user + r.RemoteAddr
 			})

--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -887,7 +887,8 @@ func (s *ServerCommand) addAuthProviders(authenticator *auth.Service) error {
 	if s.Auth.Anonymous {
 		log.Print("[INFO] anonymous access enabled")
 		var isValidAnonName = regexp.MustCompile(`^[\p{L}\d_ ]+$`).MatchString
-		authenticator.AddDirectProvider("anonymous", provider.CredCheckerFunc(func(user, _ string) (ok bool, err error) {
+		authenticator.AddDirectProviderWithUserIDFunc("anonymous", provider.CredCheckerFunc(func(user, _ string) (ok bool, err error) {
+
 			// don't allow anon with space prefix or suffix
 			if strings.HasPrefix(user, " ") || strings.HasSuffix(user, " ") {
 				log.Printf("[WARN] name %q has space as a suffix or prefix", user)
@@ -909,7 +910,10 @@ func (s *ServerCommand) addAuthProviders(authenticator *auth.Service) error {
 				return false, nil
 			}
 			return true, nil
-		}))
+		}),
+			func(user string, r *http.Request) string {
+				return user + r.RemoteAddr
+			})
 	}
 
 	if providersCount == 0 {


### PR DESCRIPTION
[Direct](https://github.com/go-pkgz/auth/blob/fa21d23/provider/direct.go#L99-L102) auth from go-pkgz/auth [used](https://github.com/umputun/remark42/blob/90e5373/backend/app/cmd/server.go#L834-L861) in Remark42 for anonymous authentication. The problem is that as soon as a user logs in with the same name as another anonymous user, they get precisely the same user ID and can delete or alter messages by that other user.
To prevent that, we need to provide custom [UserIDFunc](https://github.com/go-pkgz/auth/blob/fa21d23ff361c2728f10807ba3dda386ef0c541b/provider/direct.go#L41), which I propose should return hashed IP of the user so that there will be no way another anonymous user and I get the same ID at the same time, but it would be possible to re-login right away with the same ID if I want to adjust my anonymous comment.

Issue description has been originally provided by @paskal 