### PR TITLE
fix positive_score and low_score comments options

### DIFF
--- a/frontend/app/components/comment/comment-votes.spec.tsx
+++ b/frontend/app/components/comment/comment-votes.spec.tsx
@@ -99,8 +99,10 @@ describe('<CommentVote />', () => {
   it('should allow only upvote ability', () => {
     StaticStore.config.positive_score = true;
     render(<CommentVotes id="1" vote={0} votes={10} controversy={0} />);
-    expect(screen.queryByTitle('Vote down')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Vote down')).toBeVisible();
+    expect(screen.queryByTitle('Vote down')).toBeDisabled();
     expect(screen.getByTitle('Vote up')).toBeVisible();
+    expect(screen.getByTitle('Vote up')).not.toBeDisabled();
   });
 
   it('should disable downvote ability when `low_score` is reached', async () => {
@@ -111,6 +113,7 @@ describe('<CommentVote />', () => {
     fireEvent(screen.getByTitle('Vote down'), new Event('click'));
     await waitFor(() => {
       expect(screen.getByTitle('Vote down')).toBeDisabled();
+      expect(screen.getByTitle('Vote up')).toBeDisabled();
     });
   });
 });

--- a/frontend/app/components/comment/comment-votes.spec.tsx
+++ b/frontend/app/components/comment/comment-votes.spec.tsx
@@ -104,16 +104,4 @@ describe('<CommentVote />', () => {
     expect(screen.getByTitle('Vote up')).toBeVisible();
     expect(screen.getByTitle('Vote up')).not.toBeDisabled();
   });
-
-  it('should disable downvote ability when `low_score` is reached', async () => {
-    StaticStore.config.low_score = -4;
-    jest.spyOn(api, 'putCommentVote').mockImplementation(jest.fn(async () => ({ id: '1', score: -4 })));
-    render(<CommentVotes id="1" vote={0} votes={-3} controversy={0} />);
-    expect(screen.getByTitle('Vote down')).not.toBeDisabled();
-    fireEvent(screen.getByTitle('Vote down'), new Event('click'));
-    await waitFor(() => {
-      expect(screen.getByTitle('Vote down')).toBeDisabled();
-      expect(screen.getByTitle('Vote up')).toBeDisabled();
-    });
-  });
 });

--- a/frontend/app/components/comment/comment-votes.tsx
+++ b/frontend/app/components/comment/comment-votes.tsx
@@ -48,16 +48,17 @@ export function CommentVotes({ id, votes, vote, disabled, controversy = 0 }: Pro
   const positiveScore = StaticStore.config.positive_score;
   const isUpvoted = vote === 1;
   const isDownvoted = vote === -1;
+  const value = loadingState?.votes ?? votes;
 
   return (
     <span className={clsx(styles.root, disabled && styles.rootDisabled)}>
-      {Boolean(!disabled && !positiveScore) && (
+      {Boolean(!disabled) && (
         <button
           className={clsx(styles.voteButton, styles.downVoteButton, isDownvoted && styles.downVoteButtonActive)}
           onClick={handleClick}
           data-value={-1}
           title={intl.formatMessage(messages.downvote)}
-          disabled={lowScore || loadingState !== null || isDownvoted}
+          disabled={lowScore || loadingState !== null || isDownvoted || (positiveScore && value > -1)}
         >
           <ArrowIcon className={styles.downVoteIcon} />
         </button>
@@ -80,7 +81,7 @@ export function CommentVotes({ id, votes, vote, disabled, controversy = 0 }: Pro
             [styles.votesPositive]: votes > 0,
           })}
         >
-          {loadingState?.votes ?? votes}
+          {value}
         </div>
       </Tooltip>
       {!disabled && (

--- a/frontend/app/components/comment/comment-votes.tsx
+++ b/frontend/app/components/comment/comment-votes.tsx
@@ -44,11 +44,10 @@ export function CommentVotes({ id, votes, vote, disabled, controversy = 0 }: Pro
     }
   }
 
-  const lowScore = StaticStore.config.low_score === votes;
-  const positiveScore = StaticStore.config.positive_score;
   const isUpvoted = vote === 1;
   const isDownvoted = vote === -1;
   const value = loadingState?.votes ?? votes;
+  const isPositiveScore = StaticStore.config.positive_score && value > -1;
 
   return (
     <span className={clsx(styles.root, disabled && styles.rootDisabled)}>
@@ -58,7 +57,7 @@ export function CommentVotes({ id, votes, vote, disabled, controversy = 0 }: Pro
           onClick={handleClick}
           data-value={-1}
           title={intl.formatMessage(messages.downvote)}
-          disabled={lowScore || loadingState !== null || isDownvoted || (positiveScore && value > -1)}
+          disabled={loadingState !== null || isDownvoted || isPositiveScore}
         >
           <ArrowIcon className={styles.downVoteIcon} />
         </button>

--- a/frontend/app/components/comment/comment.tsx
+++ b/frontend/app/components/comment/comment.tsx
@@ -326,6 +326,14 @@ export class Comment extends Component<CommentProps, State> {
     const defaultMods = {
       disabled: props.disabled,
       pinned: props.data.pin,
+      // TODO: we also have critical_score, so we need to collapse comments with it in future
+      useless:
+        !!props.isUserBanned ||
+        !!props.data.delete ||
+        (props.view !== 'preview' &&
+          props.data.score < StaticStore.config.low_score &&
+          !props.data.pin &&
+          !props.disabled),
       // TODO: add default view mod or don't?
       guest: isGuest,
       view: props.view === 'main' || props.view === 'pinned' ? props.data.user.admin && 'admin' : props.view,


### PR DESCRIPTION
- enable downvoting for only positive. it should give ability to downvote until score is 0
- restore low_score state of a comment. it should make comment semi transparent when downvoted
