### PR TITLE
Replace errors package with fmt.Errorf

### DIFF
--- a/backend/_example/memory_store/accessor/admin.go
+++ b/backend/_example/memory_store/accessor/admin.go
@@ -7,8 +7,9 @@
 package accessor
 
 import (
+	"fmt"
+
 	log "github.com/go-pkgz/lgr"
-	"github.com/pkg/errors"
 
 	"github.com/umputun/remark42/backend/app/store/admin"
 )
@@ -43,7 +44,7 @@ func (m *MemAdmin) Key(_ string) (key string, err error) {
 func (m *MemAdmin) Admins(siteID string) (ids []string, err error) {
 	resp, ok := m.data[siteID]
 	if !ok {
-		return nil, errors.Errorf("site %s not found", siteID)
+		return nil, fmt.Errorf("site %s not found", siteID)
 	}
 	log.Printf("[DEBUG] admins for %s, %+v", siteID, resp.IDs)
 	return resp.IDs, nil
@@ -53,7 +54,7 @@ func (m *MemAdmin) Admins(siteID string) (ids []string, err error) {
 func (m *MemAdmin) Email(siteID string) (email string, err error) {
 	resp, ok := m.data[siteID]
 	if !ok {
-		return "", errors.Errorf("site %s not found", siteID)
+		return "", fmt.Errorf("site %s not found", siteID)
 	}
 
 	return resp.Email, nil
@@ -63,7 +64,7 @@ func (m *MemAdmin) Email(siteID string) (email string, err error) {
 func (m *MemAdmin) Enabled(siteID string) (ok bool, err error) {
 	resp, ok := m.data[siteID]
 	if !ok {
-		return false, errors.Errorf("site %s not found", siteID)
+		return false, fmt.Errorf("site %s not found", siteID)
 	}
 	return resp.Enabled, nil
 }
@@ -72,7 +73,7 @@ func (m *MemAdmin) Enabled(siteID string) (ok bool, err error) {
 func (m *MemAdmin) OnEvent(siteID string, ev admin.EventType) error {
 	resp, ok := m.data[siteID]
 	if !ok {
-		return errors.Errorf("site %s not found", siteID)
+		return fmt.Errorf("site %s not found", siteID)
 	}
 	if ev == admin.EvCreate {
 		resp.CountCreated++ // not a good idea, just for demo

--- a/backend/_example/memory_store/accessor/image.go
+++ b/backend/_example/memory_store/accessor/image.go
@@ -8,11 +8,11 @@ package accessor
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
 	log "github.com/go-pkgz/lgr"
-	"github.com/pkg/errors"
 
 	"github.com/umputun/remark42/backend/app/store/image"
 )
@@ -53,7 +53,7 @@ func (m *MemImage) ResetCleanupTimer(id string) error {
 		m.insertTime[id] = time.Now()
 		return nil
 	}
-	return errors.Errorf("image %s not found", id)
+	return fmt.Errorf("image %s not found", id)
 }
 
 // Load image by ID
@@ -65,7 +65,7 @@ func (m *MemImage) Load(id string) ([]byte, error) {
 	}
 	m.mu.RUnlock()
 	if !ok {
-		return nil, errors.Errorf("image %s not found", id)
+		return nil, fmt.Errorf("image %s not found", id)
 	}
 	return img, nil
 }
@@ -76,7 +76,7 @@ func (m *MemImage) Commit(id string) error {
 	img, ok := m.imagesStaging[id]
 	m.mu.RUnlock()
 	if !ok {
-		return errors.Errorf("failed to commit %s, not found in staging", id)
+		return fmt.Errorf("failed to commit %s, not found in staging", id)
 	}
 
 	m.mu.Lock()

--- a/backend/_example/memory_store/go.mod
+++ b/backend/_example/memory_store/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/go-pkgz/jrpc v0.2.0
 	github.com/go-pkgz/lgr v0.10.4
 	github.com/jessevdk/go-flags v1.5.0
-	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.1
 	github.com/umputun/remark42/backend v1.9.0
 )
@@ -29,6 +28,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.18 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rs/xid v1.4.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/backend/app/cmd/avatar.go
+++ b/backend/app/cmd/avatar.go
@@ -1,10 +1,10 @@
 package cmd
 
 import (
+	"fmt"
 	"path"
 
 	log "github.com/go-pkgz/lgr"
-	"github.com/pkg/errors"
 	bolt "go.etcd.io/bbolt"
 
 	"github.com/go-pkgz/auth/avatar"
@@ -39,12 +39,12 @@ func (ac *AvatarCommand) Execute(_ []string) error {
 
 	src, err := ac.makeAvatarStore(ac.AvatarSrc)
 	if err != nil {
-		return errors.Wrapf(err, "can't make avatart store for %s", ac.AvatarSrc.Type)
+		return fmt.Errorf("can't make avatart store for %s: %w", ac.AvatarSrc.Type, err)
 	}
 
 	dst, err := ac.makeAvatarStore(ac.AvatarDst)
 	if err != nil {
-		return errors.Wrapf(err, "can't make avatart store for %s", ac.AvatarDst.Type)
+		return fmt.Errorf("can't make avatart store for %s: %w", ac.AvatarDst.Type, err)
 	}
 
 	if ac.migrator == nil {
@@ -72,14 +72,14 @@ func (ac *AvatarCommand) makeAvatarStore(gr AvatarGroup) (avatar.Store, error) {
 	switch gr.Type {
 	case "fs":
 		if err := makeDirs(gr.FS.Path); err != nil {
-			return nil, errors.Wrap(err, "failed to create avatar store")
+			return nil, fmt.Errorf("failed to create avatar store: %w", err)
 		}
 		return avatar.NewLocalFS(gr.FS.Path), nil
 	case "bolt":
 		if err := makeDirs(path.Dir(gr.Bolt.File)); err != nil {
-			return nil, errors.Wrap(err, "failed to create avatar store")
+			return nil, fmt.Errorf("failed to create avatar store: %w", err)
 		}
 		return avatar.NewBoltDB(gr.Bolt.File, bolt.Options{})
 	}
-	return nil, errors.Errorf("unsupported avatar store type %s", gr.Type)
+	return nil, fmt.Errorf("unsupported avatar store type %s", gr.Type)
 }

--- a/backend/app/cmd/avatar_test.go
+++ b/backend/app/cmd/avatar_test.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"errors"
+	"fmt"
 	"os"
 	"testing"
 
@@ -25,7 +25,7 @@ func TestAvatar_Execute(t *testing.T) {
 	assert.NoError(t, err)
 
 	// failed
-	cmd = AvatarCommand{migrator: &avatarMigratorMock{retCount: 0, retError: errors.New("failed blah")}}
+	cmd = AvatarCommand{migrator: &avatarMigratorMock{retCount: 0, retError: fmt.Errorf("failed blah")}}
 	cmd.SetCommon(CommonOpts{RemarkURL: "", SharedSecret: "123456"})
 	p = flags.NewParser(&cmd, flags.Default)
 	_, err = p.ParseArgs([]string{"--src.type=fs", "--src.fs.path=/tmp/ava-test", "--dst.type=bolt",

--- a/backend/app/cmd/cmd.go
+++ b/backend/app/cmd/cmd.go
@@ -4,6 +4,7 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -13,7 +14,6 @@ import (
 	"time"
 
 	log "github.com/go-pkgz/lgr"
-	"github.com/pkg/errors"
 )
 
 // CommonOptionsCommander extends flags.Commander with SetCommon
@@ -87,7 +87,7 @@ func (p *fileParser) parse(now time.Time) (string, error) {
 	}
 
 	if err := template.Must(template.New("bb").Parse(fname)).Execute(&bb, fileTemplate); err != nil {
-		return "", errors.Wrapf(err, "failed to parse %q", fname)
+		return "", fmt.Errorf("failed to parse %q: %w", fname, err)
 	}
 	return bb.String(), nil
 }
@@ -107,14 +107,14 @@ func responseError(resp *http.Response) error {
 	if e != nil {
 		body = []byte("")
 	}
-	return errors.Errorf("error response %q, %s", resp.Status, body)
+	return fmt.Errorf("error response %q, %s", resp.Status, body)
 }
 
 // mkdir -p for all dirs
 func makeDirs(dirs ...string) error {
 	for _, dir := range dirs {
 		if err := os.MkdirAll(dir, 0o700); err != nil { // If path is already a directory, MkdirAll does nothing
-			return errors.Wrapf(err, "can't make directory %s", dir)
+			return fmt.Errorf("can't make directory %s: %w", dir, err)
 		}
 	}
 	return nil

--- a/backend/app/cmd/remap.go
+++ b/backend/app/cmd/remap.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	log "github.com/go-pkgz/lgr"
-	"github.com/pkg/errors"
 )
 
 // RemapCommand set of flags and command for change linkage between comments to
@@ -29,7 +28,7 @@ func (rc *RemapCommand) Execute(_ []string) error {
 
 	rulesReader, err := os.Open(rc.InputFile)
 	if err != nil {
-		return errors.Wrapf(err, "cant open file %s", rc.InputFile)
+		return fmt.Errorf("cant open file %s: %w", rc.InputFile, err)
 	}
 
 	client := http.Client{}
@@ -38,13 +37,13 @@ func (rc *RemapCommand) Execute(_ []string) error {
 	remapURL := fmt.Sprintf("%s/api/v1/admin/remap?site=%s", rc.RemarkURL, rc.Site)
 	req, err := http.NewRequest(http.MethodPost, remapURL, rulesReader)
 	if err != nil {
-		return errors.Wrapf(err, "can't make remap request for %s", remapURL)
+		return fmt.Errorf("can't make remap request for %s: %w", remapURL, err)
 	}
 	req.SetBasicAuth("admin", rc.AdminPasswd)
 
 	resp, err := client.Do(req.WithContext(ctx))
 	if err != nil {
-		return errors.Wrapf(err, "request failed for %s", remapURL)
+		return fmt.Errorf("request failed for %s: %w", remapURL, err)
 	}
 	defer func() {
 		if err = resp.Body.Close(); err != nil {
@@ -57,7 +56,7 @@ func (rc *RemapCommand) Execute(_ []string) error {
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return errors.Wrap(err, "can't get response")
+		return fmt.Errorf("can't get response: %w", err)
 	}
 
 	log.Printf("[INFO] completed, status=%d, %s", resp.StatusCode, string(body))

--- a/backend/app/migrator/backup.go
+++ b/backend/app/migrator/backup.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	log "github.com/go-pkgz/lgr"
-	"github.com/pkg/errors"
 )
 
 // AutoBackup struct handles daily backups params for siteID
@@ -50,18 +49,18 @@ func (ab AutoBackup) makeBackup() (string, error) {
 	backupFile := fmt.Sprintf("%s/backup-%s-%s.gz", ab.BackupLocation, ab.SiteID, time.Now().Format("20060102"))
 	fh, err := os.Create(backupFile) //nolint:gosec // harmless
 	if err != nil {
-		return "", errors.Wrapf(err, "can't create backup file %s", backupFile)
+		return "", fmt.Errorf("can't create backup file %s: %w", backupFile, err)
 	}
 	gz := gzip.NewWriter(fh)
 
 	if _, err = ab.Exporter.Export(gz, ab.SiteID); err != nil {
-		return "", errors.Wrapf(err, "export failed for %s", ab.SiteID)
+		return "", fmt.Errorf("export failed for %s: %w", ab.SiteID, err)
 	}
 	if err = gz.Close(); err != nil {
-		return "", errors.Wrapf(err, "can't close gz for %s", backupFile)
+		return "", fmt.Errorf("can't close gz for %s: %w", backupFile, err)
 	}
 	if err = fh.Close(); err != nil {
-		return "", errors.Wrapf(err, "can't close file handler for %s", backupFile)
+		return "", fmt.Errorf("can't close file handler for %s: %w", backupFile, err)
 	}
 	log.Printf("[DEBUG] created backup file %s", backupFile)
 	return backupFile, nil

--- a/backend/app/migrator/commento.go
+++ b/backend/app/migrator/commento.go
@@ -2,10 +2,10 @@ package migrator
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/umputun/remark42/backend/app/store"
 
 	log "github.com/go-pkgz/lgr"
@@ -68,9 +68,9 @@ func (d *Commento) Import(r io.Reader, siteID string) (size int, err error) {
 	}
 
 	if failed > 0 {
-		err = errors.Errorf("failed to save %d comments", failed)
+		err = fmt.Errorf("failed to save %d comments", failed)
 		if passed == 0 {
-			err = errors.New("import failed")
+			err = fmt.Errorf("import failed")
 		}
 	}
 

--- a/backend/app/migrator/commento_test.go
+++ b/backend/app/migrator/commento_test.go
@@ -7,11 +7,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	bolt "go.etcd.io/bbolt"
+
 	"github.com/umputun/remark42/backend/app/store"
 	"github.com/umputun/remark42/backend/app/store/admin"
 	"github.com/umputun/remark42/backend/app/store/engine"
 	"github.com/umputun/remark42/backend/app/store/service"
-	bolt "go.etcd.io/bbolt"
 )
 
 func TestCommento_Import(t *testing.T) {

--- a/backend/app/migrator/disqus.go
+++ b/backend/app/migrator/disqus.go
@@ -2,12 +2,12 @@ package migrator
 
 import (
 	"encoding/xml"
+	"fmt"
 	"io"
 	"strings"
 	"time"
 
 	log "github.com/go-pkgz/lgr"
-	"github.com/pkg/errors"
 
 	"github.com/umputun/remark42/backend/app/store"
 )
@@ -68,9 +68,9 @@ func (d *Disqus) Import(r io.Reader, siteID string) (size int, err error) {
 	}
 
 	if failed > 0 {
-		err = errors.Errorf("failed to save %d comments", failed)
+		err = fmt.Errorf("failed to save %d comments", failed)
 		if passed == 0 {
-			err = errors.New("import failed")
+			err = fmt.Errorf("import failed")
 		}
 	}
 

--- a/backend/app/migrator/migrator.go
+++ b/backend/app/migrator/migrator.go
@@ -4,11 +4,11 @@
 package migrator
 
 import (
+	"fmt"
 	"io"
 	"os"
 
 	log "github.com/go-pkgz/lgr"
-	"github.com/pkg/errors"
 
 	"github.com/umputun/remark42/backend/app/store"
 	"github.com/umputun/remark42/backend/app/store/service"
@@ -69,12 +69,12 @@ func ImportComments(p ImportParams) (int, error) {
 	case "native":
 		importer = &Native{DataStore: p.DataStore}
 	default:
-		return 0, errors.Errorf("unsupported import provider %s", p.Provider)
+		return 0, fmt.Errorf("unsupported import provider %s", p.Provider)
 	}
 
 	fh, err := os.Open(p.InputFile)
 	if err != nil {
-		return 0, errors.Wrapf(err, "can't open import file %s", p.InputFile)
+		return 0, fmt.Errorf("can't open import file %s: %w", p.InputFile, err)
 	}
 
 	defer func() { //nolint:gosec // false positive on defer without error check when it's checked here

--- a/backend/app/migrator/wordpress.go
+++ b/backend/app/migrator/wordpress.go
@@ -2,12 +2,12 @@ package migrator
 
 import (
 	"encoding/xml"
+	"fmt"
 	"html"
 	"io"
 	"time"
 
 	log "github.com/go-pkgz/lgr"
-	"github.com/pkg/errors"
 
 	"github.com/umputun/remark42/backend/app/store"
 )
@@ -75,9 +75,9 @@ func (w *WordPress) Import(r io.Reader, siteID string) (size int, err error) {
 	}
 
 	if failed > 0 {
-		err = errors.Errorf("failed to save %d comments", failed)
+		err = fmt.Errorf("failed to save %d comments", failed)
 		if passed == 0 {
-			err = errors.New("import failed")
+			err = fmt.Errorf("import failed")
 		}
 	}
 

--- a/backend/app/notify/email_test.go
+++ b/backend/app/notify/email_test.go
@@ -3,7 +3,7 @@ package notify
 import (
 	"bytes"
 	"context"
-	"errors"
+	"fmt"
 	"io"
 	"net/smtp"
 	"sync"
@@ -361,7 +361,7 @@ type fakeTestSMTP struct {
 
 func (f *fakeTestSMTP) Create(SMTPParams) (smtpClient, error) {
 	if f.fail["create"] {
-		return nil, errors.New("failed to create client")
+		return nil, fmt.Errorf("failed to create client")
 	}
 	return f, nil
 }
@@ -373,7 +373,7 @@ func (f *fakeTestSMTP) Mail(m string) error {
 	f.mail = m
 	f.lock.Unlock()
 	if f.fail["mail"] {
-		return errors.New("failed to verify sender")
+		return fmt.Errorf("failed to verify sender")
 	}
 	return nil
 }
@@ -383,7 +383,7 @@ func (f *fakeTestSMTP) Rcpt(r string) error {
 	f.rcpt = r
 	f.lock.Unlock()
 	if f.fail["rcpt"] {
-		return errors.New("failed to verify receiver")
+		return fmt.Errorf("failed to verify receiver")
 	}
 	return nil
 }
@@ -393,7 +393,7 @@ func (f *fakeTestSMTP) Quit() error {
 	f.quitCount++
 	f.lock.Unlock()
 	if f.fail["quit"] {
-		return errors.New("failed to quit")
+		return fmt.Errorf("failed to quit")
 	}
 	return nil
 }
@@ -401,14 +401,14 @@ func (f *fakeTestSMTP) Quit() error {
 func (f *fakeTestSMTP) Close() error {
 	f.close = true
 	if f.fail["close"] {
-		return errors.New("failed to close")
+		return fmt.Errorf("failed to close")
 	}
 	return nil
 }
 
 func (f *fakeTestSMTP) Data() (io.WriteCloser, error) {
 	if f.fail["data"] {
-		return nil, errors.New("failed to send")
+		return nil, fmt.Errorf("failed to send")
 	}
 	return nopCloser{&f.buff}, nil
 }
@@ -433,7 +433,7 @@ func (f *fakeTestSMTP) readQuitCount() int {
 
 func TokenGenFn(user, _, _ string) (string, error) {
 	if user == "error" {
-		return "", errors.New("token generation error")
+		return "", fmt.Errorf("token generation error")
 	}
 	return "token", nil
 }

--- a/backend/app/notify/notify_test.go
+++ b/backend/app/notify/notify_test.go
@@ -1,7 +1,6 @@
 package notify
 
 import (
-	"errors"
 	"fmt"
 	"math/rand"
 	"sync/atomic"
@@ -284,7 +283,7 @@ type mockStore struct {
 func (m mockStore) getUserDetail(userID string) (string, error) {
 	detail, ok := m.userDetails[userID]
 	if !ok {
-		return "", errors.New("no such user")
+		return "", fmt.Errorf("no such user")
 	}
 	return detail, nil
 }
@@ -292,7 +291,7 @@ func (m mockStore) getUserDetail(userID string) (string, error) {
 func (m mockStore) Get(_ store.Locator, id string, _ store.User) (store.Comment, error) {
 	res, ok := m.data[id]
 	if !ok {
-		return store.Comment{}, errors.New("no such id")
+		return store.Comment{}, fmt.Errorf("no such id")
 	}
 	return res, nil
 }

--- a/backend/app/notify/slack.go
+++ b/backend/app/notify/slack.go
@@ -2,9 +2,9 @@ package notify
 
 import (
 	"context"
+	"fmt"
 
 	log "github.com/go-pkgz/lgr"
-	"github.com/pkg/errors"
 	"github.com/slack-go/slack"
 )
 
@@ -26,7 +26,7 @@ func NewSlack(token, channelName string, opts ...slack.Option) (*Slack, error) {
 
 	channelID, err := res.findChannelIDByName(channelName)
 	if err != nil {
-		return nil, errors.Wrap(err, "can not find slack channel '"+channelName+"'")
+		return nil, fmt.Errorf("can not find slack channel '"+channelName+"': %w", err)
 	}
 
 	res.channelID = channelID
@@ -91,5 +91,5 @@ func (t *Slack) findChannelIDByName(name string) (string, error) {
 		}
 		params.Cursor = next
 	}
-	return "", errors.New("no such channel")
+	return "", fmt.Errorf("no such channel")
 }

--- a/backend/app/notify/telegram_test.go
+++ b/backend/app/notify/telegram_test.go
@@ -453,7 +453,7 @@ func TestTelegram_TokenVerification(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	go tb.Run(ctx)
 	assert.Eventually(t, func() bool {
-		return tb.ProcessUpdate(ctx, "").Error() == "Run goroutine should not be used with ProcessUpdate"
+		return tb.ProcessUpdate(ctx, "").Error() == "the Run goroutine should not be used with ProcessUpdate"
 	}, time.Millisecond*100, time.Millisecond*10, "ProcessUpdate should not work same time as Run")
 	tb.AddToken("expired token", "user", "site", time.Now().Add(-time.Minute))
 	tb.requests.RLock()

--- a/backend/app/notify/webhook_test.go
+++ b/backend/app/notify/webhook_test.go
@@ -3,7 +3,7 @@ package notify
 import (
 	"bytes"
 	"context"
-	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"testing"
@@ -31,7 +31,7 @@ type errReader struct {
 }
 
 func (errReader) Read(p []byte) (n int, err error) {
-	return 0, errors.New("test error")
+	return 0, fmt.Errorf("test error")
 }
 
 func TestWebhook_NewWebhook(t *testing.T) {
@@ -104,7 +104,7 @@ func TestWebhook_Send(t *testing.T) {
 	assert.Contains(t, err.Error(), "unable to create webhook request")
 
 	wh, err = NewWebhook(funcWebhookClient(func(*http.Request) (*http.Response, error) {
-		return nil, errors.New("request failed")
+		return nil, fmt.Errorf("request failed")
 	}), WebhookParams{WebhookURL: "https://not-existing-url.net"})
 	assert.NoError(t, err)
 	err = wh.Send(context.TODO(), Request{Comment: c})

--- a/backend/app/providers/telegram_test.go
+++ b/backend/app/providers/telegram_test.go
@@ -3,7 +3,7 @@ package providers
 import (
 	"context"
 	"encoding/json"
-	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -46,7 +46,7 @@ func (m *mockTGRequester) Request(_ context.Context, _ string, _ []byte, data in
 		assert.NoError(m.t, json.Unmarshal([]byte(getUpdatesResp), data))
 		return nil
 	}
-	return errors.New("test error")
+	return fmt.Errorf("test error")
 }
 
 type mockTGUpdatesReceiver struct {
@@ -68,5 +68,5 @@ func (m *mockTGUpdatesReceiver) ProcessUpdate(_ context.Context, textUpdate stri
 		return nil
 	}
 	assert.Nil(m.t, result.Result)
-	return errors.New("test error")
+	return fmt.Errorf("test error")
 }

--- a/backend/app/rest/api/admin.go
+++ b/backend/app/rest/api/admin.go
@@ -1,7 +1,7 @@
 package api
 
 import (
-	"errors"
+	"fmt"
 	"net/http"
 	"path"
 	"time"
@@ -103,7 +103,7 @@ func (a *admin) deleteMeRequestCtrl(w http.ResponseWriter, r *http.Request) {
 
 	// deleteme set by deleteMeCtrl, this check just to make sure we not trying to delete with leaked token
 	if !claims.User.BoolAttr("delete_me") {
-		rest.SendErrorJSON(w, r, http.StatusForbidden, errors.New("forbidden"), "can't use provided token", rest.ErrNoAccess)
+		rest.SendErrorJSON(w, r, http.StatusForbidden, fmt.Errorf("forbidden"), "can't use provided token", rest.ErrNoAccess)
 		return
 	}
 
@@ -183,7 +183,7 @@ func (a *admin) setReadOnlyCtrl(w http.ResponseWriter, r *http.Request) {
 	// don't allow to reset ro for posts turned to ro by ReadOnlyAge
 	if !roStatus {
 		if info, e := a.dataService.Info(locator, a.readOnlyAge); e == nil && isRoByAge(info) {
-			rest.SendErrorJSON(w, r, http.StatusForbidden, errors.New("rejected"),
+			rest.SendErrorJSON(w, r, http.StatusForbidden, fmt.Errorf("rejected"),
 				"read-only due the age", rest.ErrActionRejected)
 			return
 		}

--- a/backend/app/rest/api/migrator.go
+++ b/backend/app/rest/api/migrator.go
@@ -15,7 +15,6 @@ import (
 	cache "github.com/go-pkgz/lcw"
 	log "github.com/go-pkgz/lgr"
 	R "github.com/go-pkgz/rest"
-	"github.com/pkg/errors"
 
 	"github.com/umputun/remark42/backend/app/migrator"
 	"github.com/umputun/remark42/backend/app/rest"
@@ -47,7 +46,7 @@ func (m *Migrator) importCtrl(w http.ResponseWriter, r *http.Request) {
 	siteID := r.URL.Query().Get("site")
 
 	if m.isBusy(siteID) {
-		rest.SendErrorJSON(w, r, http.StatusConflict, errors.New("already running"),
+		rest.SendErrorJSON(w, r, http.StatusConflict, fmt.Errorf("already running"),
 			"import rejected", rest.ErrActionRejected)
 		return
 	}
@@ -70,7 +69,7 @@ func (m *Migrator) importFormCtrl(w http.ResponseWriter, r *http.Request) {
 	siteID := r.URL.Query().Get("site")
 
 	if m.isBusy(siteID) {
-		rest.SendErrorJSON(w, r, http.StatusConflict, errors.New("already running"),
+		rest.SendErrorJSON(w, r, http.StatusConflict, fmt.Errorf("already running"),
 			"import rejected", rest.ErrActionRejected)
 		return
 	}
@@ -253,15 +252,15 @@ func (m *Migrator) runImport(siteID, provider, tmpfile string) {
 func (m *Migrator) saveTemp(r io.Reader) (string, error) {
 	tmpfile, err := ioutil.TempFile("", "remark42_import")
 	if err != nil {
-		return "", errors.Wrap(err, "can't make temp file")
+		return "", fmt.Errorf("can't make temp file: %w", err)
 	}
 
 	if _, err = io.Copy(tmpfile, r); err != nil {
-		return "", errors.Wrap(err, "can't copy to temp file")
+		return "", fmt.Errorf("can't copy to temp file: %w", err)
 	}
 
 	if err = tmpfile.Close(); err != nil {
-		return "", errors.Wrap(err, "can't close temp file")
+		return "", fmt.Errorf("can't close temp file: %w", err)
 	}
 
 	return tmpfile.Name(), nil

--- a/backend/app/rest/api/rest.go
+++ b/backend/app/rest/api/rest.go
@@ -21,7 +21,6 @@ import (
 	log "github.com/go-pkgz/lgr"
 	R "github.com/go-pkgz/rest"
 	"github.com/go-pkgz/rest/logger"
-	"github.com/pkg/errors"
 	"github.com/rakyll/statik/fs"
 
 	"github.com/umputun/remark42/backend/app/notify"
@@ -505,7 +504,7 @@ func encodeJSONWithHTML(v interface{}) ([]byte, error) {
 	enc := json.NewEncoder(buf)
 	enc.SetEscapeHTML(false)
 	if err := enc.Encode(v); err != nil {
-		return nil, errors.Wrap(err, "json encoding failed")
+		return nil, fmt.Errorf("json encoding failed: %w", err)
 	}
 	return buf.Bytes(), nil
 }

--- a/backend/app/rest/api/rest_private_test.go
+++ b/backend/app/rest/api/rest_private_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -1287,7 +1286,7 @@ func (m *mockTelegram) GetBotUsername() string {
 
 func (m *mockTelegram) CheckToken(string, string) (telegram, site string, err error) {
 	if m.notVerified {
-		return "", "", errors.New("not verified")
+		return "", "", fmt.Errorf("not verified")
 	}
 	return "good_telegram", m.site, nil
 }

--- a/backend/app/rest/api/rest_public.go
+++ b/backend/app/rest/api/rest_public.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/sha1" // nolint
 	"encoding/base64"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -17,7 +18,6 @@ import (
 	cache "github.com/go-pkgz/lcw"
 	log "github.com/go-pkgz/lgr"
 	R "github.com/go-pkgz/rest"
-	"github.com/pkg/errors"
 	"github.com/skip2/go-qrcode"
 
 	"github.com/umputun/remark42/backend/app/rest"
@@ -372,12 +372,12 @@ func (s *public) robotsCtrl(w http.ResponseWriter, r *http.Request) {
 func (s *public) telegramQrCtrl(w http.ResponseWriter, r *http.Request) {
 	text := r.URL.Query().Get("url")
 	if text == "" {
-		rest.SendErrorJSON(w, r, http.StatusBadRequest, errors.New("missing parameter"), "text parameter is required", rest.ErrInternal)
+		rest.SendErrorJSON(w, r, http.StatusBadRequest, fmt.Errorf("missing parameter"), "text parameter is required", rest.ErrInternal)
 		return
 	}
 
 	if !strings.HasPrefix(text, "https://t.me/") {
-		rest.SendErrorJSON(w, r, http.StatusBadRequest, errors.New("wrong parameter"), "text parameter should start with https://t.me/", rest.ErrInternal)
+		rest.SendErrorJSON(w, r, http.StatusBadRequest, fmt.Errorf("wrong parameter"), "text parameter should start with https://t.me/", rest.ErrInternal)
 		return
 	}
 
@@ -423,7 +423,7 @@ func (s *public) parseSince(r *http.Request) (time.Time, error) {
 	if since := r.URL.Query().Get("since"); since != "" {
 		unixTS, e := strconv.ParseInt(since, 10, 64)
 		if e != nil {
-			return time.Time{}, errors.Wrap(e, "can't translate since parameter")
+			return time.Time{}, fmt.Errorf("can't translate since parameter: %w", e)
 		}
 		sinceTS = time.Unix(unixTS/1000, 1000000*(unixTS%1000)) // since param in msec timestamp
 	}

--- a/backend/app/rest/api/rest_test.go
+++ b/backend/app/rest/api/rest_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -277,13 +276,13 @@ func TestRest_parseError(t *testing.T) {
 		err error
 		res int
 	}{
-		{errors.New("can not vote for his own comment"), rest.ErrVoteSelf},
-		{errors.New("already voted for"), rest.ErrVoteDbl},
-		{errors.New("maximum number of votes exceeded for comment"), rest.ErrVoteMax},
-		{errors.New("minimal score reached for comment"), rest.ErrVoteMinScore},
-		{errors.New("too late to edit"), rest.ErrCommentEditExpired},
-		{errors.New("parent comment with reply can't be edited"), rest.ErrCommentEditChanged},
-		{errors.New("blah blah"), rest.ErrInternal},
+		{fmt.Errorf("can not vote for his own comment"), rest.ErrVoteSelf},
+		{fmt.Errorf("already voted for"), rest.ErrVoteDbl},
+		{fmt.Errorf("maximum number of votes exceeded for comment"), rest.ErrVoteMax},
+		{fmt.Errorf("minimal score reached for comment"), rest.ErrVoteMinScore},
+		{fmt.Errorf("too late to edit"), rest.ErrCommentEditExpired},
+		{fmt.Errorf("parent comment with reply can't be edited"), rest.ErrCommentEditChanged},
+		{fmt.Errorf("blah blah"), rest.ErrInternal},
 	}
 
 	for n, tt := range tbl {
@@ -398,7 +397,7 @@ func randomPath(tempDir, basename, suffix string) (string, error) {
 			return fname, nil
 		}
 	}
-	return "", errors.New("cannot create temp file")
+	return "", fmt.Errorf("cannot create temp file in %s", tempDir)
 }
 
 // startupT runs fully configured testing server

--- a/backend/app/rest/api/rss.go
+++ b/backend/app/rest/api/rss.go
@@ -8,7 +8,6 @@ import (
 	cache "github.com/go-pkgz/lcw"
 	log "github.com/go-pkgz/lgr"
 	"github.com/gorilla/feeds"
-	"github.com/pkg/errors"
 
 	"github.com/umputun/remark42/backend/app/rest"
 	"github.com/umputun/remark42/backend/app/store"
@@ -104,7 +103,7 @@ func (s *rss) repliesCtrl(w http.ResponseWriter, r *http.Request) {
 	data, err := s.cache.Get(key, func() (res []byte, e error) {
 		replies, userName, e := s.dataService.UserReplies(siteID, userID, maxRssItems, maxReplyDuration)
 		if e != nil {
-			return nil, errors.Wrap(e, "can't get last comments")
+			return nil, fmt.Errorf("can't get last comments: %w", e)
 		}
 
 		feed, e := s.toRssFeed(siteID, replies, "replies to "+userName)

--- a/backend/app/rest/httperrors_test.go
+++ b/backend/app/rest/httperrors_test.go
@@ -1,7 +1,6 @@
 package rest
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -18,7 +17,7 @@ func TestSendErrorJSON(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/error" {
 			t.Log("http err request", r.URL)
-			SendErrorJSON(w, r, 500, errors.New("error 500"), "error details 123456", 123)
+			SendErrorJSON(w, r, 500, fmt.Errorf("error 500"), "error details 123456", 123)
 			return
 		}
 		w.WriteHeader(404)
@@ -48,7 +47,7 @@ func TestSendErrorHTML(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/error" {
 			t.Log("http err request", r.URL)
-			SendErrorHTML(w, r, 500, errors.New("error 500"), "error details 123456", 987, fs)
+			SendErrorHTML(w, r, 500, fmt.Errorf("error 500"), "error details 123456", 987, fs)
 			return
 		}
 		w.WriteHeader(404)
@@ -74,7 +73,7 @@ func TestErrorDetailsMsg(t *testing.T) {
 		req, err := http.NewRequest("GET", "https://example.com/test?k1=v1&k2=v2", http.NoBody)
 		require.NoError(t, err)
 		req.RemoteAddr = "1.2.3.4"
-		msg := errDetailsMsg(req, 500, errors.New("error 500"), "error details 123456", 123)
+		msg := errDetailsMsg(req, 500, fmt.Errorf("error 500"), "error details 123456", 123)
 		assert.Contains(t, msg, "error details 123456 - error 500 - 500 (123) - https://example.com/test?k1=v1&k2=v2 - [app/rest/httperrors_test.go:")
 		// error line in the middle of the message is not checked
 		assert.Contains(t, msg, " rest.TestErrorDetailsMsg]")
@@ -89,7 +88,7 @@ func TestErrorDetailsMsgWithUser(t *testing.T) {
 		req.RemoteAddr = "127.0.0.1:1234"
 		req = SetUserInfo(req, store.User{Name: "test", ID: "id"})
 		require.NoError(t, err)
-		msg := errDetailsMsg(req, 500, errors.New("error 500"), "error details 123456", 34567)
+		msg := errDetailsMsg(req, 500, fmt.Errorf("error 500"), "error details 123456", 34567)
 		assert.Contains(t, msg, "error details 123456 - error 500 - 500 (34567) - test/id - https://example.com/test?k1=v1&k2=v2 - [app/rest/httperrors_test.go:")
 		// error line in the middle of the message is not checked
 		assert.Contains(t, msg, " rest.TestErrorDetailsMsgWithUser]")

--- a/backend/app/rest/user.go
+++ b/backend/app/rest/user.go
@@ -1,10 +1,10 @@
 package rest
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-pkgz/auth/token"
-	"github.com/pkg/errors"
 
 	"github.com/umputun/remark42/backend/app/store"
 )
@@ -23,7 +23,7 @@ func MustGetUserInfo(r *http.Request) store.User {
 func GetUserInfo(r *http.Request) (user store.User, err error) {
 	u, err := token.GetUserInfo(r)
 	if err != nil {
-		return store.User{}, errors.Wrap(err, "can't extract user info from the token")
+		return store.User{}, fmt.Errorf("can't extract user info from the token: %w", err)
 	}
 
 	return store.User{

--- a/backend/app/store/admin/admin.go
+++ b/backend/app/store/admin/admin.go
@@ -2,7 +2,7 @@
 package admin
 
 import (
-	"errors"
+	"fmt"
 	"strings"
 
 	log "github.com/go-pkgz/lgr"
@@ -50,7 +50,7 @@ func NewStaticKeyStore(key string) *StaticStore {
 // Key returns static key, same for all sites
 func (s *StaticStore) Key(_ string) (key string, err error) {
 	if s.key == "" {
-		return "", errors.New("empty key for static key store")
+		return "", fmt.Errorf("empty key for static key store")
 	}
 	return s.key, nil
 }

--- a/backend/app/store/service/service_test.go
+++ b/backend/app/store/service/service_test.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/go-pkgz/lgr"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	bolt "go.etcd.io/bbolt"
@@ -754,10 +753,10 @@ func TestService_ValidateComment(t *testing.T) {
 		inp store.Comment
 		err error
 	}{
-		{inp: store.Comment{}, err: errors.New("empty comment text")},
+		{inp: store.Comment{}, err: fmt.Errorf("empty comment text")},
 		{inp: store.Comment{Orig: "something blah", User: store.User{ID: "myid", Name: "name"}}, err: nil},
-		{inp: store.Comment{Orig: "something blah", User: store.User{ID: "myid"}}, err: errors.New("empty user info")},
-		{inp: store.Comment{Orig: longText, User: store.User{ID: "myid", Name: "name"}}, err: errors.New("comment text exceeded max allowed size 2000 (4000)")},
+		{inp: store.Comment{Orig: "something blah", User: store.User{ID: "myid"}}, err: fmt.Errorf("empty user info")},
+		{inp: store.Comment{Orig: longText, User: store.User{ID: "myid", Name: "name"}}, err: fmt.Errorf("comment text exceeded max allowed size 2000 (4000)")},
 	}
 
 	for n, tt := range tbl {
@@ -1439,7 +1438,7 @@ func TestService_ResubmitStagingImages(t *testing.T) {
 	bError := DataStore{Engine: eng, EditDuration: 10 * time.Millisecond, ImageService: imgSvcError}
 
 	// resubmit will receive error from image storage and should return it
-	mockStoreError.On("Info").Once().Return(image.StoreInfo{}, errors.New("mock_err"))
+	mockStoreError.On("Info").Once().Return(image.StoreInfo{}, fmt.Errorf("mock_err"))
 	err = bError.ResubmitStagingImages([]string{"radio-t"})
 	assert.EqualError(t, err, "mock_err")
 
@@ -1459,7 +1458,7 @@ func TestService_ResubmitStagingImages_EngineError(t *testing.T) {
 	site1Req := engine.FindRequest{Locator: store.Locator{SiteID: "site1", URL: ""}, Sort: "time", Since: time.Time{}.Add(time.Second)}
 	site2Req := engine.FindRequest{Locator: store.Locator{SiteID: "site2", URL: ""}, Sort: "time", Since: time.Time{}.Add(time.Second)}
 	engineMock.On("Find", site1Req).Return(nil, nil)
-	engineMock.On("Find", site2Req).Return(nil, errors.New("mockError"))
+	engineMock.On("Find", site2Req).Return(nil, fmt.Errorf("mockError"))
 	b := DataStore{Engine: &engineMock, EditDuration: 10 * time.Millisecond, ImageService: imgSvc}
 
 	// One call without error and one with error

--- a/backend/app/store/service/title.go
+++ b/backend/app/store/service/title.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -8,7 +9,6 @@ import (
 
 	"github.com/go-pkgz/lcw"
 	log "github.com/go-pkgz/lgr"
-	"github.com/pkg/errors"
 	"golang.org/x/net/html"
 )
 
@@ -43,7 +43,7 @@ func (t *TitleExtractor) Get(url string) (string, error) {
 	b, err := t.cache.Get(url, func() (interface{}, error) {
 		resp, err := client.Get(url)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to load page %s", url)
+			return nil, fmt.Errorf("failed to load page %s: %w", url, err)
 		}
 		defer func() {
 			if err = resp.Body.Close(); err != nil {
@@ -51,12 +51,12 @@ func (t *TitleExtractor) Get(url string) (string, error) {
 			}
 		}()
 		if resp.StatusCode != 200 {
-			return nil, errors.Errorf("can't load page %s, code %d", url, resp.StatusCode)
+			return nil, fmt.Errorf("can't load page %s, code %d", url, resp.StatusCode)
 		}
 
 		title, ok := t.getTitle(resp.Body)
 		if !ok {
-			return nil, errors.Errorf("can't get title for %s", url)
+			return nil, fmt.Errorf("can't get title for %s", url)
 		}
 		return title, nil
 	})

--- a/backend/app/store/user_test.go
+++ b/backend/app/store/user_test.go
@@ -2,7 +2,7 @@ package store
 
 import (
 	"crypto/sha1"
-	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -63,4 +63,4 @@ func (mock mockHash) Sum(_ []byte) []byte               { return nil }
 func (mock mockHash) Reset()                            {}
 func (mock mockHash) Size() int                         { return 0 }
 func (mock mockHash) BlockSize() int                    { return 0 }
-func (mock mockHash) Write(_ []byte) (n int, err error) { return 0, errors.New("error") }
+func (mock mockHash) Write(_ []byte) (n int, err error) { return 0, fmt.Errorf("error") }


### PR DESCRIPTION
https://gist.github.com/Peltoche/60b8b81dfbf70164d0e2b88988003229 was used for it, thanks to @Peltoche for publishing it.

I've reviewed each changed line manually and changed all wraps without checking for errors not equal to `nil` to have that check and return plain `nil` otherwise.