### PR TITLE
Fix typo in index.md

### DIFF
--- a/site/src/docs/contributing/development/index.md
+++ b/site/src/docs/contributing/development/index.md
@@ -4,7 +4,7 @@ title: Development
 
 ### Backend development
 
-The frontend development guide can be found [here](https://remark42.com/docs/contributing/development/backend/).
+The backend development guide can be found [here](https://remark42.com/docs/contributing/development/backend/).
 
 ### Frontend development
 


### PR DESCRIPTION
The text in the backend development section should be backend instead of frontend