### PR TITLE
Links rune

### DIFF
--- a/backend/app/store/formatter.go
+++ b/backend/app/store/formatter.go
@@ -83,11 +83,12 @@ func (f *CommentFormatter) shortenAutoLinks(commentHTML string, max int) (resHTM
 			if host == "" {
 				return
 			}
-			short := href[:max-3]
+
+			short := string([]rune(href)[:max-3])
 			if len(short) < len(host) {
 				short = host
 			}
-			s.SetText(short + "...")
+			s.SetText(string(short) + "...")
 		}
 	})
 	resHTML, err = doc.Find("body").Html()

--- a/backend/app/store/formatter.go
+++ b/backend/app/store/formatter.go
@@ -88,7 +88,7 @@ func (f *CommentFormatter) shortenAutoLinks(commentHTML string, max int) (resHTM
 			if len(short) < len(host) {
 				short = host
 			}
-			s.SetText(string(short) + "...")
+			s.SetText(short + "...")
 		}
 	})
 	resHTML, err = doc.Find("body").Html()

--- a/backend/app/store/formatter_test.go
+++ b/backend/app/store/formatter_test.go
@@ -26,6 +26,10 @@ func TestFormatter_FormatText(t *testing.T) {
 				"1/some-long-link/12345/6789012...</a></p>\n!converted", "links",
 		},
 		{
+			"something https://amp.dw.com/ru/илон-маск-купил-twitter/a-61590911",
+			"<p>something <a href=\"https://amp.dw.com/ru/илон-маск-купил-twitter/a-61590911\">https://amp.dw.com/ru/илон-маск-купил-twitter...</a></p>\n!converted", "links",
+		},
+		{
 			"something <img src=\"some.png\"/>  _aaa_",
 			"<p>something <img src=\"some.png\" loading=\"lazy\"/>  <em>aaa</em></p>\n!converted",
 			"lazy image",


### PR DESCRIPTION
Short automatic links in messages got stipped as bytes, not rune

The text like this `https://amp.dw.com/ru/илон-маск-купил-twitter/a-61590911` was converted to [https://amp.dw.com/ru/илон-маск-ку�...](https://amp.dw.com/ru/%D0%B8%D0%BB%D0%BE%D0%BD-%D0%BC%D0%B0%D1%81%D0%BA-%D0%BA%D1%83%D0%BF%D0%B8%D0%BB-twitter/a-61590911)

the fix is to treat links as rune