### PR TITLE
Add "invite your tg bot" note to documentation

### DIFF
--- a/site/src/docs/configuration/telegram/index.md
+++ b/site/src/docs/configuration/telegram/index.md
@@ -48,7 +48,7 @@ To enable Telegram authentication for the users, set variable `AUTH_TELEGRAM=tru
 To integrate notifications about any comment on your sites with remark42 with [Telegram](https://telegram.org)
 
 1. Set `NOTIFY_ADMINS=telegram`
-1. Make [a channel](https://telegram.org/faq_channels) and add its ID to remark42 configuration as `NOTIFY_TELEGRAM_CHAN`
+1. Make [a channel](https://telegram.org/faq_channels), **invite your bot** into it and add channel ID to remark42 configuration as `NOTIFY_TELEGRAM_CHAN`
   * To obtain a public channel ID, forward any message from it to [@JsonDumpBot](https://t.me/JsonDumpBot): look for `id` in `forward_from_chat`.
   * If you want to use a private channel or chat, use [these instructions](https://github.com/GabrielRF/telegram-id) to obtain the ID.
 


### PR DESCRIPTION
Pointed out in #1221 originally. Kudos to @elmaester for pointing it out.