### PR TITLE
Improve tests reliability

### DIFF
--- a/backend/app/cmd/avatar_test.go
+++ b/backend/app/cmd/avatar_test.go
@@ -21,6 +21,7 @@ func TestAvatar_Execute(t *testing.T) {
 	_, err := p.ParseArgs([]string{"--src.type=fs", "--src.fs.path=/tmp/ava-test", "--dst.type=bolt",
 		"--dst.bolt.file=/tmp/ava-test.db"})
 	require.NoError(t, err)
+	defer os.Remove("/tmp/ava-test.db")
 	err = cmd.Execute(nil)
 	assert.NoError(t, err)
 
@@ -31,6 +32,7 @@ func TestAvatar_Execute(t *testing.T) {
 	_, err = p.ParseArgs([]string{"--src.type=fs", "--src.fs.path=/tmp/ava-test", "--dst.type=bolt",
 		"--dst.bolt.file=/tmp/ava-test2.db"})
 	require.NoError(t, err)
+	defer os.Remove("/tmp/ava-test2.db")
 	err = cmd.Execute(nil)
 	assert.Error(t, err, "failed blah")
 }

--- a/backend/app/cmd/backup.go
+++ b/backend/app/cmd/backup.go
@@ -38,6 +38,7 @@ func (ec *BackupCommand) Execute(_ []string) error {
 
 	// prepare http client and request
 	client := http.Client{}
+	defer client.CloseIdleConnections()
 	ctx, cancel := context.WithTimeout(context.Background(), ec.Timeout)
 	defer cancel()
 	exportURL := fmt.Sprintf("%s/api/v1/admin/export?mode=file&site=%s", ec.RemarkURL, ec.Site)

--- a/backend/app/cmd/import.go
+++ b/backend/app/cmd/import.go
@@ -35,6 +35,7 @@ func (ic *ImportCommand) Execute(_ []string) error {
 	}
 
 	client := http.Client{}
+	defer client.CloseIdleConnections()
 	ctx, cancel := context.WithTimeout(context.Background(), ic.Timeout)
 	defer cancel()
 	importURL := fmt.Sprintf("%s/api/v1/admin/import?site=%s&provider=%s", ic.RemarkURL, ic.Site, ic.Provider)

--- a/backend/app/cmd/remap.go
+++ b/backend/app/cmd/remap.go
@@ -33,6 +33,7 @@ func (rc *RemapCommand) Execute(_ []string) error {
 	}
 
 	client := http.Client{}
+	defer client.CloseIdleConnections()
 	ctx, cancel := context.WithTimeout(context.Background(), rc.Timeout)
 	defer cancel()
 	remapURL := fmt.Sprintf("%s/api/v1/admin/remap?site=%s", rc.RemarkURL, rc.Site)

--- a/backend/app/main_test.go
+++ b/backend/app/main_test.go
@@ -142,6 +142,7 @@ func chooseRandomUnusedPort() (port int) {
 func waitForHTTPServerStart(port int) {
 	// wait for up to 10 seconds for server to start before returning it
 	client := http.Client{Timeout: time.Second}
+	defer client.CloseIdleConnections()
 	for i := 0; i < 100; i++ {
 		time.Sleep(time.Millisecond * 100)
 		if resp, err := client.Get(fmt.Sprintf("http://localhost:%d", port)); err == nil {

--- a/backend/app/rest/api/admin_test.go
+++ b/backend/app/rest/api/admin_test.go
@@ -219,6 +219,7 @@ func TestAdmin_Pin(t *testing.T) {
 
 	pin := func(val int) int {
 		client := http.Client{}
+		defer client.CloseIdleConnections()
 		req, err := http.NewRequest(http.MethodPut,
 			fmt.Sprintf("%s/api/v1/admin/pin/%s?site=remark42&url=https://radio-t.com/blah&pin=%d", ts.URL, id1, val), http.NoBody)
 		assert.NoError(t, err)
@@ -719,6 +720,7 @@ func TestAdmin_DeleteMeRequest(t *testing.T) {
 	assert.NoError(t, err)
 
 	client := http.Client{}
+	defer client.CloseIdleConnections()
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/admin/deleteme?token=%s", ts.URL, tkn), http.NoBody)
 	assert.NoError(t, err)
 
@@ -752,6 +754,7 @@ func TestAdmin_DeleteMeRequestFailed(t *testing.T) {
 
 	// try with bad token
 	client := http.Client{}
+	defer client.CloseIdleConnections()
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/admin/deleteme?token=%s", ts.URL, "bad token"), http.NoBody)
 	assert.NoError(t, err)
 	req.SetBasicAuth("admin", "password")

--- a/backend/app/rest/api/migrator_test.go
+++ b/backend/app/rest/api/migrator_test.go
@@ -34,6 +34,7 @@ func TestMigrator_Import(t *testing.T) {
 "votes":{},"time":"2018-04-30T01:37:00.861387771-05:00"}`)
 
 	client := &http.Client{Timeout: 1 * time.Second}
+	defer client.CloseIdleConnections()
 	req, err := http.NewRequest("POST", ts.URL+"/api/v1/admin/import?site=remark42&provider=native", r)
 	require.NoError(t, err)
 	req.SetBasicAuth("admin", "password")
@@ -92,6 +93,7 @@ func TestMigrator_ImportFromWP(t *testing.T) {
 	r := strings.NewReader(strings.Replace(xmlTestWP, "'", "`", -1))
 
 	client := &http.Client{Timeout: 1 * time.Second}
+	defer client.CloseIdleConnections()
 	req, err := http.NewRequest("POST", ts.URL+"/api/v1/admin/import?site=remark42&provider=wordpress", r)
 	assert.NoError(t, err)
 	req.Header.Add("Content-Type", "application/xml; charset=utf-8")
@@ -120,6 +122,7 @@ func TestMigrator_ImportFromCommento(t *testing.T) {
 "provider":"sso:example.com","joinDate":"2021-03-19T19:27:25.954285Z","isModerator":false}]}`)
 
 	client := &http.Client{Timeout: 1 * time.Second}
+	defer client.CloseIdleConnections()
 	req, err := http.NewRequest("POST", ts.URL+"/api/v1/admin/import?site=remark42&provider=commento", r)
 	assert.NoError(t, err)
 	req.Header.Add("Content-Type", "application/json; charset=utf-8")
@@ -150,6 +153,7 @@ func TestMigrator_ImportRejected(t *testing.T) {
 "votes":{},"time":"2018-04-30T01:37:00.861387771-05:00"}`)
 
 	client := &http.Client{Timeout: 1 * time.Second}
+	defer client.CloseIdleConnections()
 	req, err := http.NewRequest("POST", ts.URL+"/api/v1/admin/import?site=remark42&provider=native&secret=XYZ", r)
 	assert.NoError(t, err)
 	resp, err := client.Do(req)
@@ -172,6 +176,7 @@ func TestMigrator_ImportDouble(t *testing.T) {
 	}
 	r := strings.NewReader(`{"version":1}` + strings.Join(recs, "\n")) // reader with 10k records
 	client := &http.Client{Timeout: 1 * time.Second}
+	defer client.CloseIdleConnections()
 	req, err := http.NewRequest("POST", ts.URL+"/api/v1/admin/import?site=remark42&provider=native", r)
 	require.NoError(t, err)
 	req.SetBasicAuth("admin", "password")
@@ -182,6 +187,7 @@ func TestMigrator_ImportDouble(t *testing.T) {
 	assert.Equal(t, http.StatusAccepted, resp.StatusCode)
 
 	client = &http.Client{Timeout: 5 * time.Second}
+	defer client.CloseIdleConnections()
 	req, err = http.NewRequest("POST", ts.URL+"/api/v1/admin/import?site=remark42&provider=native", r)
 	require.NoError(t, err)
 	req.SetBasicAuth("admin", "password")
@@ -208,6 +214,7 @@ func TestMigrator_ImportWaitExpired(t *testing.T) {
 	}
 	r := strings.NewReader(`{"version":1}` + strings.Join(recs, "\n")) // reader with `nRecs` records
 	client := &http.Client{Timeout: 5 * time.Second}
+	defer client.CloseIdleConnections()
 	req, err := http.NewRequest("POST", ts.URL+"/api/v1/admin/import?site=remark42&provider=native", r)
 	require.NoError(t, err)
 	req.SetBasicAuth("admin", "password")
@@ -218,6 +225,7 @@ func TestMigrator_ImportWaitExpired(t *testing.T) {
 	assert.Equal(t, http.StatusAccepted, resp.StatusCode)
 
 	client = &http.Client{Timeout: 5 * time.Second}
+	defer client.CloseIdleConnections()
 	req, err = http.NewRequest("GET", ts.URL+"/api/v1/admin/wait?site=remark42&timeout=5ms", http.NoBody)
 	require.NoError(t, err)
 	req.SetBasicAuth("admin", "password")
@@ -245,6 +253,7 @@ func TestMigrator_Export(t *testing.T) {
 
 	// import comments first
 	client := &http.Client{Timeout: 1 * time.Second}
+	defer client.CloseIdleConnections()
 	req, err := http.NewRequest("POST", ts.URL+"/api/v1/admin/import?site=remark42&provider=native", r)
 	require.NoError(t, err)
 	req.SetBasicAuth("admin", "password")
@@ -387,6 +396,7 @@ func TestMigrator_RemapReject(t *testing.T) {
 
 	// without admin credentials
 	client := &http.Client{Timeout: 1 * time.Second}
+	defer client.CloseIdleConnections()
 	rules := strings.NewReader(`https://remark42.com/* https://www.remark42.com/*`)
 	req, err := http.NewRequest("POST", ts.URL+"/api/v1/admin/remap?site=remark42", rules)
 	require.NoError(t, err)
@@ -398,6 +408,7 @@ func TestMigrator_RemapReject(t *testing.T) {
 
 func waitForMigrationCompletion(t *testing.T, ts *httptest.Server) {
 	client := &http.Client{Timeout: 10 * time.Second}
+	defer client.CloseIdleConnections()
 	req, err := http.NewRequest("GET", ts.URL+"/api/v1/admin/wait?site=remark42", http.NoBody)
 	require.NoError(t, err)
 	req.SetBasicAuth("admin", "password")

--- a/backend/app/rest/api/rest_private_test.go
+++ b/backend/app/rest/api/rest_private_test.go
@@ -155,6 +155,7 @@ func TestRest_CreateRejected(t *testing.T) {
 
 	// try with wrong aud
 	client := &http.Client{Timeout: 5 * time.Second}
+	defer client.CloseIdleConnections()
 	req, err := http.NewRequest("POST", ts.URL+"/api/v1/comment", strings.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Add("X-JWT", devTokenBadAud)
@@ -251,6 +252,7 @@ func TestRest_Update(t *testing.T) {
 	id := addComment(t, c1, ts)
 
 	client := http.Client{}
+	defer client.CloseIdleConnections()
 	req, err := http.NewRequest(http.MethodPut, ts.URL+"/api/v1/comment/"+id+"?site=remark42&url=https://radio-t.com/blah1",
 		strings.NewReader(`{"text":"updated text", "summary":"my edit"}`))
 	assert.NoError(t, err)
@@ -304,6 +306,7 @@ func TestRest_UpdateDelete(t *testing.T) {
 
 	// delete a comment
 	client := http.Client{}
+	defer client.CloseIdleConnections()
 	req, err := http.NewRequest(http.MethodPut, ts.URL+"/api/v1/comment/"+id+"?site=remark42&url=https://radio-t.com/blah1",
 		strings.NewReader(`{"delete": true, "summary":"removed by user"}`))
 	require.NoError(t, err)
@@ -356,6 +359,7 @@ func TestRest_UpdateNotOwner(t *testing.T) {
 	assert.NoError(t, err)
 
 	client := http.Client{}
+	defer client.CloseIdleConnections()
 	req, err := http.NewRequest(http.MethodPut, ts.URL+"/api/v1/comment/"+id1+
 		"?site=remark42&url=https://radio-t.com/blah1", strings.NewReader(`{"text":"updated text", "summary":"my edit"}`))
 	assert.NoError(t, err)
@@ -369,6 +373,7 @@ func TestRest_UpdateNotOwner(t *testing.T) {
 	assert.Equal(t, `{"code":3,"details":"can not edit comments for other users","error":"rejected"}`+"\n", string(body))
 
 	client = http.Client{}
+	defer client.CloseIdleConnections()
 	req, err = http.NewRequest(http.MethodPut, ts.URL+"/api/v1/comment/"+id1+
 		"?site=remark42&url=https://radio-t.com/blah1", strings.NewReader(`ERRR "text":"updated text", "summary":"my"}`))
 	assert.NoError(t, err)
@@ -388,6 +393,7 @@ func TestRest_UpdateWrongAud(t *testing.T) {
 	id := addComment(t, c1, ts)
 
 	client := http.Client{}
+	defer client.CloseIdleConnections()
 	req, err := http.NewRequest(http.MethodPut, ts.URL+"/api/v1/comment/"+id+"?site=remark42&url=https://radio-t.com/blah1",
 		strings.NewReader(`{"text":"updated text", "summary":"my edit"}`))
 	assert.NoError(t, err)
@@ -407,6 +413,7 @@ func TestRest_UpdateWithRestrictedWords(t *testing.T) {
 	id := addComment(t, c1, ts)
 
 	client := http.Client{}
+	defer client.CloseIdleConnections()
 	req, err := http.NewRequest(http.MethodPut, ts.URL+"/api/v1/comment/"+id+"?site=remark42&url=https://radio-t.com/blah1",
 		strings.NewReader(`{"text":"What the duck is that?", "summary":"my edit"}`))
 	assert.NoError(t, err)
@@ -438,6 +445,7 @@ func TestRest_Vote(t *testing.T) {
 
 	vote := func(val int) int {
 		client := http.Client{}
+		defer client.CloseIdleConnections()
 		req, err := http.NewRequest(http.MethodPut,
 			fmt.Sprintf("%s/api/v1/vote/%s?site=remark42&url=https://radio-t.com/blah&vote=%d", ts.URL, id1, val), http.NoBody)
 		assert.NoError(t, err)
@@ -527,6 +535,7 @@ func TestRest_AnonVote(t *testing.T) {
 
 	vote := func(val int) int {
 		client := http.Client{}
+		defer client.CloseIdleConnections()
 		req, err := http.NewRequest(http.MethodPut,
 			fmt.Sprintf("%s/api/v1/vote/%s?site=remark42&url=https://radio-t.com/blah&vote=%d", ts.URL, id1, val), http.NoBody)
 		assert.NoError(t, err)
@@ -539,6 +548,7 @@ func TestRest_AnonVote(t *testing.T) {
 
 	getWithAnonAuth := func(url string) (body string, code int) {
 		client := &http.Client{Timeout: 5 * time.Second}
+		defer client.CloseIdleConnections()
 		req, err := http.NewRequest("GET", url, http.NoBody)
 		require.NoError(t, err)
 		req.Header.Add("X-JWT", anonToken)
@@ -629,6 +639,7 @@ func TestRest_EmailAndTelegram(t *testing.T) {
 		{description: "set user telegram, token is good", url: "/api/v1/telegram/subscribe?site=remark42&tkn=good_token", method: http.MethodGet, responseCode: http.StatusOK},
 	}
 	client := http.Client{}
+	defer client.CloseIdleConnections()
 	for _, x := range testData {
 		x := x
 		t.Run(x.description, func(t *testing.T) {
@@ -664,6 +675,7 @@ func TestRest_EmailNotification(t *testing.T) {
 	defer srv.privRest.notifyService.Close()
 
 	client := http.Client{}
+	defer client.CloseIdleConnections()
 
 	// create new comment from dev user
 	req, err := http.NewRequest("POST", ts.URL+"/api/v1/comment", strings.NewReader(
@@ -809,6 +821,7 @@ func TestRest_TelegramNotification(t *testing.T) {
 	defer srv.privRest.notifyService.Close()
 
 	client := http.Client{}
+	defer client.CloseIdleConnections()
 
 	// create new comment from dev user
 	req, err := http.NewRequest("POST", ts.URL+"/api/v1/comment", strings.NewReader(
@@ -1015,6 +1028,7 @@ func TestRest_UserAllData(t *testing.T) {
 	require.NoError(t, err)
 
 	client := &http.Client{Timeout: 1 * time.Second}
+	defer client.CloseIdleConnections()
 	req, err := http.NewRequest("GET", ts.URL+"/api/v1/userdata?site=remark42", http.NoBody)
 	require.NoError(t, err)
 	req.Header.Add("X-JWT", devToken)
@@ -1067,6 +1081,7 @@ func TestRest_UserAllDataManyComments(t *testing.T) {
 		require.NoError(t, err)
 	}
 	client := &http.Client{Timeout: 1 * time.Second}
+	defer client.CloseIdleConnections()
 	req, err := http.NewRequest("GET", ts.URL+"/api/v1/userdata?site=remark42", http.NoBody)
 	require.NoError(t, err)
 	req.Header.Add("X-JWT", devToken)
@@ -1091,6 +1106,7 @@ func TestRest_DeleteMe(t *testing.T) {
 	defer teardown()
 
 	client := http.Client{}
+	defer client.CloseIdleConnections()
 	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v1/deleteme?site=remark42", ts.URL), http.NoBody)
 	assert.NoError(t, err)
 	req.Header.Add("X-JWT", devToken)
@@ -1137,6 +1153,7 @@ func TestRest_SavePictureCtrl(t *testing.T) {
 		require.NoError(t, bodyWriter.Close())
 
 		client := http.Client{}
+		defer client.CloseIdleConnections()
 		req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v1/picture", ts.URL), bodyBuf)
 		require.NoError(t, err)
 		req.Header.Add("Content-Type", contentType)
@@ -1228,6 +1245,7 @@ func TestRest_CreateWithPictures(t *testing.T) {
 		contentType := bodyWriter.FormDataContentType()
 		require.NoError(t, bodyWriter.Close())
 		client := http.Client{}
+		defer client.CloseIdleConnections()
 		req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v1/picture", ts.URL), bodyBuf)
 		require.NoError(t, err)
 		req.Header.Add("Content-Type", contentType)

--- a/backend/app/rest/api/rest_public_test.go
+++ b/backend/app/rest/api/rest_public_test.go
@@ -269,6 +269,7 @@ func TestRest_FindReadOnly(t *testing.T) {
 
 	// set post to read-only
 	client := http.Client{}
+	defer client.CloseIdleConnections()
 	req, err := http.NewRequest(http.MethodPut,
 		fmt.Sprintf("%s/api/v1/admin/readonly?site=remark42&url=https://radio-t.com/blah1&ro=1", ts.URL), http.NoBody)
 	assert.NoError(t, err)

--- a/backend/app/rest/api/rest_test.go
+++ b/backend/app/rest/api/rest_test.go
@@ -147,6 +147,7 @@ func TestRest_RunStaticSSLMode(t *testing.T) {
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		},
 	}
+	defer client.CloseIdleConnections()
 
 	resp, err := client.Get(fmt.Sprintf("http://localhost:%d/blah?param=1", port))
 	require.NoError(t, err)
@@ -191,6 +192,7 @@ func TestRest_RunAutocertModeHTTPOnly(t *testing.T) {
 			return http.ErrUseLastResponse
 		},
 	}
+	defer client.CloseIdleConnections()
 
 	resp, err := client.Get(fmt.Sprintf("http://localhost:%d/blah?param=1", port))
 	require.NoError(t, err)
@@ -510,6 +512,7 @@ func get(t *testing.T, url string) (response string, statusCode int) {
 
 func sendReq(_ *testing.T, r *http.Request, tkn string) (*http.Response, error) {
 	client := http.Client{Timeout: 5 * time.Second}
+	defer client.CloseIdleConnections()
 	if tkn != "" {
 		r.Header.Set("X-JWT", tkn)
 	}
@@ -518,6 +521,7 @@ func sendReq(_ *testing.T, r *http.Request, tkn string) (*http.Response, error) 
 
 func getWithDevAuth(t *testing.T, url string) (body string, code int) {
 	client := &http.Client{Timeout: 5 * time.Second}
+	defer client.CloseIdleConnections()
 	req, err := http.NewRequest("GET", url, http.NoBody)
 	require.NoError(t, err)
 	req.Header.Add("X-JWT", devToken)
@@ -531,6 +535,7 @@ func getWithDevAuth(t *testing.T, url string) (body string, code int) {
 
 func getWithAdminAuth(t *testing.T, url string) (response string, statusCode int) {
 	client := &http.Client{Timeout: 5 * time.Second}
+	defer client.CloseIdleConnections()
 	req, err := http.NewRequest("GET", url, http.NoBody)
 	require.NoError(t, err)
 	req.SetBasicAuth("admin", "password")
@@ -543,6 +548,7 @@ func getWithAdminAuth(t *testing.T, url string) (response string, statusCode int
 }
 func post(t *testing.T, url, body string) (*http.Response, error) {
 	client := &http.Client{Timeout: 5 * time.Second}
+	defer client.CloseIdleConnections()
 	req, err := http.NewRequest("POST", url, strings.NewReader(body))
 	assert.NoError(t, err)
 	req.SetBasicAuth("admin", "password")
@@ -554,6 +560,7 @@ func addComment(t *testing.T, c store.Comment, ts *httptest.Server) string {
 	require.NoError(t, err, "can't marshal comment %+v", c)
 
 	client := &http.Client{Timeout: 5 * time.Second}
+	defer client.CloseIdleConnections()
 	req, err := http.NewRequest("POST", ts.URL+"/api/v1/comment", bytes.NewBuffer(b))
 	require.NoError(t, err)
 	req.Header.Add("X-JWT", devToken)

--- a/backend/app/rest/api/ssl_test.go
+++ b/backend/app/rest/api/ssl_test.go
@@ -30,6 +30,7 @@ func TestSSL_Redirect(t *testing.T) {
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		},
 	}
+	defer client.CloseIdleConnections()
 
 	// check http to https redirect response
 	resp, err := client.Get(ts.URL + "/blah?param=1")
@@ -59,6 +60,7 @@ func TestSSL_ACME_HTTPChallengeRouter(t *testing.T) {
 			return http.ErrUseLastResponse
 		},
 	}
+	defer client.CloseIdleConnections()
 
 	// check http to https redirect response
 	resp, err := client.Get(ts.URL + "/blah?param=1")

--- a/backend/app/rest/proxy/image.go
+++ b/backend/app/rest/proxy/image.go
@@ -145,6 +145,7 @@ func (p Image) downloadImage(ctx context.Context, imgURL string) ([]byte, error)
 	defer cancel()
 
 	client := http.Client{Timeout: 30 * time.Second}
+	defer client.CloseIdleConnections()
 	var resp *http.Response
 	err := repeater.NewDefault(5, time.Second).Do(ctx, func() error {
 		var e error

--- a/backend/app/store/engine/remote.go
+++ b/backend/app/store/engine/remote.go
@@ -112,5 +112,6 @@ func (r *RPC) Delete(req DeleteRequest) error {
 // Close storage engine
 func (r *RPC) Close() error {
 	_, err := r.Call("store.close")
+	r.Client.Client.CloseIdleConnections()
 	return err
 }

--- a/backend/app/store/service/title.go
+++ b/backend/app/store/service/title.go
@@ -40,6 +40,7 @@ func NewTitleExtractor(client http.Client) *TitleExtractor {
 // Get page for url and return title
 func (t *TitleExtractor) Get(url string) (string, error) {
 	client := http.Client{Timeout: t.client.Timeout, Transport: t.client.Transport}
+	defer client.CloseIdleConnections()
 	b, err := t.cache.Get(url, func() (interface{}, error) {
 		resp, err := client.Get(url)
 		if err != nil {
@@ -72,6 +73,7 @@ func (t *TitleExtractor) Get(url string) (string, error) {
 
 // Close title extractor
 func (t *TitleExtractor) Close() error {
+	t.client.CloseIdleConnections()
 	return t.cache.Close()
 }
 


### PR DESCRIPTION
- cleanup files in `/tmp` after integrational tests
- call CloseIdleConnections on `http` clients, as without this `go.uber.org/goleak` reports leaking goroutine caused by HTTP client on many tests when ran one by one.