### PR TITLE
Log when deprecated and new args are set at the same time

### DIFF
--- a/backend/app/cmd/cmd.go
+++ b/backend/app/cmd/cmd.go
@@ -22,6 +22,7 @@ type CommonOptionsCommander interface {
 	SetCommon(commonOpts CommonOpts)
 	Execute(args []string) error
 	HandleDeprecatedFlags() []DeprecatedFlag
+	FindDeprecatedFlagsCollisions() []DeprecatedFlag
 }
 
 // CommonOpts sets externally from main, shared across all commands
@@ -48,6 +49,10 @@ func (c *CommonOpts) SetCommon(commonOpts CommonOpts) {
 
 // HandleDeprecatedFlags sets new flags from deprecated and returns their list
 func (c *CommonOpts) HandleDeprecatedFlags() []DeprecatedFlag { return nil }
+
+// FindDeprecatedFlagsCollisions returns list of flags collisions, e.g. when both deprecated
+// and new flags are set to non-default values, and different from each other.
+func (c *CommonOpts) FindDeprecatedFlagsCollisions() []DeprecatedFlag { return nil }
 
 // fileParser used to convert template strings like blah-{{.SITE}}-{{.YYYYMMDD}} the final format
 type fileParser struct {

--- a/backend/app/cmd/cmd.go
+++ b/backend/app/cmd/cmd.go
@@ -22,7 +22,6 @@ type CommonOptionsCommander interface {
 	SetCommon(commonOpts CommonOpts)
 	Execute(args []string) error
 	HandleDeprecatedFlags() []DeprecatedFlag
-	FindDeprecatedFlagsCollisions() []DeprecatedFlag
 }
 
 // CommonOpts sets externally from main, shared across all commands
@@ -34,9 +33,10 @@ type CommonOpts struct {
 
 // DeprecatedFlag contains information about deprecated option
 type DeprecatedFlag struct {
-	Old     string
-	New     string
-	Version string
+	Old       string
+	New       string
+	Version   string
+	Collision bool
 }
 
 // SetCommon satisfies CommonOptionsCommander interface and sets common option fields
@@ -49,10 +49,6 @@ func (c *CommonOpts) SetCommon(commonOpts CommonOpts) {
 
 // HandleDeprecatedFlags sets new flags from deprecated and returns their list
 func (c *CommonOpts) HandleDeprecatedFlags() []DeprecatedFlag { return nil }
-
-// FindDeprecatedFlagsCollisions returns list of flags collisions, e.g. when both deprecated
-// and new flags are set to non-default values, and different from each other.
-func (c *CommonOpts) FindDeprecatedFlagsCollisions() []DeprecatedFlag { return nil }
 
 // fileParser used to convert template strings like blah-{{.SITE}}-{{.YYYYMMDD}} the final format
 type fileParser struct {

--- a/backend/app/cmd/server_test.go
+++ b/backend/app/cmd/server_test.go
@@ -446,6 +446,7 @@ func TestServerApp_DeprecatedArgs(t *testing.T) {
 			{Old: "img-proxy", New: "image-proxy.http2https", Version: "1.5"},
 			{Old: "notify.email.notify_admin", New: "notify.admins=email", Version: "1.9"},
 			{Old: "notify.type", New: "notify.(users|admins)", Version: "1.9"},
+			{Old: "notify.type", New: "notify.(users|admins)", Collision: true},
 			{Old: "notify.telegram.token", New: "telegram.token", Version: "1.9"},
 			{Old: "notify.telegram.timeout", New: "telegram.timeout", Version: "1.9"},
 			{Old: "notify.telegram.api", Version: "1.9"},
@@ -485,17 +486,17 @@ func TestServerApp_DeprecatedArgsCollisions(t *testing.T) {
 	}
 	_, err := p.ParseArgs(args)
 	require.NoError(t, err)
-	deprecatedFlagsCollisions := s.FindDeprecatedFlagsCollisions()
+	deprecatedFlagsCollisions := s.findDeprecatedFlagsCollisions()
 	assert.ElementsMatch(t,
 		[]DeprecatedFlag{
-			{Old: "notify.type", New: "notify.(users|admins)"},
-			{Old: "auth.email.host", New: "smtp.host"},
-			{Old: "auth.email.port", New: "smtp.port"},
-			{Old: "auth.email.user", New: "smtp.username"},
-			{Old: "auth.email.passwd", New: "smtp.password"},
-			{Old: "auth.email.timeout", New: "smtp.timeout"},
-			{Old: "notify.telegram.token", New: "telegram.token"},
-			{Old: "notify.telegram.timeout", New: "telegram.timeout"},
+			{Old: "notify.type", New: "notify.(users|admins)", Collision: true},
+			{Old: "auth.email.host", New: "smtp.host", Collision: true},
+			{Old: "auth.email.port", New: "smtp.port", Collision: true},
+			{Old: "auth.email.user", New: "smtp.username", Collision: true},
+			{Old: "auth.email.passwd", New: "smtp.password", Collision: true},
+			{Old: "auth.email.timeout", New: "smtp.timeout", Collision: true},
+			{Old: "notify.telegram.token", New: "telegram.token", Collision: true},
+			{Old: "notify.telegram.timeout", New: "telegram.timeout", Collision: true},
 		},
 		deprecatedFlagsCollisions)
 
@@ -510,7 +511,7 @@ func TestServerApp_DeprecatedArgsCollisions(t *testing.T) {
 	}
 	_, err = p.ParseArgs(args)
 	require.NoError(t, err)
-	deprecatedFlagsCollisions = s.FindDeprecatedFlagsCollisions()
+	deprecatedFlagsCollisions = s.findDeprecatedFlagsCollisions()
 	assert.Empty(t, []DeprecatedFlag{}, deprecatedFlagsCollisions)
 }
 

--- a/backend/app/main.go
+++ b/backend/app/main.go
@@ -45,6 +45,9 @@ func main() {
 			SharedSecret: opts.SharedSecret,
 			Revision:     revision,
 		})
+		for _, entry := range c.FindDeprecatedFlagsCollisions() {
+			log.Print(fmt.Sprintf("[ERROR] deprecated --%s and new --%s options are set to different values, old one is ignored: please remove it", entry.Old, entry.New))
+		}
 		for _, entry := range c.HandleDeprecatedFlags() {
 			deprecationNote := fmt.Sprintf("[WARN] --%s is deprecated since v%s and will be removed in the future", entry.Old, entry.Version)
 			if entry.New != "" {

--- a/backend/app/main.go
+++ b/backend/app/main.go
@@ -45,16 +45,7 @@ func main() {
 			SharedSecret: opts.SharedSecret,
 			Revision:     revision,
 		})
-		for _, entry := range c.FindDeprecatedFlagsCollisions() {
-			log.Print(fmt.Sprintf("[ERROR] deprecated --%s and new --%s options are set to different values, old one is ignored: please remove it", entry.Old, entry.New))
-		}
-		for _, entry := range c.HandleDeprecatedFlags() {
-			deprecationNote := fmt.Sprintf("[WARN] --%s is deprecated since v%s and will be removed in the future", entry.Old, entry.Version)
-			if entry.New != "" {
-				deprecationNote += fmt.Sprintf(", please use --%s instead", entry.New)
-			}
-			log.Print(deprecationNote)
-		}
+		logDeprecatedParams(c.HandleDeprecatedFlags())
 		err := c.Execute(args)
 		if err != nil {
 			log.Printf("[ERROR] failed with %+v", err)
@@ -77,6 +68,22 @@ func setupLog(dbg bool) {
 		return
 	}
 	log.Setup(log.Msec, log.LevelBraces)
+}
+
+// logs usual and "collision" deprecated parameters
+func logDeprecatedParams(params []cmd.DeprecatedFlag) {
+	for _, entry := range params {
+		var deprecationNote string
+		if entry.Collision {
+			deprecationNote = fmt.Sprintf("[ERROR] deprecated --%s and new --%s options are set to different values, old one is ignored: please remove it", entry.Old, entry.New)
+		} else {
+			deprecationNote = fmt.Sprintf("[WARN] --%s is deprecated since v%s and will be removed in the future", entry.Old, entry.Version)
+			if entry.New != "" {
+				deprecationNote += fmt.Sprintf(", please use --%s instead", entry.New)
+			}
+		}
+		log.Print(deprecationNote)
+	}
 }
 
 // getDump reads runtime stack and returns as a string


### PR DESCRIPTION
For example, when notify.telegram.token and telegram.token are both set but to different values, user might see "access denied" error in log on attempt to send telegram notification, thinking that notify.telegram.token value is used, when in fact it is ignored and only telegram.token is used.

New behavior is the same, ignoring the old param when new one is set, but issuing the error log message which explicitly tells the user about that.

Resolves #1218.