### PR TITLE
Move back last comments css file

### DIFF
--- a/frontend/.size-limit.js
+++ b/frontend/.size-limit.js
@@ -16,6 +16,10 @@ module.exports = [
     limit: '33 KB',
   },
   {
+    path: 'public/last-comments.css',
+    limit: '6 KB',
+  },
+  {
     path: 'public/deleteme.mjs',
     limit: '11 KB',
   },

--- a/frontend/app/last-comments.tsx
+++ b/frontend/app/last-comments.tsx
@@ -7,8 +7,6 @@ import { loadLocale } from 'utils/loadLocale';
 import { getLocale } from 'utils/getLocale';
 import { ListComments } from 'components/list-comments';
 
-import 'styles/global.css';
-
 const LAST_COMMENTS_NODE_CLASSNAME = 'remark42__last-comments';
 const DEFAULT_LAST_COMMENTS_MAX = 15;
 

--- a/frontend/templates/last-comments.ejs
+++ b/frontend/templates/last-comments.ejs
@@ -16,7 +16,7 @@
       }
     </style>
     <% if (htmlWebpackPlugin.options.env === 'production') { %>
-    <link rel="stylesheet" href="remark42.css" />
+    <link rel="stylesheet" href="last-comments.css" />
     <% } %>
   </head>
   <body>


### PR DESCRIPTION
When I removed `last-comments.css` and started to use `remark.css` instead we got base page styles overwritten by those styles. Now I'm moving the file back in order to fix the issue.
