### PR TITLE
Replace numbers with proper HTTP status codes in tests

### DIFF
--- a/backend/app/cmd/avatar_test.go
+++ b/backend/app/cmd/avatar_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestAvatar_Execute(t *testing.T) {
-
 	defer os.RemoveAll("/tmp/ava-test")
 
 	// from fs to bolt

--- a/backend/app/cmd/cleanup.go
+++ b/backend/app/cmd/cleanup.go
@@ -55,7 +55,6 @@ func (cc *CleanupCommand) Execute(_ []string) error {
 			cc.procTitles(comments)
 		} else {
 			spamComments += cc.procSpam(comments)
-
 		}
 	}
 
@@ -151,7 +150,6 @@ func (cc *CleanupCommand) listPosts() ([]store.PostInfo, error) {
 
 // get all comments for post url via /find?site=siteID&url=post-url&format=[tree|plain]
 func (cc *CleanupCommand) listComments(postURL string) ([]store.Comment, error) {
-
 	commentsURL := fmt.Sprintf("%s/api/v1/find?site=%s&url=%s&format=plain", cc.RemarkURL, cc.Site, postURL)
 
 	var r *http.Response
@@ -191,7 +189,6 @@ func (cc *CleanupCommand) listComments(postURL string) ([]store.Comment, error) 
 
 // deleteComment with DELETE /admin/comment/{id}?site=siteID&url=post-url
 func (cc *CleanupCommand) deleteComment(c store.Comment) error {
-
 	deleteURL := fmt.Sprintf("%s/api/v1/admin/comment/%s?site=%s&url=%s&format=plain", cc.RemarkURL, c.ID, cc.Site, c.Locator.URL)
 	req, err := http.NewRequest("DELETE", deleteURL, http.NoBody)
 	if err != nil {
@@ -213,7 +210,6 @@ func (cc *CleanupCommand) deleteComment(c store.Comment) error {
 
 // setTitle with PUT /admin/title/{id}?site=siteID&url=post-url
 func (cc *CleanupCommand) setTitle(c store.Comment) error {
-
 	titleURL := fmt.Sprintf("%s/api/v1/admin/title/%s?site=%s&url=%s&format=plain", cc.RemarkURL, c.ID, cc.Site, c.Locator.URL)
 	req, err := http.NewRequest("PUT", titleURL, http.NoBody)
 	if err != nil {
@@ -235,7 +231,6 @@ func (cc *CleanupCommand) setTitle(c store.Comment) error {
 
 // isSpam calculates spam's probability as a score
 func (cc *CleanupCommand) isSpam(comment store.Comment) (isSpam bool, spamScore float64) {
-
 	badWord := func(txt string) float64 {
 		res := 0.0
 		for _, w := range cc.BadWords {

--- a/backend/app/cmd/cleanup_test.go
+++ b/backend/app/cmd/cleanup_test.go
@@ -59,7 +59,6 @@ func TestCleanup_IsSpam(t *testing.T) {
 }
 
 func TestCleanup_postsInRange(t *testing.T) {
-
 	r := chi.NewRouter()
 	cleanupRoutes(t, r, nil)
 	ts := httptest.NewServer(r)
@@ -211,5 +210,4 @@ func cleanupRoutes(t *testing.T, r *chi.Mux, c *cleanedComments) {
 		c.ids = append(c.ids, r.URL.Path)
 		c.lock.Unlock()
 	})
-
 }

--- a/backend/app/cmd/cmd.go
+++ b/backend/app/cmd/cmd.go
@@ -59,7 +59,6 @@ type fileParser struct {
 
 // parse apply template and also concat path and file. In case if file contains path separator path will be ignored
 func (p *fileParser) parse(now time.Time) (string, error) {
-
 	// file/location parameters my have template masks
 	fileTemplate := struct {
 		YYYYMMDD string

--- a/backend/app/cmd/import_test.go
+++ b/backend/app/cmd/import_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestImport_Execute(t *testing.T) {
-
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, r.URL.Path, "/api/v1/admin/import")
 		assert.Equal(t, "POST", r.Method)
@@ -48,7 +47,6 @@ func TestImport_Execute(t *testing.T) {
 }
 
 func TestImport_ExecuteFailed(t *testing.T) {
-
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, r.URL.Path, "/api/v1/admin/import")
 		assert.Equal(t, "POST", r.Method)
@@ -102,7 +100,6 @@ func TestImport_ExecuteTimeout(t *testing.T) {
 		time.Sleep(500 * time.Millisecond)
 		fmt.Fprintln(w, "some response")
 		fmt.Fprintln(w, string(body))
-
 	}))
 	defer ts.Close()
 

--- a/backend/app/cmd/remap_test.go
+++ b/backend/app/cmd/remap_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestRemap_Execute(t *testing.T) {
-
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, r.URL.Path, "/api/v1/admin/remap")
 		assert.Equal(t, "POST", r.Method)

--- a/backend/app/cmd/restore_test.go
+++ b/backend/app/cmd/restore_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestRestore_Execute(t *testing.T) {
-
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, r.URL.Path, "/api/v1/admin/import")
 		assert.Equal(t, "POST", r.Method)

--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -449,7 +449,6 @@ func contains(s string, a []string) bool {
 // newServerApp prepares application and return it with all active parts
 // doesn't start anything
 func (s *ServerCommand) newServerApp(ctx context.Context) (*serverApp, error) {
-
 	if err := makeDirs(s.BackupLocation); err != nil {
 		return nil, errors.Wrap(err, "failed to create backup store")
 	}
@@ -885,7 +884,6 @@ func (s *ServerCommand) addAuthProviders(authenticator *auth.Service) error {
 		log.Print("[INFO] anonymous access enabled")
 		var isValidAnonName = regexp.MustCompile(`^[\p{L}\d_ ]+$`).MatchString
 		authenticator.AddDirectProvider("anonymous", provider.CredCheckerFunc(func(user, _ string) (ok bool, err error) {
-
 			// don't allow anon with space prefix or suffix
 			if strings.HasPrefix(user, " ") || strings.HasSuffix(user, " ") {
 				log.Printf("[WARN] name %q has space as a suffix or prefix", user)
@@ -1205,7 +1203,6 @@ func (s *ServerCommand) startTelegramAuthAndNotify(ctx context.Context, telegram
 // Eliminate leading and trailing dbl quotes in each element only if both presented
 // based on https://stackoverflow.com/a/59318708
 func splitAtCommas(s string) []string {
-
 	cleanup := func(s string) string {
 		if s == "" {
 			return s

--- a/backend/app/cmd/server_test.go
+++ b/backend/app/cmd/server_test.go
@@ -38,7 +38,7 @@ func TestServerApp(t *testing.T) {
 	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/api/v1/ping", port))
 	require.NoError(t, err)
 	defer resp.Body.Close()
-	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	body, err := io.ReadAll(resp.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, "pong", string(body))
@@ -83,7 +83,7 @@ func TestServerApp_DevMode(t *testing.T) {
 	// send ping
 	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/api/v1/ping", port))
 	require.NoError(t, err)
-	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	body, err := io.ReadAll(resp.Body)
 	assert.NoError(t, err)
 	assert.NoError(t, resp.Body.Close())
@@ -251,14 +251,14 @@ func TestServerApp_WithSSL(t *testing.T) {
 	resp, err := client.Get(fmt.Sprintf("http://localhost:%d/blah?param=1", port))
 	require.NoError(t, err)
 	defer resp.Body.Close()
-	assert.Equal(t, 307, resp.StatusCode)
+	assert.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
 	assert.Equal(t, fmt.Sprintf("https://localhost:%d/blah?param=1", sslPort), resp.Header.Get("Location"))
 
 	// check https server
 	resp, err = client.Get(fmt.Sprintf("https://localhost:%d/ping", sslPort))
 	require.NoError(t, err)
 	defer resp.Body.Close()
-	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	body, err := io.ReadAll(resp.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, "pong", string(body))
@@ -268,7 +268,6 @@ func TestServerApp_WithSSL(t *testing.T) {
 }
 
 func TestServerApp_WithRemote(t *testing.T) {
-
 	opts := ServerCommand{}
 	opts.SetCommon(CommonOpts{RemarkURL: "https://demo.remark42.com", SharedSecret: "123456"})
 
@@ -294,7 +293,7 @@ func TestServerApp_WithRemote(t *testing.T) {
 	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/api/v1/ping", port))
 	require.NoError(t, err)
 	defer resp.Body.Close()
-	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	body, err := io.ReadAll(resp.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, "pong", string(body))
@@ -377,7 +376,6 @@ func TestServerApp_Shutdown(t *testing.T) {
 }
 
 func TestServerApp_MainSignal(t *testing.T) {
-
 	done := make(chan struct{})
 	go func() {
 		<-done
@@ -663,7 +661,6 @@ func TestServer_loadEmailTemplate(t *testing.T) {
 }
 
 func TestServerCommand_parseSameSite(t *testing.T) {
-
 	tbl := []struct {
 		inp string
 		res http.SameSite
@@ -686,7 +683,6 @@ func TestServerCommand_parseSameSite(t *testing.T) {
 }
 
 func Test_splitAtCommas(t *testing.T) {
-
 	tbl := []struct {
 		inp string
 		res []string

--- a/backend/app/main_test.go
+++ b/backend/app/main_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 func Test_Main(t *testing.T) {
-
 	dir, err := ioutil.TempDir(os.TempDir(), "remark42")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
@@ -54,7 +53,7 @@ func Test_Main(t *testing.T) {
 	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/api/v1/ping", port))
 	require.NoError(t, err)
 	defer resp.Body.Close()
-	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	body, err := io.ReadAll(resp.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, "pong", string(body))
@@ -118,7 +117,7 @@ func TestMain_WithWebhook(t *testing.T) {
 		strings.NewReader(`{"text": "env test", "locator":{"url": "https://radio-t.com", "site": "remark"}}`))
 	require.NoError(t, err)
 	defer resp.Body.Close()
-	assert.Equal(t, 201, resp.StatusCode)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 }
 
 func TestGetDump(t *testing.T) {

--- a/backend/app/migrator/commento.go
+++ b/backend/app/migrator/commento.go
@@ -85,7 +85,6 @@ func (d *Commento) convert(r io.Reader, siteID string) (ch chan store.Comment) {
 	decoder := json.NewDecoder(r)
 
 	go func() {
-
 		var exportedData commentoExport
 		err := decoder.Decode(&exportedData)
 		if err != nil {

--- a/backend/app/migrator/disqus.go
+++ b/backend/app/migrator/disqus.go
@@ -82,7 +82,6 @@ func (d *Disqus) Import(r io.Reader, siteID string) (size int, err error) {
 // convert disqus stream (xml) from reader and fill channel of comments.
 // runs async and closes channel on completion.
 func (d *Disqus) convert(r io.Reader, siteID string) (ch chan store.Comment) {
-
 	postsMap := map[string]string{} // tid:url
 	decoder := xml.NewDecoder(r)
 	commentsCh := make(chan store.Comment)

--- a/backend/app/migrator/native.go
+++ b/backend/app/migrator/native.go
@@ -35,7 +35,6 @@ type meta struct {
 // Export all comments to writer as json strings. Each comment is one string, separated by "\n"
 // The final file is a valid json
 func (n *Native) Export(w io.Writer, siteID string) (size int, err error) {
-
 	if err = n.exportMeta(siteID, w); err != nil {
 		return 0, errors.Wrapf(err, "failed to export meta for site %s", siteID)
 	}
@@ -55,7 +54,6 @@ func (n *Native) Export(w io.Writer, siteID string) (size int, err error) {
 		}
 
 		for _, comment := range comments {
-
 			buf := &bytes.Buffer{}
 			enc := json.NewEncoder(buf)
 			enc.SetEscapeHTML(false)
@@ -180,7 +178,6 @@ func (n *Native) Import(reader io.Reader, siteID string) (size int, err error) {
 				log.Printf("[DEBUG] imported %d comments", num)
 			}
 		})
-
 	}
 
 	grp.Wait()

--- a/backend/app/migrator/native_test.go
+++ b/backend/app/migrator/native_test.go
@@ -153,7 +153,6 @@ func TestNative_ImportWrongVersion(t *testing.T) {
 	size, err := r.Import(strings.NewReader(inp), "radio-t")
 	assert.EqualError(t, err, "unexpected import file version 2")
 	assert.Equal(t, 0, size)
-
 }
 func TestNative_ImportManyWithError(t *testing.T) {
 	b, teardown := prep(t) // write 2 comments
@@ -181,7 +180,6 @@ func TestNative_ImportManyWithError(t *testing.T) {
 
 // makes new boltdb, put two records
 func prep(t *testing.T) (ds *service.DataStore, teardown func()) {
-
 	testDB := fmt.Sprintf("/tmp/migrator-%d.db", rand.Intn(999999999))
 
 	boltStore, err := engine.NewBoltDB(bolt.Options{}, engine.BoltSite{SiteID: "radio-t", FileName: testDB})

--- a/backend/app/migrator/wordpress.go
+++ b/backend/app/migrator/wordpress.go
@@ -60,7 +60,6 @@ func (w *WordPress) Convert(text string) string {
 
 // Import comments from WP and save to store
 func (w *WordPress) Import(r io.Reader, siteID string) (size int, err error) {
-
 	if e := w.DataStore.DeleteAll(siteID); e != nil {
 		return 0, e
 	}
@@ -88,7 +87,6 @@ func (w *WordPress) Import(r io.Reader, siteID string) (size int, err error) {
 }
 
 func (w *WordPress) convert(r io.Reader, siteID string) chan store.Comment {
-
 	decoder := xml.NewDecoder(r)
 	commentsCh := make(chan store.Comment)
 

--- a/backend/app/notify/slack.go
+++ b/backend/app/notify/slack.go
@@ -17,7 +17,6 @@ type Slack struct {
 
 // NewSlack makes Slack bot for notifications
 func NewSlack(token, channelName string, opts ...slack.Option) (*Slack, error) {
-
 	if channelName == "" {
 		channelName = "general"
 	}
@@ -38,7 +37,6 @@ func NewSlack(token, channelName string, opts ...slack.Option) (*Slack, error) {
 
 // Send to Slack channel
 func (t *Slack) Send(ctx context.Context, req Request) error {
-
 	log.Printf("[DEBUG] send slack notification, comment id %s", req.Comment.ID)
 
 	user := req.Comment.User.Name
@@ -63,7 +61,6 @@ func (t *Slack) Send(ctx context.Context, req Request) error {
 	)
 
 	return err
-
 }
 
 // SendVerification is not implemented for Slack
@@ -76,10 +73,8 @@ func (t *Slack) String() string {
 }
 
 func (t *Slack) findChannelIDByName(name string) (string, error) {
-
 	params := slack.GetConversationsParameters{}
 	for {
-
 		chans, next, err := t.client.GetConversations(&params)
 		if err != nil {
 			return "", err
@@ -95,7 +90,6 @@ func (t *Slack) findChannelIDByName(name string) (string, error) {
 			break
 		}
 		params.Cursor = next
-
 	}
 	return "", errors.New("no such channel")
 }

--- a/backend/app/notify/slack_test.go
+++ b/backend/app/notify/slack_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 func TestSlack_New(t *testing.T) {
-
 	ts := newMockSlackServer()
 	defer ts.Close()
 
@@ -28,11 +27,9 @@ func TestSlack_New(t *testing.T) {
 	_, err = ts.newClient("unknown-channel")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no such channel")
-
 }
 
 func TestSlack_Send(t *testing.T) {
-
 	ts := newMockSlackServer()
 	defer ts.Close()
 
@@ -63,7 +60,6 @@ func TestSlack_Send(t *testing.T) {
 	err = tb.Send(context.TODO(), Request{Comment: c, parent: cp})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "slack server error", "send on broken client")
-
 }
 
 func TestSlack_Name(t *testing.T) {
@@ -98,7 +94,6 @@ func (ts *mockSlackServer) newClient(channelName string) (*Slack, error) {
 }
 
 func newMockSlackServer() *mockSlackServer {
-
 	mockServer := mockSlackServer{}
 	router := chi.NewRouter()
 	router.Post("/conversations.list", func(w http.ResponseWriter, r *http.Request) {
@@ -139,10 +134,8 @@ func newMockSlackServer() *mockSlackServer {
 	})
 
 	router.Post("/chat.postMessage", func(w http.ResponseWriter, r *http.Request) {
-
 		if mockServer.isServerDown {
 			w.WriteHeader(500)
-
 		} else {
 			s := `{
 			    "ok": true,

--- a/backend/app/notify/webhook_test.go
+++ b/backend/app/notify/webhook_test.go
@@ -35,7 +35,6 @@ func (errReader) Read(p []byte) (n int, err error) {
 }
 
 func TestWebhook_NewWebhook(t *testing.T) {
-
 	wh, err := NewWebhook(okWebhookClient, WebhookParams{
 		WebhookURL: "https://example.org/webhook",
 		Headers:    []string{"Authorization:Basic AXVubzpwQDU1dzByYM=="},
@@ -68,7 +67,6 @@ func TestWebhook_NewWebhook(t *testing.T) {
 }
 
 func TestWebhook_Send(t *testing.T) {
-
 	wh, err := NewWebhook(funcWebhookClient(func(r *http.Request) (*http.Response, error) {
 		assert.Len(t, r.Header, 1)
 		assert.Equal(t, r.Header.Get("Content-Type"), "application/json,text/plain")

--- a/backend/app/rest/api/admin.go
+++ b/backend/app/rest/api/admin.go
@@ -44,7 +44,6 @@ type adminStore interface {
 
 // DELETE /comment/{id}?site=siteID&url=post-url - removes comment
 func (a *admin) deleteCommentCtrl(w http.ResponseWriter, r *http.Request) {
-
 	id := chi.URLParam(r, "id")
 	locator := store.Locator{SiteID: r.URL.Query().Get("site"), URL: r.URL.Query().Get("url")}
 	log.Printf("[INFO] delete comment %s", id)
@@ -61,7 +60,6 @@ func (a *admin) deleteCommentCtrl(w http.ResponseWriter, r *http.Request) {
 
 // DELETE /user/{userid}?site=side-id - delete all user comments for requested userid
 func (a *admin) deleteUserCtrl(w http.ResponseWriter, r *http.Request) {
-
 	userID := chi.URLParam(r, "userid")
 	siteID := r.URL.Query().Get("site")
 	log.Printf("[INFO] delete all user comments for %s, site %s", userID, siteID)
@@ -77,7 +75,6 @@ func (a *admin) deleteUserCtrl(w http.ResponseWriter, r *http.Request) {
 
 // GET /user/{userid}?site=side-id - get user info for requested userid
 func (a *admin) getUserInfoCtrl(w http.ResponseWriter, r *http.Request) {
-
 	userID := chi.URLParam(r, "userid")
 	siteID := r.URL.Query().Get("site")
 	log.Printf("[INFO] get user info for %s, site %s", userID, siteID)
@@ -94,7 +91,6 @@ func (a *admin) getUserInfoCtrl(w http.ResponseWriter, r *http.Request) {
 // GET /deleteme?token=jwt - delete all user comments and details by user's request. Gets info about deleted used from provided token
 // request made GET to allow direct click from the email sent by user
 func (a *admin) deleteMeRequestCtrl(w http.ResponseWriter, r *http.Request) {
-
 	token := r.URL.Query().Get("token")
 
 	claims, err := a.authenticator.TokenService().Parse(token)

--- a/backend/app/rest/api/admin_test.go
+++ b/backend/app/rest/api/admin_test.go
@@ -38,7 +38,7 @@ func TestAdmin_Delete(t *testing.T) {
 
 	// check last comments
 	res, code := get(t, ts.URL+"/api/v1/last/2?site=remark42")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	comments := []store.Comment{}
 	err := json.Unmarshal([]byte(res), &comments)
 	assert.NoError(t, err)
@@ -65,10 +65,10 @@ func TestAdmin_Delete(t *testing.T) {
 	resp, err = sendReq(t, req, adminUmputunToken)
 	assert.NoError(t, err)
 	assert.NoError(t, resp.Body.Close())
-	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	body, code := getWithDevAuth(t, fmt.Sprintf("%s/api/v1/id/%s?site=remark42&url=https://radio-t.com/blah", ts.URL, id1))
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	cr := store.Comment{}
 	err = json.Unmarshal([]byte(body), &cr)
 	assert.NoError(t, err)
@@ -78,7 +78,7 @@ func TestAdmin_Delete(t *testing.T) {
 	time.Sleep(250 * time.Millisecond)
 	// check last comments updated
 	res, code = get(t, ts.URL+"/api/v1/last/2?site=remark42")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	comments = []store.Comment{}
 	err = json.Unmarshal([]byte(res), &comments)
 	assert.NoError(t, err)
@@ -86,7 +86,7 @@ func TestAdmin_Delete(t *testing.T) {
 
 	// check count updated
 	res, code = get(t, ts.URL+"/api/v1/count?site=remark42&url=https://radio-t.com/blah")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	b := map[string]interface{}{}
 	err = json.Unmarshal([]byte(res), &b)
 	assert.NoError(t, err)
@@ -142,10 +142,10 @@ func TestAdmin_Title(t *testing.T) {
 	resp, err := sendReq(t, req, adminUmputunToken)
 	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
-	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	body, code := get(t, fmt.Sprintf("%s/api/v1/id/%s?site=remark42&url=%s/post1", ts.URL, id1, tss.URL))
-	require.Equal(t, 200, code)
+	require.Equal(t, http.StatusOK, code)
 	cr := store.Comment{}
 	err = json.Unmarshal([]byte(body), &cr)
 	assert.NoError(t, err)
@@ -177,11 +177,11 @@ func TestAdmin_DeleteUser(t *testing.T) {
 	resp, err := sendReq(t, req, adminUmputunToken)
 	assert.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
-	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	// all 3 comments here, but for id2 they deleted
 	res, code := get(t, ts.URL+"/api/v1/find?site=remark42&url=https://radio-t.com/blah&sort=+time")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	cmntWithInfo := commentsWithInfo{}
 	err = json.Unmarshal([]byte(res), &cmntWithInfo)
 	assert.NoError(t, err)
@@ -231,19 +231,19 @@ func TestAdmin_Pin(t *testing.T) {
 	}
 
 	code := pin(1)
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 
 	body, code := get(t, fmt.Sprintf("%s/api/v1/id/%s?site=remark42&url=https://radio-t.com/blah", ts.URL, id1))
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	cr := store.Comment{}
 	err := json.Unmarshal([]byte(body), &cr)
 	assert.NoError(t, err)
 	assert.True(t, cr.Pin)
 
 	code = pin(-1)
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	body, code = get(t, fmt.Sprintf("%s/api/v1/id/%s?site=remark42&url=https://radio-t.com/blah", ts.URL, id1))
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	cr = store.Comment{}
 	err = json.Unmarshal([]byte(body), &cr)
 	assert.NoError(t, err)
@@ -286,7 +286,7 @@ func TestAdmin_Block(t *testing.T) {
 
 	// block permanently
 	code, body := block(1, "")
-	require.Equal(t, 200, code)
+	require.Equal(t, http.StatusOK, code)
 	j := R.JSON{}
 	err := json.Unmarshal(body, &j)
 	assert.NoError(t, err)
@@ -299,7 +299,7 @@ func TestAdmin_Block(t *testing.T) {
 
 	// get last to confirm one comment deleted
 	bodyStr, code := get(t, ts.URL+"/api/v1/last/10?site=remark42")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	pi := []store.PostInfo{}
 	assert.NoError(t, json.Unmarshal([]byte(bodyStr), &pi))
 	assert.Equal(t, 1, len(pi), "last status updated, one comment left")
@@ -317,7 +317,7 @@ func TestAdmin_Block(t *testing.T) {
 	assert.Equal(t, []store.PostInfo{{URL: "https://radio-t.com/blah", Count: 1}}, pi)
 
 	res, code := get(t, ts.URL+"/api/v1/find?site=remark42&url=https://radio-t.com/blah&sort=+time")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	comments := commentsWithInfo{}
 	err = json.Unmarshal([]byte(res), &comments)
 	assert.NoError(t, err)
@@ -327,7 +327,7 @@ func TestAdmin_Block(t *testing.T) {
 
 	// unblock
 	code, body = block(-1, "")
-	require.Equal(t, 200, code)
+	require.Equal(t, http.StatusOK, code)
 	err = json.Unmarshal(body, &j)
 	assert.NoError(t, err)
 	assert.Equal(t, false, j["block"])
@@ -335,11 +335,11 @@ func TestAdmin_Block(t *testing.T) {
 	// block with ttl
 	makeTwoComments()
 	code, _ = block(1, "50ms")
-	require.Equal(t, 200, code)
+	require.Equal(t, http.StatusOK, code)
 
 	// get as regular user
 	res, code = get(t, ts.URL+"/api/v1/find?site=remark42&url=https://radio-t.com/blah&sort=+time")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	comments = commentsWithInfo{}
 	err = json.Unmarshal([]byte(res), &comments)
 	assert.NoError(t, err)
@@ -351,7 +351,7 @@ func TestAdmin_Block(t *testing.T) {
 	// time
 	time.Sleep(50 * time.Millisecond)
 	res, code = get(t, ts.URL+"/api/v1/find?site=remark42&url=https://radio-t.com/blah&sort=+time")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	comments = commentsWithInfo{}
 	err = json.Unmarshal([]byte(res), &comments)
 	assert.NoError(t, err)
@@ -385,7 +385,7 @@ func TestAdmin_BlockedList(t *testing.T) {
 	res, err := sendReq(t, req, adminUmputunToken)
 	require.NoError(t, err)
 	require.NoError(t, res.Body.Close())
-	assert.Equal(t, 200, res.StatusCode)
+	assert.Equal(t, http.StatusOK, res.StatusCode)
 
 	// block user2
 	req, err = http.NewRequest(http.MethodPut,
@@ -394,13 +394,13 @@ func TestAdmin_BlockedList(t *testing.T) {
 	res, err = sendReq(t, req, adminUmputunToken)
 	require.NoError(t, err)
 	require.NoError(t, res.Body.Close())
-	assert.Equal(t, 200, res.StatusCode)
+	assert.Equal(t, http.StatusOK, res.StatusCode)
 
 	req, err = http.NewRequest("GET", ts.URL+"/api/v1/admin/blocked?site=remark42", http.NoBody)
 	require.NoError(t, err)
 	res, err = sendReq(t, req, adminUmputunToken)
 	require.NoError(t, err)
-	require.Equal(t, 200, res.StatusCode)
+	require.Equal(t, http.StatusOK, res.StatusCode)
 	users := []store.BlockedUser{}
 	err = json.NewDecoder(res.Body).Decode(&users)
 	assert.NoError(t, err)
@@ -417,7 +417,7 @@ func TestAdmin_BlockedList(t *testing.T) {
 	require.NoError(t, err)
 	res, err = sendReq(t, req, adminUmputunToken)
 	require.NoError(t, err)
-	require.Equal(t, 200, res.StatusCode)
+	require.Equal(t, http.StatusOK, res.StatusCode)
 	users = []store.BlockedUser{}
 	err = json.NewDecoder(res.Body).Decode(&users)
 	assert.NoError(t, err)
@@ -450,11 +450,11 @@ func TestAdmin_ReadOnly(t *testing.T) {
 	resp, err := sendReq(t, req, "") // non-admin user
 	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
-	assert.Equal(t, 401, resp.StatusCode)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 	resp, err = sendReq(t, req, adminUmputunToken)
 	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
-	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	info, err = srv.DataService.Info(store.Locator{SiteID: "remark42", URL: "https://radio-t.com/blah"}, 0)
 	assert.NoError(t, err)
 	assert.True(t, info.ReadOnly)
@@ -478,7 +478,7 @@ func TestAdmin_ReadOnly(t *testing.T) {
 	resp, err = sendReq(t, req, adminUmputunToken)
 	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
-	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	info, err = srv.DataService.Info(store.Locator{SiteID: "remark42", URL: "https://radio-t.com/blah"}, 0)
 	assert.NoError(t, err)
 	assert.False(t, info.ReadOnly)
@@ -508,12 +508,12 @@ func TestAdmin_ReadOnlyNoComments(t *testing.T) {
 	resp, err := sendReq(t, req, adminUmputunToken)
 	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
-	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	_, err = srv.DataService.Info(store.Locator{SiteID: "remark42", URL: "https://radio-t.com/blah"}, 0)
 	assert.Error(t, err)
 
 	res, code := get(t, ts.URL+"/api/v1/find?site=remark42&url=https://radio-t.com/blah&format=tree")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	comments := commentsWithInfo{}
 	err = json.Unmarshal([]byte(res), &comments)
 	assert.NoError(t, err)
@@ -544,7 +544,7 @@ func TestAdmin_ReadOnlyWithAge(t *testing.T) {
 	resp, err := sendReq(t, req, adminUmputunToken)
 	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
-	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	info, err = srv.DataService.Info(store.Locator{SiteID: "remark42", URL: "https://radio-t.com/blah"}, 0)
 	assert.NoError(t, err)
 	assert.True(t, info.ReadOnly)
@@ -556,11 +556,10 @@ func TestAdmin_ReadOnlyWithAge(t *testing.T) {
 	resp, err = sendReq(t, req, adminUmputunToken)
 	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
-	assert.Equal(t, 403, resp.StatusCode)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 	info, err = srv.DataService.Info(store.Locator{SiteID: "remark42", URL: "https://radio-t.com/blah"}, 0)
 	assert.NoError(t, err)
 	assert.True(t, info.ReadOnly)
-
 }
 func TestAdmin_Verify(t *testing.T) {
 	ts, srv, teardown := startupT(t)
@@ -586,12 +585,12 @@ func TestAdmin_Verify(t *testing.T) {
 	resp, err := sendReq(t, req, adminUmputunToken)
 	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
-	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	verified = srv.DataService.IsVerified("remark42", "user1")
 	assert.True(t, verified)
 
 	res, code := get(t, ts.URL+"/api/v1/find?site=remark42&url=https://radio-t.com/blah&sort=+time")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	comments := commentsWithInfo{}
 	err = json.Unmarshal([]byte(res), &comments)
 	assert.NoError(t, err)
@@ -605,12 +604,12 @@ func TestAdmin_Verify(t *testing.T) {
 	resp, err = sendReq(t, req, adminUmputunToken)
 	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
-	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	verified = srv.DataService.IsVerified("remark42", "user1")
 	assert.False(t, verified)
 
 	res, code = get(t, ts.URL+"/api/v1/find?site=remark42&url=https://radio-t.com/blah&sort=+time")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	comments = commentsWithInfo{}
 	err = json.Unmarshal([]byte(res), &comments)
 	assert.NoError(t, err)
@@ -632,7 +631,7 @@ func TestAdmin_ExportStream(t *testing.T) {
 	addComment(t, c2, ts)
 
 	body, code := getWithAdminAuth(t, ts.URL+"/api/v1/admin/export?site=remark42&mode=stream")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	assert.Equal(t, 3, strings.Count(body, "\n"))
 	assert.Equal(t, 2, strings.Count(body, "\"text\""))
 	t.Logf("%s", body)
@@ -656,7 +655,7 @@ func TestAdmin_ExportFile(t *testing.T) {
 	resp, err := sendReq(t, req, adminUmputunToken)
 	require.NoError(t, err)
 
-	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "application/gzip", resp.Header.Get("Content-Type"))
 
 	ungzReader, err := gzip.NewReader(resp.Body)
@@ -727,7 +726,7 @@ func TestAdmin_DeleteMeRequest(t *testing.T) {
 	resp, err := client.Do(req)
 	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
-	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	_, err = srv.DataService.User("remark42", "user1", 0, 0, store.User{})
 	assert.EqualError(t, err, "no comments for user user1 in store")
@@ -735,7 +734,6 @@ func TestAdmin_DeleteMeRequest(t *testing.T) {
 	email, err = srv.DataService.GetUserEmail("remark42", "user1")
 	assert.NoError(t, err)
 	assert.Empty(t, email, "user1 email was deleted")
-
 }
 
 func TestAdmin_DeleteMeRequestFailed(t *testing.T) {
@@ -760,7 +758,7 @@ func TestAdmin_DeleteMeRequestFailed(t *testing.T) {
 	resp, err := client.Do(req)
 	assert.NoError(t, err)
 	assert.NoError(t, resp.Body.Close())
-	assert.Equal(t, 400, resp.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 	// try with bad auth
 	claims := token.Claims{
@@ -788,7 +786,7 @@ func TestAdmin_DeleteMeRequestFailed(t *testing.T) {
 	resp, err = client.Do(req)
 	assert.NoError(t, err)
 	assert.NoError(t, resp.Body.Close())
-	assert.Equal(t, 403, resp.StatusCode)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 
 	// try bad user
 	badClaims := claims
@@ -801,7 +799,7 @@ func TestAdmin_DeleteMeRequestFailed(t *testing.T) {
 	resp, err = client.Do(req)
 	assert.NoError(t, err)
 	assert.NoError(t, resp.Body.Close())
-	assert.Equal(t, 400, resp.StatusCode, resp.Status)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, resp.Status)
 
 	// try without deleteme flag
 	badClaims2 := claims
@@ -813,7 +811,7 @@ func TestAdmin_DeleteMeRequestFailed(t *testing.T) {
 	req.SetBasicAuth("admin", "password")
 	resp, err = client.Do(req)
 	assert.NoError(t, err)
-	assert.Equal(t, 403, resp.StatusCode)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 	b, err := io.ReadAll(resp.Body)
 	assert.NoError(t, err)
 	assert.NoError(t, resp.Body.Close())
@@ -836,7 +834,7 @@ func TestAdmin_GetUserInfo(t *testing.T) {
 
 	body, code := getWithAdminAuth(t, fmt.Sprintf("%s/api/v1/admin/user/user1?site=remark42&url=https://radio-t.com/blah",
 		ts.URL))
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	u := store.User{}
 	err = json.Unmarshal([]byte(body), &u)
 	assert.NoError(t, err)
@@ -844,8 +842,8 @@ func TestAdmin_GetUserInfo(t *testing.T) {
 		Admin: false, Blocked: false, Verified: false}, u)
 
 	_, code = get(t, fmt.Sprintf("%s/api/v1/admin/user/user1?site=remark42&url=https://radio-t.com/blah", ts.URL))
-	assert.Equal(t, 401, code, "no auth")
+	assert.Equal(t, http.StatusUnauthorized, code, "no auth")
 
 	_, code = getWithAdminAuth(t, fmt.Sprintf("%s/api/v1/admin/user/userX?site=remark42&url=https://radio-t.com/blah", ts.URL))
-	assert.Equal(t, 400, code, "no info about user")
+	assert.Equal(t, http.StatusBadRequest, code, "no info about user")
 }

--- a/backend/app/rest/api/migrator.go
+++ b/backend/app/rest/api/migrator.go
@@ -44,7 +44,6 @@ type KeyStore interface {
 // POST /import?secret=key&site=site-id&provider=disqus|remark|wordpress
 // imports comments from post body.
 func (m *Migrator) importCtrl(w http.ResponseWriter, r *http.Request) {
-
 	siteID := r.URL.Query().Get("site")
 
 	if m.isBusy(siteID) {
@@ -132,7 +131,6 @@ func (m *Migrator) waitCtrl(w http.ResponseWriter, r *http.Request) {
 // GET /export?site=site-id&secret=12345&?mode=file|stream
 // exports all comments for siteID as gz file
 func (m *Migrator) exportCtrl(w http.ResponseWriter, r *http.Request) {
-
 	siteID := r.URL.Query().Get("site")
 
 	var writer io.Writer = w

--- a/backend/app/rest/api/migrator_test.go
+++ b/backend/app/rest/api/migrator_test.go
@@ -260,7 +260,7 @@ func TestMigrator_Export(t *testing.T) {
 	req.SetBasicAuth("admin", "password")
 	resp, err = client.Do(req)
 	require.NoError(t, err)
-	require.Equal(t, 200, resp.StatusCode)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.Equal(t, "application/gzip", resp.Header.Get("Content-Type"))
 
 	ungzReader, err := gzip.NewReader(resp.Body)
@@ -278,7 +278,7 @@ func TestMigrator_Export(t *testing.T) {
 	req.SetBasicAuth("admin", "password")
 	resp, err = client.Do(req)
 	require.NoError(t, err)
-	require.Equal(t, 200, resp.StatusCode)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.Equal(t, "text/plain; charset=utf-8", resp.Header.Get("Content-Type"))
 
 	body, err := io.ReadAll(resp.Body)
@@ -325,7 +325,7 @@ func TestMigrator_Remap(t *testing.T) {
 
 	// check that comments created as expected
 	res, code := get(t, ts.URL+"/api/v1/find?site=remark42&url=https://remark42.com/demo/")
-	require.Equal(t, 200, code)
+	require.Equal(t, http.StatusOK, code)
 	comments := commentsWithInfo{}
 	err = json.Unmarshal([]byte(res), &comments)
 	require.NoError(t, err)
@@ -333,7 +333,7 @@ func TestMigrator_Remap(t *testing.T) {
 	require.False(t, comments.Info.ReadOnly)
 
 	res, code = get(t, ts.URL+"/api/v1/find?site=remark42&url=https://remark42.com/demo-another/")
-	require.Equal(t, 200, code)
+	require.Equal(t, http.StatusOK, code)
 	comments = commentsWithInfo{}
 	err = json.Unmarshal([]byte(res), &comments)
 	require.NoError(t, err)
@@ -350,7 +350,7 @@ func TestMigrator_Remap(t *testing.T) {
 
 	// after remap finished we should find comments from new urls
 	res, code = get(t, ts.URL+"/api/v1/find?site=remark42&url=https://www.remark42.com/demo/")
-	require.Equal(t, 200, code)
+	require.Equal(t, http.StatusOK, code)
 	comments = commentsWithInfo{}
 	err = json.Unmarshal([]byte(res), &comments)
 	require.NoError(t, err)
@@ -358,7 +358,7 @@ func TestMigrator_Remap(t *testing.T) {
 	require.False(t, comments.Info.ReadOnly)
 
 	res, code = get(t, ts.URL+"/api/v1/find?site=remark42&url=https://www.remark42.com/demo-another/")
-	require.Equal(t, 200, code)
+	require.Equal(t, http.StatusOK, code)
 	comments = commentsWithInfo{}
 	err = json.Unmarshal([]byte(res), &comments)
 	require.NoError(t, err)
@@ -367,14 +367,14 @@ func TestMigrator_Remap(t *testing.T) {
 
 	// should find nothing from previous url
 	res, code = get(t, ts.URL+"/api/v1/find?site=remark42&url=https://remark42.com/demo/")
-	require.Equal(t, 200, code)
+	require.Equal(t, http.StatusOK, code)
 	comments = commentsWithInfo{}
 	err = json.Unmarshal([]byte(res), &comments)
 	require.NoError(t, err)
 	require.Equal(t, 0, comments.Info.Count)
 
 	res, code = get(t, ts.URL+"/api/v1/find?site=remark42&url=https://remark42.com/demo-another/")
-	require.Equal(t, 200, code)
+	require.Equal(t, http.StatusOK, code)
 	comments = commentsWithInfo{}
 	err = json.Unmarshal([]byte(res), &comments)
 	require.NoError(t, err)
@@ -403,7 +403,7 @@ func waitForMigrationCompletion(t *testing.T, ts *httptest.Server) {
 	req.SetBasicAuth("admin", "password")
 	resp, err := client.Do(req)
 	require.NoError(t, err)
-	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	b, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	defer resp.Body.Close()

--- a/backend/app/rest/api/rest.go
+++ b/backend/app/rest/api/rest.go
@@ -96,7 +96,6 @@ type commentsWithInfo struct {
 
 // Run the lister and request's router, activate rest server
 func (s *Rest) Run(address string, port int) {
-
 	if address == "*" {
 		address = ""
 	}
@@ -239,7 +238,6 @@ func (s *Rest) routes() chi.Router {
 
 	// api routes
 	router.Route("/api/v1", func(rapi chi.Router) {
-
 		rapi.Group(func(rava chi.Router) {
 			rava.Use(middleware.Timeout(5 * time.Second))
 			rava.Use(tollbooth_chi.LimitHandler(tollbooth.NewLimiter(100, nil)))
@@ -267,7 +265,6 @@ func (s *Rest) routes() chi.Router {
 				rrss.Get("/site", s.rssRest.siteCommentsCtrl)
 				rrss.Get("/reply", s.rssRest.repliesCtrl)
 			})
-
 		})
 
 		// open routes, cached
@@ -342,7 +339,6 @@ func (s *Rest) routes() chi.Router {
 			rauth.Use(logger.New(logger.Log(log.Default()), logger.Prefix("[DEBUG]"), logger.IPfn(ipFn)).Handler)
 			rauth.Post("/picture", s.privRest.savePictureCtrl)
 		})
-
 	})
 
 	// open routes on root level
@@ -361,7 +357,6 @@ func (s *Rest) routes() chi.Router {
 }
 
 func (s *Rest) controllerGroups() (public, private, admin, rss) {
-
 	pubGrp := public{
 		dataService:      s.DataService,
 		cache:            s.Cache,
@@ -472,7 +467,6 @@ func (s *Rest) configCtrl(w http.ResponseWriter, r *http.Request) {
 
 // serves static files from /web or embedded by statik
 func addFileServer(r chi.Router, path string, root http.FileSystem, version string) {
-
 	var webFS http.Handler
 
 	statikFS, err := fs.New()
@@ -597,7 +591,6 @@ func matchSiteID(next http.Handler) http.Handler {
 
 // cacheControl is a middleware setting cache expiration. Using url+version as etag
 func cacheControl(expiration time.Duration, version string) func(http.Handler) http.Handler {
-
 	etag := func(r *http.Request, version string) string {
 		s := version + ":" + r.URL.String()
 		return store.EncodeID(s)
@@ -677,7 +670,6 @@ func parseError(err error, defaultCode int) (code int) {
 		code = rest.ErrCommentEditExpired
 	case strings.HasPrefix(err.Error(), "parent comment with reply can't be edited"):
 		code = rest.ErrCommentEditChanged
-
 	}
 
 	return code

--- a/backend/app/rest/api/rest_private.go
+++ b/backend/app/rest/api/rest_private.go
@@ -106,7 +106,6 @@ func (s *private) previewCommentCtrl(w http.ResponseWriter, r *http.Request) {
 
 // POST /comment - adds comment, resets all immutable fields
 func (s *private) createCommentCtrl(w http.ResponseWriter, r *http.Request) {
-
 	comment := store.Comment{}
 	if err := render.DecodeJSON(http.MaxBytesReader(w, r.Body, hardBodyLimit), &comment); err != nil {
 		rest.SendErrorJSON(w, r, http.StatusBadRequest, err, "can't bind comment", rest.ErrDecode)
@@ -183,7 +182,6 @@ func (s *private) createCommentCtrl(w http.ResponseWriter, r *http.Request) {
 
 // PUT /comment/{id}?site=siteID&url=post-url - update comment
 func (s *private) updateCommentCtrl(w http.ResponseWriter, r *http.Request) {
-
 	edit := struct {
 		Text    string
 		Summary string
@@ -657,7 +655,6 @@ func (s *private) userAllDataCtrl(w http.ResponseWriter, r *http.Request) {
 		rest.SendErrorJSON(w, r, http.StatusInternalServerError, merr, "can't write user info", rest.ErrInternal)
 		return
 	}
-
 }
 
 // POST /deleteme?site_id=site - requesting delete of all user info

--- a/backend/app/rest/api/rest_public.go
+++ b/backend/app/rest/api/rest_public.go
@@ -174,7 +174,6 @@ func (s *public) lastCommentsCtrl(w http.ResponseWriter, r *http.Request) {
 
 // GET /id/{id}?site=siteID&url=post-url - gets a comment by id
 func (s *public) commentByIDCtrl(w http.ResponseWriter, r *http.Request) {
-
 	id := chi.URLParam(r, "id")
 	siteID := r.URL.Query().Get("site")
 	url := r.URL.Query().Get("url")
@@ -195,7 +194,6 @@ func (s *public) commentByIDCtrl(w http.ResponseWriter, r *http.Request) {
 
 // GET /comments?site=siteID&user=id&limit=123&skip=10 - returns comments for given userID
 func (s *public) findUserCommentsCtrl(w http.ResponseWriter, r *http.Request) {
-
 	userID := r.URL.Query().Get("user")
 	siteID := r.URL.Query().Get("site")
 
@@ -291,7 +289,6 @@ func (s *public) countMultiCtrl(w http.ResponseWriter, r *http.Request) {
 
 // GET /list?site=siteID&limit=50&skip=10 - list posts with comments
 func (s *public) listCtrl(w http.ResponseWriter, r *http.Request) {
-
 	siteID := r.URL.Query().Get("site")
 	limit, skip := 0, 0
 

--- a/backend/app/rest/api/rest_public_test.go
+++ b/backend/app/rest/api/rest_public_test.go
@@ -66,7 +66,7 @@ func TestRest_Preview(t *testing.T) {
 	resp, err = post(t, ts.URL+"/api/v1/preview", "bad")
 	assert.NoError(t, err)
 	assert.NoError(t, resp.Body.Close())
-	assert.Equal(t, 400, resp.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 	resp, err = post(t, ts.URL+"/api/v1/preview", fmt.Sprintf(`{"text": "![non-existent.jpg](%s/api/v1/picture/dev_user/bad_picture)", "locator":{"url": "https://radio-t.com/blah1", "site": "radio-t"}}`, srv.RemarkURL))
 	assert.NoError(t, err)
@@ -83,7 +83,6 @@ func TestRest_Preview(t *testing.T) {
 		string(b),
 		"/pics-remark42/staging/dev_user/62/bad_picture: no such file or directory\"}\n",
 	)
-
 }
 
 func TestRest_PreviewWithWrongImage(t *testing.T) {
@@ -168,7 +167,7 @@ func TestRest_Find(t *testing.T) {
 	defer teardown()
 
 	res, code := get(t, ts.URL+"/api/v1/find?site=remark42&url=https://radio-t.com/blah1")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	comments := commentsWithInfo{}
 	err := json.Unmarshal([]byte(res), &comments)
 	assert.NoError(t, err)
@@ -186,7 +185,7 @@ func TestRest_Find(t *testing.T) {
 
 	// get sorted by +time
 	res, code = get(t, ts.URL+"/api/v1/find?site=remark42&url=https://radio-t.com/blah1&sort=+time")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	comments = commentsWithInfo{}
 	err = json.Unmarshal([]byte(res), &comments)
 	assert.NoError(t, err)
@@ -202,7 +201,7 @@ func TestRest_Find(t *testing.T) {
 
 	// get sorted by -time
 	res, code = get(t, ts.URL+"/api/v1/find?site=remark42&url=https://radio-t.com/blah1&sort=-time")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	err = json.Unmarshal([]byte(res), &comments)
 	assert.NoError(t, err)
 	require.Equal(t, 2, len(comments.Comments), "should have 2 comments")
@@ -212,7 +211,7 @@ func TestRest_Find(t *testing.T) {
 	// get in tree mode
 	tree := service.Tree{}
 	res, code = get(t, ts.URL+"/api/v1/find?site=remark42&url=https://radio-t.com/blah1&format=tree")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	err = json.Unmarshal([]byte(res), &tree)
 	assert.NoError(t, err)
 	require.Equal(t, 1, len(tree.Nodes))
@@ -239,14 +238,14 @@ func TestRest_FindAge(t *testing.T) {
 	tree := service.Tree{}
 
 	res, code := get(t, ts.URL+"/api/v1/find?site=remark42&url=https://radio-t.com/blah1&format=tree")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	err = json.Unmarshal([]byte(res), &tree)
 	assert.NoError(t, err)
 	assert.Equal(t, "https://radio-t.com/blah1", tree.Info.URL)
 	assert.False(t, tree.Info.ReadOnly, "post is fresh")
 
 	res, code = get(t, ts.URL+"/api/v1/find?site=remark42&url=https://radio-t.com/blah2&format=tree")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	err = json.Unmarshal([]byte(res), &tree)
 	assert.NoError(t, err)
 	assert.Equal(t, "https://radio-t.com/blah2", tree.Info.URL)
@@ -280,7 +279,7 @@ func TestRest_FindReadOnly(t *testing.T) {
 
 	tree := service.Tree{}
 	res, code := get(t, ts.URL+"/api/v1/find?site=remark42&url=https://radio-t.com/blah1&format=tree")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	err = json.Unmarshal([]byte(res), &tree)
 	require.NoError(t, err)
 	assert.Equal(t, "https://radio-t.com/blah1", tree.Info.URL)
@@ -288,7 +287,7 @@ func TestRest_FindReadOnly(t *testing.T) {
 
 	tree = service.Tree{}
 	res, code = get(t, ts.URL+"/api/v1/find?site=remark42&url=https://radio-t.com/blah2&format=tree")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	err = json.Unmarshal([]byte(res), &tree)
 	require.NoError(t, err)
 	assert.Equal(t, "https://radio-t.com/blah2", tree.Info.URL)
@@ -300,7 +299,7 @@ func TestRest_FindUserView(t *testing.T) {
 	defer teardown()
 
 	res, code := get(t, ts.URL+"/api/v1/find?site=remark42&url=https://radio-t.com/blah1&view=user")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	comments := commentsWithInfo{}
 	err := json.Unmarshal([]byte(res), &comments)
 	assert.NoError(t, err)
@@ -318,7 +317,7 @@ func TestRest_FindUserView(t *testing.T) {
 
 	// get sorted by +time with view=user
 	res, code = get(t, ts.URL+"/api/v1/find?site=remark42&url=https://radio-t.com/blah1&sort=+time&view=user")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	comments = commentsWithInfo{}
 	err = json.Unmarshal([]byte(res), &comments)
 	assert.NoError(t, err)
@@ -335,7 +334,7 @@ func TestRest_FindUserView(t *testing.T) {
 	srv.Cache.Flush(cache.FlusherRequest{})
 
 	res, code = get(t, ts.URL+"/api/v1/find?site=remark42&url=https://radio-t.com/blah1&sort=+time&view=user")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	comments = commentsWithInfo{}
 	err = json.Unmarshal([]byte(res), &comments)
 	assert.NoError(t, err)
@@ -348,7 +347,7 @@ func TestRest_Last(t *testing.T) {
 	defer teardown()
 
 	res, code := get(t, ts.URL+"/api/v1/last/2?site=remark42")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	assert.Equal(t, "[]\n", res, "empty last should return empty list")
 
 	c1 := store.Comment{Text: "test test #1", ParentID: "p1",
@@ -365,7 +364,7 @@ func TestRest_Last(t *testing.T) {
 	id2 := addComment(t, c2, ts)
 
 	res, code = get(t, ts.URL+"/api/v1/last/2?site=remark42")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	comments := []store.Comment{}
 	err := json.Unmarshal([]byte(res), &comments)
 	assert.NoError(t, err)
@@ -374,7 +373,7 @@ func TestRest_Last(t *testing.T) {
 	assert.Equal(t, id2, comments[0].ID)
 
 	res, code = get(t, fmt.Sprintf("%s/api/v1/last/2?site=remark42&since=%d", ts.URL, ts1))
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	comments = []store.Comment{}
 	err = json.Unmarshal([]byte(res), &comments)
 	assert.NoError(t, err)
@@ -383,7 +382,7 @@ func TestRest_Last(t *testing.T) {
 	assert.Equal(t, id2, comments[0].ID)
 
 	res, code = get(t, fmt.Sprintf("%s/api/v1/last/2?site=remark42&since=%d", ts.URL, ts2))
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	comments = []store.Comment{}
 	err = json.Unmarshal([]byte(res), &comments)
 	assert.NoError(t, err)
@@ -391,13 +390,13 @@ func TestRest_Last(t *testing.T) {
 	assert.Equal(t, id2, comments[0].ID)
 
 	res, code = get(t, ts.URL+"/api/v1/last/5?site=remark42")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	err = json.Unmarshal([]byte(res), &comments)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(comments), "should have 3 comments")
 
 	res, code = get(t, ts.URL+"/api/v1/last/X?site=remark42")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	err = json.Unmarshal([]byte(res), &comments)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(comments), "should have 3 comments")
@@ -406,13 +405,13 @@ func TestRest_Last(t *testing.T) {
 	assert.NoError(t, err)
 	srv.Cache.Flush(cache.FlusherRequest{})
 	res, code = get(t, ts.URL+"/api/v1/last/5?site=remark42")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	err = json.Unmarshal([]byte(res), &comments)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(comments), "should have 2 comments")
 
 	_, code = get(t, ts.URL+"/api/v1/last/2?site=remark42-BLAH")
-	assert.Equal(t, 500, code)
+	assert.Equal(t, http.StatusInternalServerError, code)
 }
 
 func TestRest_FindUserComments(t *testing.T) {
@@ -437,11 +436,11 @@ func TestRest_FindUserComments(t *testing.T) {
 	assert.NoError(t, err)
 
 	comments, code := get(t, ts.URL+"/api/v1/comments?site=remark42&user=blah")
-	assert.Equal(t, 200, code, "noting for user blah")
+	assert.Equal(t, http.StatusOK, code, "noting for user blah")
 	assert.Equal(t, `{"comments":[],"count":0}`+"\n", comments)
 	{
 		res, code := get(t, ts.URL+"/api/v1/comments?site=remark42&user=dev")
-		assert.Equal(t, 200, code)
+		assert.Equal(t, http.StatusOK, code)
 
 		resp := struct {
 			Comments []store.Comment
@@ -460,7 +459,7 @@ func TestRest_FindUserComments(t *testing.T) {
 
 	{
 		res, code := get(t, ts.URL+"/api/v1/comments?site=remark42&user=dev&skip=1&limit=2")
-		assert.Equal(t, 200, code)
+		assert.Equal(t, http.StatusOK, code)
 
 		resp := struct {
 			Comments []store.Comment
@@ -482,7 +481,7 @@ func TestRest_UserInfo(t *testing.T) {
 	defer teardown()
 
 	body, code := getWithDevAuth(t, ts.URL+"/api/v1/user?site=remark42")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	user := store.User{}
 	err := json.Unmarshal([]byte(body), &user)
 	assert.NoError(t, err)
@@ -506,20 +505,20 @@ func TestRest_Count(t *testing.T) {
 	addComment(t, c2, ts)
 
 	body, code := get(t, ts.URL+"/api/v1/count?site=remark42&url=https://radio-t.com/blah1")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	j := R.JSON{}
 	err := json.Unmarshal([]byte(body), &j)
 	assert.NoError(t, err)
 	assert.Equal(t, 3.0, j["count"])
 
 	body, code = get(t, ts.URL+"/api/v1/count?site=remark42&url=https://radio-t.com/blah2")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	err = json.Unmarshal([]byte(body), &j)
 	assert.NoError(t, err)
 	assert.Equal(t, 2.0, j["count"])
 
 	_, code = get(t, ts.URL+"/api/v1/count?site=remark42-BLAH&url=https://radio-t.com/blah1XXX")
-	assert.Equal(t, 400, code)
+	assert.Equal(t, http.StatusBadRequest, code)
 }
 
 func TestRest_Counts(t *testing.T) {
@@ -553,7 +552,7 @@ func TestRest_Counts(t *testing.T) {
 
 	resp, err = post(t, ts.URL+"/api/v1/counts?site=radio-XXX", `{}`)
 	require.NoError(t, err)
-	assert.Equal(t, 400, resp.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	assert.NoError(t, resp.Body.Close())
 }
 
@@ -573,7 +572,7 @@ func TestRest_List(t *testing.T) {
 	addComment(t, c2, ts)
 
 	body, code := get(t, ts.URL+"/api/v1/list?site=remark42")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	pi := []store.PostInfo{}
 	err := json.Unmarshal([]byte(body), &pi)
 	assert.NoError(t, err)
@@ -583,7 +582,7 @@ func TestRest_List(t *testing.T) {
 	assert.Equal(t, 3, pi[1].Count)
 
 	_, code = get(t, ts.URL+"/api/v1/list?site=remark42-BLAH")
-	assert.Equal(t, 400, code)
+	assert.Equal(t, http.StatusBadRequest, code)
 }
 
 func TestRest_ListWithSkipAndLimit(t *testing.T) {
@@ -606,7 +605,7 @@ func TestRest_ListWithSkipAndLimit(t *testing.T) {
 	addComment(t, c3, ts)
 
 	body, code := get(t, ts.URL+"/api/v1/list?site=remark42&skip=1&limit=2")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	pi := []store.PostInfo{}
 	err := json.Unmarshal([]byte(body), &pi)
 	assert.NoError(t, err)
@@ -622,7 +621,7 @@ func TestRest_Config(t *testing.T) {
 	defer teardown()
 
 	body, code := get(t, ts.URL+"/api/v1/config?site=remark42")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	j := R.JSON{}
 	err := json.Unmarshal([]byte(body), &j)
 	assert.NoError(t, err)
@@ -645,17 +644,17 @@ func TestRest_QR(t *testing.T) {
 
 	// missing parameter
 	body, code := get(t, ts.URL+"/api/v1/qr/telegram")
-	assert.Equal(t, 400, code)
+	assert.Equal(t, http.StatusBadRequest, code)
 	assert.Equal(t, "{\"code\":0,\"details\":\"text parameter is required\",\"error\":\"missing parameter\"}\n", body)
 
 	// too long request to build the qr
 	body, code = get(t, ts.URL+"/api/v1/qr/telegram?url=https://t.me/"+strings.Repeat("string", 1000))
-	assert.Equal(t, 500, code)
+	assert.Equal(t, http.StatusInternalServerError, code)
 	assert.Equal(t, "{\"code\":0,\"details\":\"can't generate QR\",\"error\":\"content too long to encode\"}\n", body)
 
 	// wrong request
 	body, code = get(t, ts.URL+"/api/v1/qr/telegram?url=nonsense")
-	assert.Equal(t, 400, code)
+	assert.Equal(t, http.StatusBadRequest, code)
 	assert.Equal(t, "{\"code\":0,\"details\":\"text parameter should start with https://t.me/\",\"error\":\"wrong parameter\"}\n", body)
 
 	// correct request
@@ -666,7 +665,7 @@ func TestRest_QR(t *testing.T) {
 	require.NoError(t, r.Body.Close())
 	require.NotEmpty(t, bdy)
 	assert.Equal(t, "image/png", r.Header.Get("Content-Type"))
-	assert.Equal(t, 200, r.StatusCode)
+	assert.Equal(t, http.StatusOK, r.StatusCode)
 
 	// compare the image
 	fh, err := os.Open("testdata/qr_test.png")
@@ -699,7 +698,7 @@ func TestRest_Info(t *testing.T) {
 	require.NoError(t, err)
 
 	body, code := get(t, ts.URL+"/api/v1/info?site=remark42&url=https://radio-t.com/blah1")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 
 	info := store.PostInfo{}
 	err = json.Unmarshal([]byte(body), &info)
@@ -709,9 +708,9 @@ func TestRest_Info(t *testing.T) {
 	assert.Equal(t, exp, info)
 
 	_, code = get(t, ts.URL+"/api/v1/info?site=remark42&url=https://radio-t.com/blah-no")
-	assert.Equal(t, 400, code)
+	assert.Equal(t, http.StatusBadRequest, code)
 	_, code = get(t, ts.URL+"/api/v1/info?site=remark42-no&url=https://radio-t.com/blah-no")
-	assert.Equal(t, 400, code)
+	assert.Equal(t, http.StatusBadRequest, code)
 }
 
 func TestRest_Robots(t *testing.T) {
@@ -719,7 +718,7 @@ func TestRest_Robots(t *testing.T) {
 	defer teardown()
 
 	body, code := get(t, ts.URL+"/robots.txt")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	assert.Equal(t, "User-agent: *\nDisallow: /auth/\nDisallow: /api/\nAllow: /api/v1/find\n"+
 		"Allow: /api/v1/last\nAllow: /api/v1/id\nAllow: /api/v1/count\nAllow: /api/v1/counts\n"+
 		"Allow: /api/v1/list\nAllow: /api/v1/config\nAllow: /api/v1/user\nAllow: /api/v1/img\n"+

--- a/backend/app/rest/api/rss.go
+++ b/backend/app/rest/api/rss.go
@@ -102,7 +102,6 @@ func (s *rss) repliesCtrl(w http.ResponseWriter, r *http.Request) {
 
 	key := cache.NewKey(siteID).ID(URLKey(r)).Scopes(siteID, lastCommentsScope)
 	data, err := s.cache.Get(key, func() (res []byte, e error) {
-
 		replies, userName, e := s.dataService.UserReplies(siteID, userID, maxRssItems, maxReplyDuration)
 		if e != nil {
 			return nil, errors.Wrap(e, "can't get last comments")
@@ -128,7 +127,6 @@ func (s *rss) repliesCtrl(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *rss) toRssFeed(url string, comments []store.Comment, description string) (string, error) {
-
 	if description == "" {
 		description = "comment updates"
 	}

--- a/backend/app/rest/api/rss_test.go
+++ b/backend/app/rest/api/rss_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"net/http"
 	"regexp"
 	"strings"
 	"testing"
@@ -31,7 +32,7 @@ func TestServer_RssPost(t *testing.T) {
 	pubDate := time.Now().Format(time.RFC1123Z)
 
 	res, code := get(t, ts.URL+"/api/v1/rss/post?site=remark42&url=https://radio-t.com/blah1")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	t.Log(res)
 
 	expected := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
@@ -55,7 +56,7 @@ func TestServer_RssPost(t *testing.T) {
 	assert.Equal(t, expected, res)
 
 	_, code = get(t, ts.URL+"/api/v1/rss/post?site=remark42-bad&url=https://radio-t.com/blah1")
-	assert.Equal(t, 400, code)
+	assert.Equal(t, http.StatusBadRequest, code)
 }
 
 func TestServer_RssSite(t *testing.T) {
@@ -86,7 +87,7 @@ func TestServer_RssSite(t *testing.T) {
 
 	require.NoError(t, err)
 	res, code := get(t, ts.URL+"/api/v1/rss/site?site=remark42")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	t.Log(res)
 
 	expected := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
@@ -118,7 +119,7 @@ func TestServer_RssSite(t *testing.T) {
 	assert.Equal(t, expected, res)
 
 	_, code = get(t, ts.URL+"/api/v1/rss/site?site=bad-radio-t")
-	assert.Equal(t, 400, code)
+	assert.Equal(t, http.StatusBadRequest, code)
 }
 
 func TestServer_RssWithReply(t *testing.T) {
@@ -149,7 +150,7 @@ func TestServer_RssWithReply(t *testing.T) {
 	require.NoError(t, err)
 
 	res, code := get(t, ts.URL+"/api/v1/rss/post?site=remark42&url=https://radio-t.com/blah10")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	t.Log(res)
 
 	expected := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
@@ -236,7 +237,7 @@ func TestServer_RssReplies(t *testing.T) {
 
 	// replies to c1 (user1). Must be [c3, c2]
 	res, code := get(t, ts.URL+"/api/v1/rss/reply?user=user1&site=remark42")
-	assert.Equal(t, 200, code)
+	assert.Equal(t, http.StatusOK, code)
 	t.Log(res)
 	expected := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
 	    <channel>
@@ -266,7 +267,7 @@ func TestServer_RssReplies(t *testing.T) {
 	assert.Equal(t, expected, res)
 
 	_, code = get(t, ts.URL+"/api/v1/rss/reply?user=user1&site=remark42-bad")
-	assert.Equal(t, 400, code)
+	assert.Equal(t, http.StatusBadRequest, code)
 }
 
 func waitOnSecChange() {

--- a/backend/app/rest/api/ssl_test.go
+++ b/backend/app/rest/api/ssl_test.go
@@ -35,7 +35,7 @@ func TestSSL_Redirect(t *testing.T) {
 	resp, err := client.Get(ts.URL + "/blah?param=1")
 	require.NoError(t, err)
 	defer resp.Body.Close()
-	assert.Equal(t, 307, resp.StatusCode)
+	assert.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
 	assert.Equal(t, "https://localhost:443/blah?param=1", resp.Header.Get("Location"))
 }
 
@@ -64,7 +64,7 @@ func TestSSL_ACME_HTTPChallengeRouter(t *testing.T) {
 	resp, err := client.Get(ts.URL + "/blah?param=1")
 	require.NoError(t, err)
 	defer resp.Body.Close()
-	assert.Equal(t, 307, resp.StatusCode)
+	assert.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
 	assert.Equal(t, "https://localhost:443/blah?param=1", resp.Header.Get("Location"))
 
 	// check acme http challenge
@@ -74,7 +74,7 @@ func TestSSL_ACME_HTTPChallengeRouter(t *testing.T) {
 	resp, err = client.Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
-	assert.Equal(t, 404, resp.StatusCode)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 
 	err = m.Cache.Put(context.Background(), "token123+http-01", []byte("token"))
 	assert.NoError(t, err)
@@ -82,7 +82,7 @@ func TestSSL_ACME_HTTPChallengeRouter(t *testing.T) {
 	resp, err = client.Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
-	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	assert.Equal(t, "token", string(body))

--- a/backend/app/rest/httperrors_test.go
+++ b/backend/app/rest/httperrors_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestSendErrorJSON(t *testing.T) {
-
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/error" {
 			t.Log("http err request", r.URL)
@@ -33,7 +32,7 @@ func TestSendErrorJSON(t *testing.T) {
 
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
-	assert.Equal(t, 500, resp.StatusCode)
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
 
 	assert.Equal(t, `{"code":123,"details":"error details 123456","error":"error 500"}`+"\n", string(body))
 }
@@ -63,7 +62,7 @@ func TestSendErrorHTML(t *testing.T) {
 
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
-	assert.Equal(t, 500, resp.StatusCode)
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
 
 	assert.NotContains(t, string(body), `987`, "user html should not contain internal error code")
 	assert.Contains(t, string(body), `error details 123456`)

--- a/backend/app/rest/user.go
+++ b/backend/app/rest/user.go
@@ -21,7 +21,6 @@ func MustGetUserInfo(r *http.Request) store.User {
 
 // GetUserInfo returns user from request context
 func GetUserInfo(r *http.Request) (user store.User, err error) {
-
 	u, err := token.GetUserInfo(r)
 	if err != nil {
 		return store.User{}, errors.Wrap(err, "can't extract user info from the token")

--- a/backend/app/store/comment_test.go
+++ b/backend/app/store/comment_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestComment_Sanitize(t *testing.T) {
-
 	tbl := []struct {
 		inp Comment
 		out Comment
@@ -114,7 +113,6 @@ func TestComment_PrepareUntrusted(t *testing.T) {
 	assert.Equal(t, User{ID: "username"}, comment.User)
 	assert.Equal(t, 0., comment.Controversy)
 	assert.Equal(t, false, comment.Imported)
-
 }
 
 func TestComment_SetDeleted(t *testing.T) {
@@ -195,7 +193,6 @@ func TestComment_Snippet(t *testing.T) {
 }
 
 func TestComment_sanitizeAsURL(t *testing.T) {
-
 	tbl := []struct {
 		inp, out string
 	}{
@@ -231,7 +228,6 @@ func TestComment_sanitizeAsURL(t *testing.T) {
 }
 
 func TestComment_sanitizeText(t *testing.T) {
-
 	tbl := []struct {
 		inp, out string
 	}{
@@ -260,5 +256,4 @@ func TestComment_sanitizeText(t *testing.T) {
 			assert.Equal(t, tt.out, c.SanitizeText(tt.inp))
 		})
 	}
-
 }

--- a/backend/app/store/engine/bolt_test.go
+++ b/backend/app/store/engine/bolt_test.go
@@ -416,7 +416,6 @@ func TestBoltDB_InfoList(t *testing.T) {
 }
 
 func TestBolt_FlagBlockedUser(t *testing.T) {
-
 	b, teardown := prep(t)
 	defer teardown()
 
@@ -461,7 +460,6 @@ func TestBolt_FlagBlockedUser(t *testing.T) {
 }
 
 func TestBolt_FlagReadOnlyPost(t *testing.T) {
-
 	b, teardown := prep(t)
 	defer teardown()
 
@@ -503,7 +501,6 @@ func TestBolt_FlagReadOnlyPost(t *testing.T) {
 }
 
 func TestBolt_FlagVerified(t *testing.T) {
-
 	b, teardown := prep(t)
 	defer teardown()
 
@@ -540,7 +537,6 @@ func TestBolt_FlagVerified(t *testing.T) {
 }
 
 func TestBolt_FlagListVerified(t *testing.T) {
-
 	b, teardown := prep(t)
 	defer teardown()
 
@@ -575,7 +571,6 @@ func TestBolt_FlagListVerified(t *testing.T) {
 }
 
 func TestBolt_FlagListBlocked(t *testing.T) {
-
 	b, teardown := prep(t)
 	defer teardown()
 
@@ -617,11 +612,9 @@ func TestBolt_FlagListBlocked(t *testing.T) {
 
 	_, err = b.ListFlags(FlagRequest{Flag: Blocked, Locator: store.Locator{SiteID: "bad"}})
 	assert.EqualError(t, err, `site "bad" not found`)
-
 }
 
 func TestBoltDB_UserDetail(t *testing.T) {
-
 	b, teardown := prep(t)
 	defer teardown()
 
@@ -672,7 +665,6 @@ func TestBoltDB_UserDetail(t *testing.T) {
 }
 
 func TestBolt_DeleteComment(t *testing.T) {
-
 	b, teardown := prep(t)
 	defer teardown()
 
@@ -728,7 +720,6 @@ func TestBolt_DeleteComment(t *testing.T) {
 }
 
 func TestBolt_DeleteHard(t *testing.T) {
-
 	b, teardown := prep(t)
 	defer teardown()
 
@@ -751,7 +742,6 @@ func TestBolt_DeleteHard(t *testing.T) {
 }
 
 func TestBolt_DeleteAll(t *testing.T) {
-
 	b, teardown := prep(t)
 	defer teardown()
 
@@ -811,7 +801,6 @@ func TestBolt_DeleteUserDetail(t *testing.T) {
 }
 
 func TestBoltAdmin_DeleteUserHard(t *testing.T) {
-
 	b, teardown := prep(t)
 	defer teardown()
 
@@ -852,7 +841,6 @@ func TestBoltAdmin_DeleteUserHard(t *testing.T) {
 }
 
 func TestBoltAdmin_DeleteUserSoft(t *testing.T) {
-
 	b, teardown := prep(t)
 	defer teardown()
 

--- a/backend/app/store/engine/remote.go
+++ b/backend/app/store/engine/remote.go
@@ -15,7 +15,6 @@ type RPC struct {
 
 // Create comment and return ID
 func (r *RPC) Create(comment store.Comment) (commentID string, err error) {
-
 	resp, err := r.Call("store.create", comment)
 	if err != nil {
 		return "", err

--- a/backend/app/store/engine/remote_test.go
+++ b/backend/app/store/engine/remote_test.go
@@ -95,7 +95,6 @@ func TestRemote_Update(t *testing.T) {
 	err := c.Update(store.Comment{ID: "123", Locator: store.Locator{URL: "http://example.com/url", SiteID: "site123"},
 		Text: "msg"})
 	assert.NoError(t, err)
-
 }
 
 func TestRemote_Find(t *testing.T) {

--- a/backend/app/store/formatter_test.go
+++ b/backend/app/store/formatter_test.go
@@ -122,7 +122,6 @@ func TestFormatter_ShortenAutoLinks(t *testing.T) {
 }
 
 func TestCommentFormatter_lazyImage(t *testing.T) {
-
 	tbl := []struct {
 		inp, out string
 	}{
@@ -139,5 +138,4 @@ func TestCommentFormatter_lazyImage(t *testing.T) {
 			assert.Equal(t, tt.out, f.lazyImage(tt.inp))
 		})
 	}
-
 }

--- a/backend/app/store/image/bolt_store_test.go
+++ b/backend/app/store/image/bolt_store_test.go
@@ -40,7 +40,6 @@ func TestBoltStore_SaveCommit(t *testing.T) {
 		return nil
 	})
 	assert.NoError(t, err)
-
 }
 
 func TestBoltStore_LoadAfterSave(t *testing.T) {

--- a/backend/app/store/image/fs_store.go
+++ b/backend/app/store/image/fs_store.go
@@ -78,7 +78,6 @@ func (f *FileSystem) ResetCleanupTimer(id string) error {
 
 // Load image from FS. Uses id to get partition subdirectory.
 func (f *FileSystem) Load(id string) ([]byte, error) {
-
 	// get image file by id. first try permanent location and if not found - staging
 	img := func(id string) (file string, err error) {
 		file = f.location(f.Location, id)
@@ -104,7 +103,6 @@ func (f *FileSystem) Load(id string) ([]byte, error) {
 
 // Cleanup runs scan of staging and removes old files based on ttl
 func (f *FileSystem) Cleanup(_ context.Context, ttl time.Duration) error {
-
 	if _, err := os.Stat(f.Staging); os.IsNotExist(err) {
 		return nil
 	}
@@ -161,7 +159,6 @@ func (f *FileSystem) Info() (StoreInfo, error) {
 // the end result is a full path like this - /tmp/images/user1/92/xxx-yyy.png.
 // Number of partitions defined by FileSystem.Partitions
 func (f *FileSystem) location(base, id string) string {
-
 	partition := func(id string) string {
 		f.crc.Do(func() {
 			f.crc.Table = crc64.MakeTable(crc64.ECMA)

--- a/backend/app/store/image/fs_store_test.go
+++ b/backend/app/store/image/fs_store_test.go
@@ -100,7 +100,6 @@ func TestFsStore_SaveAndCommit(t *testing.T) {
 }
 
 func TestFsStore_LoadAfterSave(t *testing.T) {
-
 	svc, teardown := prepareImageTest(t)
 	defer teardown()
 
@@ -117,7 +116,6 @@ func TestFsStore_LoadAfterSave(t *testing.T) {
 }
 
 func TestFsStore_LoadAfterCommit(t *testing.T) {
-
 	svc, teardown := prepareImageTest(t)
 	defer teardown()
 

--- a/backend/app/store/image/image.go
+++ b/backend/app/store/image/image.go
@@ -144,7 +144,6 @@ func (s *Service) Submit(idsFn func() []string) {
 
 // ExtractPictures gets list of images from the doc html and convert from urls to ids, i.e. user/pic.png
 func (s *Service) ExtractPictures(commentHTML string) (ids []string) {
-
 	doc, err := goquery.NewDocumentFromReader(strings.NewReader(commentHTML))
 	if err != nil {
 		log.Printf("[ERROR] can't parse commentHTML to parse images: %q, error: %v", commentHTML, err)
@@ -313,7 +312,6 @@ func resize(data []byte, limitW, limitH int) []byte {
 
 // getProportionalSizes returns width and height resized by both dimensions proportionally
 func getProportionalSizes(srcW, srcH, limitW, limitH int) (resW, resH int) {
-
 	if srcW <= limitW && srcH <= limitH {
 		return srcW, srcH
 	}
@@ -333,7 +331,6 @@ func getProportionalSizes(srcW, srcH, limitW, limitH int) (resW, resH int) {
 
 // check if file f is a valid image format, i.e. gif, png, jpeg or webp and reads up to maxSize.
 func readAndValidateImage(r io.Reader, maxSize int) ([]byte, error) {
-
 	isValidImage := func(b []byte) bool {
 		ct := http.DetectContentType(b)
 		return ct == "image/gif" || ct == "image/png" || ct == "image/jpeg" || ct == "image/webp"

--- a/backend/app/store/image/image_test.go
+++ b/backend/app/store/image/image_test.go
@@ -226,7 +226,6 @@ func TestService_resize(t *testing.T) {
 		assert.Equal(t, c.wr, bounds.Dx(), "file %s", c.file)
 		assert.Equal(t, c.hr, bounds.Dy(), "file %s", c.file)
 	}
-
 }
 
 func TestGetProportionalSizes(t *testing.T) {

--- a/backend/app/store/service/restricted_words_test.go
+++ b/backend/app/store/service/restricted_words_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestMatcher_Tokenize(t *testing.T) {
-
 	matcher := NewRestrictedWordsMatcher(StaticRestrictedWordsLister{})
 
 	tbl := []struct {
@@ -32,7 +31,6 @@ func TestMatcher_Tokenize(t *testing.T) {
 }
 
 func TestWildcardTrie_Check(t *testing.T) {
-
 	tbl := []struct {
 		input   []string
 		match   []string

--- a/backend/app/store/service/service.go
+++ b/backend/app/store/service/service.go
@@ -81,7 +81,6 @@ var ErrRestrictedWordsFound = errors.New("comment contains restricted words")
 
 // Create prepares comment and forward to Interface.Create
 func (s *DataStore) Create(comment store.Comment) (commentID string, err error) {
-
 	if comment, err = s.prepareNewComment(comment); err != nil {
 		return "", errors.Wrap(err, "failed to prepare comment")
 	}
@@ -338,7 +337,6 @@ type VoteReq struct {
 
 // Vote for comment by id and locator
 func (s *DataStore) Vote(req VoteReq) (comment store.Comment, err error) {
-
 	cLock := s.getScopedLocks(req.Locator.URL) // get lock for URL scope
 	cLock.Lock()                               // prevents race on voting
 	defer cLock.Unlock()
@@ -444,7 +442,6 @@ func (s *DataStore) isSameIPVote(req VoteReq, userIPHash string, comment store.C
 // controversy calculates controversial index of votes
 // source - https://github.com/reddit-archive/reddit/blob/master/r2/r2/lib/db/_sorts.pyx#L60
 func (s *DataStore) controversy(ups, downs int) float64 {
-
 	if downs <= 0 || ups <= 0 {
 		return 0
 	}
@@ -468,7 +465,6 @@ type EditRequest struct {
 
 // EditComment to edit text and update Edit info
 func (s *DataStore) EditComment(locator store.Locator, commentID string, req EditRequest) (comment store.Comment, err error) {
-
 	editAllowed := func(comment store.Comment) error {
 		if req.Admin && s.AdminEdits {
 			return nil
@@ -525,7 +521,6 @@ func (s *DataStore) EditComment(locator store.Locator, commentID string, req Edi
 // Loads last maxLastCommentsReply comments and compare parent id to the comment's id
 // Comments with replies cached for 5 minutes
 func (s *DataStore) HasReplies(comment store.Comment) bool {
-
 	s.repliesCache.once.Do(func() {
 		// default expiration time of 5 minutes and cleanup time of 2.5 minutes
 		s.repliesCache.LoadingCache, _ = lcw.NewExpirableCache(lcw.TTL(5 * time.Minute))
@@ -558,7 +553,6 @@ func (s *DataStore) HasReplies(comment store.Comment) bool {
 
 // UserReplies returns list of all comments replied to given user
 func (s *DataStore) UserReplies(siteID, userID string, limit int, duration time.Duration) ([]store.Comment, string, error) {
-
 	comments, e := s.Last(siteID, maxLastCommentsReply, time.Time{}, nonAdminUser)
 	if e != nil {
 		return nil, "", errors.Wrap(e, "can't get last comments")
@@ -573,7 +567,6 @@ func (s *DataStore) UserReplies(siteID, userID string, limit int, duration time.
 
 	// collect replies
 	for _, c := range comments {
-
 		if len(replies) > limit || time.Since(c.Timestamp) > duration {
 			break
 		}
@@ -671,7 +664,6 @@ func (s *DataStore) SetReadOnly(locator store.Locator, status bool) error {
 	roStatus := engine.FlagFalse
 	if status {
 		roStatus = engine.FlagTrue
-
 	}
 	req := engine.FlagRequest{Locator: locator, Flag: engine.ReadOnly, Update: roStatus}
 	_, err := s.Engine.Flag(req)
@@ -944,7 +936,6 @@ func (s *DataStore) alterComments(cc []store.Comment, user store.User) (res []st
 }
 
 func (s *DataStore) alterComment(c store.Comment, user store.User) (res store.Comment) {
-
 	blocReq := engine.FlagRequest{Flag: engine.Blocked, Locator: store.Locator{SiteID: c.Locator.SiteID}, UserID: c.User.ID}
 	blocked, bErr := s.Engine.Flag(blocReq)
 
@@ -972,7 +963,6 @@ func (s *DataStore) alterComment(c store.Comment, user store.User) (res store.Co
 
 // prepare vote info for client view
 func (s *DataStore) prepVotes(c store.Comment, user store.User) store.Comment {
-
 	c.Vote = 0 // default is "none" (not voted)
 
 	if v, ok := c.Votes[user.ID]; ok {
@@ -991,7 +981,6 @@ func (s *DataStore) prepVotes(c store.Comment, user store.User) store.Comment {
 // get secret for given siteID
 // Note: secret shared across sites, but some sites can be disabled.
 func (s *DataStore) getSecret(siteID string) (secret string, err error) {
-
 	if secret, err = s.AdminStore.Key("any"); err != nil {
 		return "", errors.Wrapf(err, "can't get secret for site %s", siteID)
 	}

--- a/backend/app/store/service/service_test.go
+++ b/backend/app/store/service/service_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 func TestService_CreateFromEmpty(t *testing.T) {
-
 	ks := admin.NewStaticKeyStore("secret 123")
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
@@ -56,7 +55,6 @@ func TestService_CreateFromEmpty(t *testing.T) {
 }
 
 func TestService_CreateSiteDisabled(t *testing.T) {
-
 	ks := admin.NewStaticStore("secret 123", []string{"xxx"}, nil, "email")
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
@@ -71,7 +69,6 @@ func TestService_CreateSiteDisabled(t *testing.T) {
 }
 
 func TestService_CreateFromPartial(t *testing.T) {
-
 	ks := admin.NewStaticKeyStore("secret 123")
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
@@ -147,7 +144,6 @@ func TestService_CreateFromPartialWithTitle(t *testing.T) {
 }
 
 func TestService_SetTitle(t *testing.T) {
-
 	var titleEnable int32
 	tss := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if atomic.LoadInt32(&titleEnable) == 0 {
@@ -204,7 +200,6 @@ func TestService_SetTitle(t *testing.T) {
 }
 
 func TestService_Vote(t *testing.T) {
-
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
 	b := DataStore{Engine: eng, AdminStore: admin.NewStaticKeyStore("secret 123"), MaxVotes: -1}
@@ -311,7 +306,6 @@ func TestService_Vote(t *testing.T) {
 }
 
 func TestService_VoteLimit(t *testing.T) {
-
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
 	b := DataStore{Engine: eng, AdminStore: admin.NewStaticKeyStore("secret 123"), MaxVotes: 2}
@@ -335,7 +329,6 @@ func TestService_VoteLimit(t *testing.T) {
 }
 
 func TestService_VotesDisabled(t *testing.T) {
-
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
 	b := DataStore{Engine: eng, AdminStore: admin.NewStaticKeyStore("secret 123"), MaxVotes: 0}
@@ -346,7 +339,6 @@ func TestService_VotesDisabled(t *testing.T) {
 }
 
 func TestService_VoteAggressive(t *testing.T) {
-
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
 	b := DataStore{Engine: eng, AdminStore: admin.NewStaticKeyStore("secret 123"), MaxVotes: -1}
@@ -412,7 +404,6 @@ func TestService_VoteAggressive(t *testing.T) {
 }
 
 func TestService_VoteConcurrent(t *testing.T) {
-
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
 	b := DataStore{Engine: eng, AdminStore: admin.NewStaticKeyStore("secret 123"), MaxVotes: -1}
@@ -448,7 +439,6 @@ func TestService_VoteConcurrent(t *testing.T) {
 }
 
 func TestService_VotePositive(t *testing.T) {
-
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
 	b := DataStore{Engine: eng, AdminStore: admin.NewStaticKeyStore("secret 123"),
@@ -496,11 +486,9 @@ func TestService_VotePositive(t *testing.T) {
 		UserID: "user4", Val: false})
 	assert.NoError(t, err, "minimal score ignored")
 	assert.Equal(t, -1, c.Score)
-
 }
 
 func TestService_VoteControversy(t *testing.T) {
-
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
 	b := DataStore{Engine: eng, AdminStore: admin.NewStaticKeyStore("secret 123"), MaxVotes: -1}
@@ -531,7 +519,6 @@ func TestService_VoteControversy(t *testing.T) {
 }
 
 func TestService_VoteSameIP(t *testing.T) {
-
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
 	b := DataStore{Engine: eng, AdminStore: admin.NewStaticKeyStore("secret 123"), MaxVotes: -1}
@@ -559,7 +546,6 @@ func TestService_VoteSameIP(t *testing.T) {
 }
 
 func TestService_VoteSameIPWithDuration(t *testing.T) {
-
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
 	b := DataStore{Engine: eng, AdminStore: admin.NewStaticKeyStore("secret 123"),
@@ -616,7 +602,6 @@ func TestService_Controversy(t *testing.T) {
 }
 
 func TestService_Pin(t *testing.T) {
-
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
 	b := DataStore{Engine: eng, AdminStore: admin.NewStaticKeyStore("secret 123")}
@@ -642,7 +627,6 @@ func TestService_Pin(t *testing.T) {
 }
 
 func TestService_EditComment(t *testing.T) {
-
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
 	b := DataStore{Engine: eng, AdminStore: admin.NewStaticKeyStore("secret 123")}
@@ -672,7 +656,6 @@ func TestService_EditComment(t *testing.T) {
 }
 
 func TestService_DeleteComment(t *testing.T) {
-
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
 	b := DataStore{Engine: eng, AdminStore: admin.NewStaticKeyStore("secret 123")}
@@ -694,7 +677,6 @@ func TestService_DeleteComment(t *testing.T) {
 }
 
 func TestService_EditCommentDurationFailed(t *testing.T) {
-
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
 	b := DataStore{Engine: eng, EditDuration: 100 * time.Millisecond,
@@ -714,7 +696,6 @@ func TestService_EditCommentDurationFailed(t *testing.T) {
 }
 
 func TestService_EditCommentReplyFailed(t *testing.T) {
-
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
 	b := DataStore{Engine: eng, AdminStore: admin.NewStaticKeyStore("secret 123")}
@@ -766,7 +747,6 @@ func TestService_EditCommentAdmin(t *testing.T) {
 }
 
 func TestService_ValidateComment(t *testing.T) {
-
 	b := DataStore{MaxCommentSize: 2000, AdminStore: admin.NewStaticKeyStore("secret 123")}
 	longText := fmt.Sprintf("%4000s", "X")
 
@@ -792,7 +772,6 @@ func TestService_ValidateComment(t *testing.T) {
 }
 
 func TestService_Counts(t *testing.T) {
-
 	b, teardown := prepStoreEngine(t) // two comments for https://radio-t.com
 	defer teardown()
 
@@ -822,7 +801,6 @@ func TestService_Counts(t *testing.T) {
 }
 
 func TestService_GetMetas(t *testing.T) {
-
 	// two comments for https://radio-t.com
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
@@ -869,7 +847,6 @@ func TestService_GetMetas(t *testing.T) {
 }
 
 func TestService_SetMetas(t *testing.T) {
-
 	// two comments for https://radio-t.com
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
@@ -898,7 +875,6 @@ func TestService_SetMetas(t *testing.T) {
 }
 
 func TestService_UserDetailsOperations(t *testing.T) {
-
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
 	b := DataStore{Engine: eng, EditDuration: 100 * time.Millisecond,
@@ -952,7 +928,6 @@ func TestService_UserDetailsOperations(t *testing.T) {
 }
 
 func TestService_IsAdmin(t *testing.T) {
-
 	// two comments for https://radio-t.com
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
@@ -965,7 +940,6 @@ func TestService_IsAdmin(t *testing.T) {
 }
 
 func TestService_HasReplies(t *testing.T) {
-
 	// two comments for https://radio-t.com, no reply
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
@@ -997,7 +971,6 @@ func TestService_HasReplies(t *testing.T) {
 }
 
 func TestService_UserReplies(t *testing.T) {
-
 	// two comments for https://radio-t.com, no reply
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
@@ -1079,11 +1052,9 @@ func TestService_UserReplies(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(cc), "0 replies to uxxx")
 	assert.Equal(t, "", u)
-
 }
 
 func TestService_Find(t *testing.T) {
-
 	// two comments for https://radio-t.com, no reply
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
@@ -1141,7 +1112,6 @@ func TestService_FindSince(t *testing.T) {
 }
 
 func TestService_Info(t *testing.T) {
-
 	// two comments for https://radio-t.com, no reply
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
@@ -1163,7 +1133,6 @@ func TestService_Info(t *testing.T) {
 }
 
 func TestService_Delete(t *testing.T) {
-
 	// two comments for https://radio-t.com, no reply
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
@@ -1184,7 +1153,6 @@ func TestService_Delete(t *testing.T) {
 
 // DeleteUser removes all comments from user
 func TestService_DeleteUser(t *testing.T) {
-
 	// two comments for https://radio-t.com, no reply
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
@@ -1216,7 +1184,6 @@ func TestService_DeleteUser(t *testing.T) {
 }
 
 func TestService_List(t *testing.T) {
-
 	// two comments for https://radio-t.com, no reply
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
@@ -1249,7 +1216,6 @@ func TestService_List(t *testing.T) {
 }
 
 func TestService_Count(t *testing.T) {
-
 	// two comments for https://radio-t.com, no reply
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
@@ -1281,7 +1247,6 @@ func TestService_Count(t *testing.T) {
 }
 
 func TestService_UserComments(t *testing.T) {
-
 	// two comments for https://radio-t.com, no reply
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
@@ -1307,7 +1272,6 @@ func TestService_UserComments(t *testing.T) {
 }
 
 func TestService_UserCount(t *testing.T) {
-
 	// two comments for https://radio-t.com, no reply
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
@@ -1338,7 +1302,6 @@ func TestService_UserCount(t *testing.T) {
 }
 
 func TestService_DeleteAll(t *testing.T) {
-
 	// two comments for https://radio-t.com, no reply
 	eng, teardown := prepStoreEngine(t)
 	defer teardown()
@@ -1365,7 +1328,6 @@ func TestService_DeleteAll(t *testing.T) {
 }
 
 func TestService_submitImages(t *testing.T) {
-
 	lgr.Setup(lgr.Debug, lgr.CallerFile, lgr.CallerFunc)
 
 	mockStore := image.MockStore{}
@@ -1510,7 +1472,6 @@ func TestService_ResubmitStagingImages_EngineError(t *testing.T) {
 }
 
 func TestService_alterComment(t *testing.T) {
-
 	engineMock := engine.MockInterface{}
 	engineMock.On("Flag", engine.FlagRequest{Flag: engine.Blocked, UserID: "devid"}).Return(false, nil)
 	engineMock.On("Flag", engine.FlagRequest{Flag: engine.Verified, UserID: "devid"}).Return(false, nil)

--- a/backend/app/store/service/title_test.go
+++ b/backend/app/store/service/title_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func TestTitle_GetTitle(t *testing.T) {
-
 	tbl := []struct {
 		page  string
 		ok    bool

--- a/backend/app/store/service/tree.go
+++ b/backend/app/store/service/tree.go
@@ -80,7 +80,6 @@ func MakeTree(comments []store.Comment, sortType string, readOnlyAge int) *Tree 
 
 // proc makes tree for one top-level comment recursively
 func (t *Tree) proc(comments []store.Comment, node *Node, rd *recurData, parentID string) (result *Node, modified, created time.Time) {
-
 	if rd.tsModified.IsZero() || rd.tsCreated.IsZero() {
 		rd.tsModified, rd.tsCreated = node.Comment.Timestamp, node.Comment.Timestamp
 	}
@@ -124,7 +123,6 @@ func (t *Tree) filter(comments []store.Comment, fn func(comment store.Comment) b
 // sort list of nodes, i.e. top-level comments
 // time sort uses tsModified from latest reply
 func (t *Tree) sortNodes(sortType string) {
-
 	sort.Slice(t.Nodes, func(i, j int) bool {
 		switch sortType {
 		case "+time", "-time", "time":

--- a/backend/app/store/service/tree_test.go
+++ b/backend/app/store/service/tree_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestMakeTree(t *testing.T) {
-
 	loc := store.Locator{URL: "url", SiteID: "site"}
 	ts := func(min int, sec int) time.Time { return time.Date(2017, 12, 25, 19, min, sec, 0, time.UTC) }
 
@@ -87,7 +86,6 @@ func TestMakeEmptySubtree(t *testing.T) {
 
 	expJSON := mustLoadJSONFile(t, "testdata/tree_del.json")
 	assert.Equal(t, string(expJSON), string(resJSON))
-
 }
 
 func TestTreeSortNodes(t *testing.T) {

--- a/backend/app/store/user.go
+++ b/backend/app/store/user.go
@@ -49,7 +49,6 @@ func EncodeID(id string) string {
 
 // hashWithFallback tries to has val with hash.Hash and fallback to crc if needed
 func hashWithFallback(h hash.Hash, val string) string {
-
 	if reValidSha.MatchString(val) {
 		return val // already hashed
 	}

--- a/backend/app/store/user_test.go
+++ b/backend/app/store/user_test.go
@@ -55,7 +55,6 @@ func TestUser_HashFailed(t *testing.T) {
 
 	r = hashWithFallback(sha1.New(), "123456789")
 	assert.Equal(t, "f7c3bc1d808e04732adf679965ccc34ca7ae3441", r)
-
 }
 
 type mockHash struct{}


### PR DESCRIPTION
Also, remove unneeded whitespaces using whitespace linter for golangci-lint.