### PR TITLE
Remove explicit /srv/ usage from docker-compose files

### DIFF
--- a/backend/_example/memory_store/compose-dev-memstore.yml
+++ b/backend/_example/memory_store/compose-dev-memstore.yml
@@ -29,7 +29,6 @@ services:
     environment:
       - REMARK_URL=http://127.0.0.1:8080
       - SECRET=123456
-      - BACKUP_PATH=/srv/var/backup
       - DEBUG=true
       - EMOJI=true
       - AUTH_ANON=true

--- a/compose-dev-backend.yml
+++ b/compose-dev-backend.yml
@@ -35,8 +35,6 @@ services:
       #            - TIME_ZONE=GMT
       - REMARK_URL=http://127.0.0.1:8080
       - SECRET=12345
-      - STORE_BOLT_PATH=/srv/var/db
-      - BACKUP_PATH=/srv/var/backup
       - DEBUG=true
       - ADMIN_PASSWD=password
       - AUTH_DEV=true # activate local oauth "dev"

--- a/compose-dev-frontend.yml
+++ b/compose-dev-frontend.yml
@@ -32,8 +32,6 @@ services:
     environment:
       - REMARK_URL=http://127.0.0.1:8080
       - SECRET=12345
-      - STORE_BOLT_PATH=/srv/var/db
-      - BACKUP_PATH=/srv/var/backupang
       - DEBUG=true
       - ADMIN_PASSWD=password
       - AUTH_DEV=true # activate local oauth "dev"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,6 @@ services:
     environment:
       - REMARK_URL
       - SECRET
-      - STORE_BOLT_PATH=/srv/var/db
-      - BACKUP_PATH=/srv/var/backup
       - DEBUG=true
       - AUTH_GOOGLE_CID
       - AUTH_GOOGLE_CSEC

--- a/site/src/docs/manuals/kubernetes/index.md
+++ b/site/src/docs/manuals/kubernetes/index.md
@@ -47,10 +47,6 @@ spec:
                 secretKeyRef:
                   name: remark42
                   key: SECRET
-            - name: STORE_BOLT_PATH
-              value: "/srv/var/db"
-            - name: BACKUP_PATH
-              value: "/srv/var/backup"
             - name: AUTH_GOOGLE_CID
               valueFrom:
                 secretKeyRef:

--- a/site/src/docs/manuals/reproxy/index.md
+++ b/site/src/docs/manuals/reproxy/index.md
@@ -53,8 +53,6 @@ services:
       - SECRET=some-secret-thing
       - USER=app
       - REMARK_URL=https://remark42.example.com
-      - STORE_BOLT_PATH=/srv/var
-      - BACKUP_PATH=/srv/var/backup
       - CACHE_MAX_VALUE=10000000
       - IMAGE_PROXY_HTTP2HTTPS=true
       - AVATAR_RESIZE=48


### PR DESCRIPTION
We have plenty of paths used in the application (like `AVATAR_FS_PATH`, `IMAGE_FS_PATH`), but two of them are hardcoded in examples all over the code for historical reasons.

I found that by default in Docker, the path would anyway resolve to the value we are setting it explicitly to, so it doesn't make sense to set a few variables we are setting now explicitly.

I was confused by these two variables when figuring out how to run the application outside of docker by looking at the default variables we propose in docker-compose.yml.