### PR TITLE
fix light bg on dark theme

### DIFF
--- a/frontend/app/styles/custom-properties.css
+++ b/frontend/app/styles/custom-properties.css
@@ -86,6 +86,4 @@
   --error-color: #ffa0a0;
   --line-brighter-color: var(--color11);
   --text-color: var(--white-color);
-
-  color-scheme: dark;
 }


### PR DESCRIPTION
`color-scheme: dark` makes iframe background lighter than original website.
 
 Bug:
<img width="245" alt="CleanShot 2022-04-13 at 20 05 15@2x" src="https://user-images.githubusercontent.com/2330682/163305629-7ffda166-3cb9-44cb-a341-947afaab29ed.png">


After fix:
<img width="274" alt="CleanShot 2022-04-13 at 20 04 39@2x" src="https://user-images.githubusercontent.com/2330682/163305570-2688a556-fbb8-4c52-984c-f85e53eacbe3.png">
