### PR TITLE
use default system font

### DIFF
--- a/frontend/.size-limit.js
+++ b/frontend/.size-limit.js
@@ -16,10 +16,6 @@ module.exports = [
     limit: '32 KB',
   },
   {
-    path: 'public/last-comments.css',
-    limit: '6 KB',
-  },
-  {
     path: 'public/deleteme.mjs',
     limit: '11 KB',
   },

--- a/frontend/app/components/button/_kind/_link/button_kind_link.css
+++ b/frontend/app/components/button/_kind/_link/button_kind_link.css
@@ -1,6 +1,6 @@
 .button_kind_link {
   background: transparent;
-  font-weight: bold;
+  font-weight: 600;
   color: var(--color9);
 
   &:hover {

--- a/frontend/app/components/comment-form/__field/comment-form__field.css
+++ b/frontend/app/components/comment-form/__field/comment-form__field.css
@@ -9,7 +9,6 @@
   min-height: var(--height);
   padding: 10px 12px;
   margin: 0;
-  font-family: 'PT Sans', Helvetica, Arial, sans-serif;
   font-size: 16px;
   line-height: 1.4;
   border: 0;

--- a/frontend/app/components/comment/__action/comment__action.css
+++ b/frontend/app/components/comment/__action/comment__action.css
@@ -1,7 +1,6 @@
 .comment__action {
   font-size: 14px;
   vertical-align: middle;
-  font-weight: normal;
 
   & + .comment__action {
     margin-left: 8px;

--- a/frontend/app/components/comment/__control/comment__control.css
+++ b/frontend/app/components/comment/__control/comment__control.css
@@ -1,6 +1,5 @@
 .comment__control {
   margin-right: 8px;
-  color: var(--color33);
 
   &:last-child {
     margin-right: 0;

--- a/frontend/app/components/comment/__controls/comment__controls.css
+++ b/frontend/app/components/comment/__controls/comment__controls.css
@@ -3,10 +3,10 @@
   vertical-align: middle;
   user-select: none;
   font-size: 14px;
-  font-weight: 700;
 
   @media (hover: hover) {
     opacity: 0;
+    transition: opacity 0.15s;
 
     &:hover,
     &:focus-within {

--- a/frontend/app/components/comment/comment.css
+++ b/frontend/app/components/comment/comment.css
@@ -2,7 +2,7 @@
   display: block;
   padding: 12px 0 8px;
   font-size: 16px;
-  line-height: 1.2;
+  line-height: 1.4;
   transition: background 0.3s ease-in-out;
 
   @media (hover: hover) {

--- a/frontend/app/components/comment/comment.tsx
+++ b/frontend/app/components/comment/comment.tsx
@@ -398,18 +398,15 @@ export class Comment extends Component<CommentProps, State> {
     if (isAdmin) {
       controls.push(
         this.state.isCopied ? (
-          <span className="comment__control comment__control_view_inactive">
+          <span className="comment__control comment__control_view_inactive comment__action">
             <FormattedMessage id="comment.copied" defaultMessage="Copied!" />
           </span>
         ) : (
-          <Button kind="link" onClick={this.copyComment} mix="comment__control">
+          <Button kind="link" onClick={this.copyComment} mix={['comment__control', 'comment__action']}>
             <FormattedMessage id="comment.copy" defaultMessage="Copy" />
           </Button>
-        )
-      );
-
-      controls.push(
-        <Button kind="link" onClick={this.togglePin} mix="comment__control">
+        ),
+        <Button kind="link" onClick={this.togglePin} mix={['comment__control', 'comment__action']}>
           {this.props.data.pin ? (
             <FormattedMessage id="comment.unpin" defaultMessage="Unpin" />
           ) : (
@@ -421,7 +418,7 @@ export class Comment extends Component<CommentProps, State> {
 
     if (!isCurrentUser) {
       controls.push(
-        <Button kind="link" onClick={this.hideUser} mix="comment__control">
+        <Button kind="link" onClick={this.hideUser} mix={['comment__control', 'comment__action']}>
           <FormattedMessage id="comment.hide" defaultMessage="Hide" />
         </Button>
       );
@@ -430,7 +427,7 @@ export class Comment extends Component<CommentProps, State> {
     if (isAdmin) {
       if (this.props.isUserBanned) {
         controls.push(
-          <Button kind="link" onClick={this.onUnblockUserClick} mix="comment__control">
+          <Button kind="link" onClick={this.onUnblockUserClick} mix={['comment__control', 'comment__action']}>
             <FormattedMessage id="comment.unblock" defaultMessage="Unblock" />
           </Button>
         );
@@ -456,7 +453,7 @@ export class Comment extends Component<CommentProps, State> {
 
       if (!this.props.data.delete) {
         controls.push(
-          <Button kind="link" onClick={this.deleteComment} mix="comment__control">
+          <Button kind="link" onClick={this.deleteComment} mix={['comment__control', 'comment__action']}>
             <FormattedMessage id="comment.delete" defaultMessage="Delete" />
           </Button>
         );

--- a/frontend/app/components/list-comments/list-comments.module.css
+++ b/frontend/app/components/list-comments/list-comments.module.css
@@ -1,3 +1,0 @@
-.root {
-  font-family: 'PT Sans', Helvetica, Arial, sans-serif;
-}

--- a/frontend/app/components/list-comments/list-comments.tsx
+++ b/frontend/app/components/list-comments/list-comments.tsx
@@ -1,11 +1,8 @@
 import { h } from 'preact';
 import { useIntl } from 'react-intl';
-import clsx from 'clsx';
 
 import type { Comment as CommentType } from 'common/types';
 import { Comment } from 'components/comment';
-
-import styles from './list-comments.module.css';
 
 type Props = {
   comments: CommentType[];
@@ -15,7 +12,7 @@ export function ListComments({ comments = [] }: Props) {
   const intl = useIntl();
 
   return (
-    <div className={clsx('comments-list', styles.root)}>
+    <div className="comments-list">
       {comments.map((comment) => (
         <Comment
           intl={intl}

--- a/frontend/app/components/raw-content/raw-content.css
+++ b/frontend/app/components/raw-content/raw-content.css
@@ -14,7 +14,7 @@
 
   & p,
   & blockquote {
-    margin: 1rem 0;
+    margin: 0.5rem 0;
 
     &:first-child {
       margin-top: 0;
@@ -22,13 +22,6 @@
 
     &:last-child {
       margin-bottom: 0;
-    }
-
-    /* imported comments have br instead of p */
-    & br {
-      content: '';
-      display: block;
-      margin-top: 1rem;
     }
   }
 

--- a/frontend/app/last-comments.tsx
+++ b/frontend/app/last-comments.tsx
@@ -7,6 +7,8 @@ import { loadLocale } from 'utils/loadLocale';
 import { getLocale } from 'utils/getLocale';
 import { ListComments } from 'components/list-comments';
 
+import 'styles/global.css';
+
 const LAST_COMMENTS_NODE_CLASSNAME = 'remark42__last-comments';
 const DEFAULT_LAST_COMMENTS_MAX = 15;
 

--- a/frontend/app/styles/global.css
+++ b/frontend/app/styles/global.css
@@ -3,14 +3,18 @@ body {
   -moz-osx-font-smoothing: grayscale;
   margin: 0;
   padding: 6px;
-  font-family: "PT Sans", Helvetica, Arial, sans-serif;
+  font-family: system-ui;
+  font-size: 14px;
   color: rgb(var(--primary-text-color));
   box-sizing: border-box;
 }
 
 input,
+textarea,
+select,
 button {
   font-family: inherit;
+  font-size: inherit;
   color: inherit;
 }
 
@@ -19,7 +23,6 @@ button {
   margin: 0;
   border: 0;
   background: unset;
-  font-size: inherit;
   transition-property: color, background, border-color;
   transition-timing-function: linear;
   transition-duration: 150ms;

--- a/frontend/templates/last-comments.ejs
+++ b/frontend/templates/last-comments.ejs
@@ -16,7 +16,7 @@
       }
     </style>
     <% if (htmlWebpackPlugin.options.env === 'production') { %>
-    <link rel="stylesheet" href="last-comments.css" />
+    <link rel="stylesheet" href="remark42.css" />
     <% } %>
   </head>
   <body>

--- a/frontend/templates/markdown-help.html
+++ b/frontend/templates/markdown-help.html
@@ -54,7 +54,7 @@
       }
 
       body {
-        font: 16px/26px Helvetica, "Helvetica Neue", Arial, sans-serif;
+        font: 16px/26px Helvetica, 'Helvetica Neue', Arial, sans-serif;
       }
 
       .wrapper {


### PR DESCRIPTION
Resolves #1268

- changes base font to system font
- adjustments for comment styles accordingly to the  new font
- adjustments for comment action button styles accordingly to the new font
- use `remark.css` for all of the widgets because it contains all of the necessary fonts and can be cached one time. that means no need to load other chunks and increase the amount of code for download

<img width="825" alt="CleanShot 2022-04-09 at 18 00 36@2x" src="https://user-images.githubusercontent.com/2330682/162596988-48e2d07f-9b6f-46cf-9e9f-a0d4e20663d0.png">
<img width="810" alt="CleanShot 2022-04-09 at 18 00 29@2x" src="https://user-images.githubusercontent.com/2330682/162596990-cb3770cb-ca49-4c3f-a88e-c33ce78ea17a.png">

