### PR TITLE
rename "store" to "storage" and "picture" to "image"

### DIFF
--- a/backend/_example/memory_store/README.md
+++ b/backend/_example/memory_store/README.md
@@ -1,4 +1,4 @@
-# sample store implementation
+# sample storage implementation
 
 `memory_store` illustrates how to make a custom storage plugin for remark42.
 

--- a/backend/_example/memory_store/accessor/admin.go
+++ b/backend/_example/memory_store/accessor/admin.go
@@ -31,7 +31,7 @@ type AdminRec struct {
 
 // NewMemAdminStore makes admin Store in memory
 func NewMemAdminStore(key string) *MemAdmin {
-	log.Print("[DEBUG] make memory admin store")
+	log.Print("[DEBUG] make memory admin storage")
 	return &MemAdmin{data: map[string]AdminRec{}, key: key}
 }
 

--- a/backend/_example/memory_store/accessor/data_test.go
+++ b/backend/_example/memory_store/accessor/data_test.go
@@ -747,7 +747,7 @@ func TestMemAdmin_DeleteUserHard(t *testing.T) {
 	assert.Equal(t, 0, c, "0 count")
 
 	_, err = b.Find(engine.FindRequest{Locator: store.Locator{SiteID: "radio-t"}, UserID: "user1", Limit: 5})
-	assert.NoError(t, err, "no comments for user user1 in store")
+	assert.NoError(t, err, "no comments for user user1 in storage")
 
 	comments, err = b.Find(engine.FindRequest{Locator: store.Locator{SiteID: "radio-t"}, Sort: "time"})
 	assert.NoError(t, err)
@@ -773,7 +773,7 @@ func TestMemAdmin_DeleteUserSoft(t *testing.T) {
 	assert.Equal(t, 0, c, "0 count")
 
 	comments, err = b.Find(engine.FindRequest{Locator: store.Locator{SiteID: "radio-t"}, UserID: "user1", Limit: 5})
-	assert.NoError(t, err, "no comments for user user1 in store")
+	assert.NoError(t, err, "no comments for user user1 in storage")
 	require.Equal(t, 2, len(comments), "2 comments with deleted info")
 	assert.True(t, comments[0].Deleted)
 	assert.True(t, comments[1].Deleted)

--- a/backend/_example/memory_store/accessor/image.go
+++ b/backend/_example/memory_store/accessor/image.go
@@ -27,7 +27,7 @@ type MemImage struct {
 
 // NewMemImageStore makes admin Store in memory.
 func NewMemImageStore() *MemImage {
-	log.Print("[DEBUG] make memory image store")
+	log.Print("[DEBUG] make memory image storage")
 	return &MemImage{
 		imagesStaging: map[string][]byte{},
 		images:        map[string][]byte{},

--- a/backend/_example/memory_store/server/rpc.go
+++ b/backend/_example/memory_store/server/rpc.go
@@ -14,7 +14,7 @@ import (
 	"github.com/umputun/remark42/backend/app/store/image"
 )
 
-// RPC handler wraps both engine and remote server and implements all handlers for data store and admin store
+// RPC handler wraps both engine and remote server and implements all handlers for data store and admin storage
 // Note: this file can be used as-is in any custom jrpc plugin
 type RPC struct {
 	*jrpc.Server
@@ -46,7 +46,7 @@ func (s *RPC) addHandlers() {
 		"close":       s.closeHndl,
 	})
 
-	// admin store handlers
+	// admin storage handlers
 	s.Group("admin", jrpc.HandlersGroup{
 		"key":     s.admKeyHndl,
 		"admins":  s.admAdminsHndl,

--- a/backend/app/cmd/avatar.go
+++ b/backend/app/cmd/avatar.go
@@ -28,7 +28,7 @@ type AvatarMigrator interface {
 
 type avatarMigrator struct{}
 
-// Migrate from one avatar store to another. Can be used to convert between stores
+// Migrate from one avatar storage to another. Can be used to convert between storages
 func (a avatarMigrator) Migrate(dst, src avatar.Store) (int, error) {
 	return avatar.Migrate(dst, src)
 }
@@ -39,12 +39,12 @@ func (ac *AvatarCommand) Execute(_ []string) error {
 
 	src, err := ac.makeAvatarStore(ac.AvatarSrc)
 	if err != nil {
-		return fmt.Errorf("can't make avatart store for %s: %w", ac.AvatarSrc.Type, err)
+		return fmt.Errorf("can't make avatart storage for %s: %w", ac.AvatarSrc.Type, err)
 	}
 
 	dst, err := ac.makeAvatarStore(ac.AvatarDst)
 	if err != nil {
-		return fmt.Errorf("can't make avatart store for %s: %w", ac.AvatarDst.Type, err)
+		return fmt.Errorf("can't make avatart storage for %s: %w", ac.AvatarDst.Type, err)
 	}
 
 	if ac.migrator == nil {
@@ -57,10 +57,10 @@ func (ac *AvatarCommand) Execute(_ []string) error {
 	}
 
 	if err = dst.Close(); err != nil {
-		log.Printf("[WARN] failed to close dst store %s", ac.AvatarDst.Type)
+		log.Printf("[WARN] failed to close dst storage %s", ac.AvatarDst.Type)
 	}
 	if err = src.Close(); err != nil {
-		log.Printf("[WARN] failed to close src store %s", ac.AvatarSrc.Type)
+		log.Printf("[WARN] failed to close src storage %s", ac.AvatarSrc.Type)
 	}
 
 	log.Printf("[INFO] completed, migrated avatars = %d", count)
@@ -68,18 +68,18 @@ func (ac *AvatarCommand) Execute(_ []string) error {
 }
 
 func (ac *AvatarCommand) makeAvatarStore(gr AvatarGroup) (avatar.Store, error) {
-	log.Printf("[DEBUG] make avatar store, type=%s", gr.Type)
+	log.Printf("[DEBUG] make avatar storage, type=%s", gr.Type)
 	switch gr.Type {
 	case "fs":
 		if err := makeDirs(gr.FS.Path); err != nil {
-			return nil, fmt.Errorf("failed to create avatar store: %w", err)
+			return nil, fmt.Errorf("failed to create avatar storage: %w", err)
 		}
 		return avatar.NewLocalFS(gr.FS.Path), nil
 	case "bolt":
 		if err := makeDirs(path.Dir(gr.Bolt.File)); err != nil {
-			return nil, fmt.Errorf("failed to create avatar store: %w", err)
+			return nil, fmt.Errorf("failed to create avatar storage: %w", err)
 		}
 		return avatar.NewBoltDB(gr.Bolt.File, bolt.Options{})
 	}
-	return nil, fmt.Errorf("unsupported avatar store type %s", gr.Type)
+	return nil, fmt.Errorf("unsupported avatar storage type %s", gr.Type)
 }

--- a/backend/app/cmd/server_test.go
+++ b/backend/app/cmd/server_test.go
@@ -319,7 +319,7 @@ func TestServerApp_Failed(t *testing.T) {
 	_, err := p.ParseArgs([]string{"--backup=/tmp", "--store.bolt.path=/dev/null", "--image.fs.path=/tmp"})
 	assert.NoError(t, err)
 	_, err = opts.newServerApp(context.Background())
-	assert.EqualError(t, err, "failed to make data store engine: failed to create bolt store: can't make directory /dev/null: mkdir /dev/null: not a directory")
+	assert.EqualError(t, err, "failed to make data storage: failed to create bolt storage: can't make directory /dev/null: mkdir /dev/null: not a directory")
 	t.Log(err)
 
 	// RO backup location
@@ -330,7 +330,7 @@ func TestServerApp_Failed(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.Remove("/tmp/remark.db")
 	_, err = opts.newServerApp(context.Background())
-	assert.EqualError(t, err, "failed to create backup store: can't make directory /dev/null/not-writable: mkdir /dev/null: not a directory")
+	assert.EqualError(t, err, "failed to create backup storage: can't make directory /dev/null/not-writable: mkdir /dev/null: not a directory")
 	t.Log(err)
 
 	// invalid url
@@ -351,7 +351,7 @@ func TestServerApp_Failed(t *testing.T) {
 
 	opts.Store.Type = "blah"
 	_, err = opts.newServerApp(context.Background())
-	assert.EqualError(t, err, "failed to make data store engine: unsupported store type blah")
+	assert.EqualError(t, err, "failed to make data storage: unsupported storage type blah")
 	t.Log(err)
 
 	// wrong redis location

--- a/backend/app/rest/api/admin_test.go
+++ b/backend/app/rest/api/admin_test.go
@@ -163,7 +163,7 @@ func TestAdmin_DeleteUser(t *testing.T) {
 	c3 := store.Comment{Text: "test test #3", Orig: "o test test #3", User: store.User{ID: "id2", Name: "name"}, ParentID: "",
 		Locator: store.Locator{SiteID: "remark42", URL: "https://radio-t.com/blah"}}
 
-	// write comments directly to store to keep user id
+	// write comments directly to storage to keep user id
 	id1, err := srv.DataService.Create(c1)
 	assert.NoError(t, err)
 	_, err = srv.DataService.Create(c2)
@@ -731,7 +731,7 @@ func TestAdmin_DeleteMeRequest(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	_, err = srv.DataService.User("remark42", "user1", 0, 0, store.User{})
-	assert.EqualError(t, err, "no comments for user user1 in store")
+	assert.EqualError(t, err, "no comments for user user1 in storage")
 
 	email, err = srv.DataService.GetUserEmail("remark42", "user1")
 	assert.NoError(t, err)

--- a/backend/app/rest/api/rest_private.go
+++ b/backend/app/rest/api/rest_private.go
@@ -92,7 +92,7 @@ func (s *private) previewCommentCtrl(w http.ResponseWriter, r *http.Request) {
 	comment.Sanitize()
 
 	// check if images are valid
-	for _, id := range s.imageService.ExtractPictures(comment.Text) {
+	for _, id := range s.imageService.ExtractImages(comment.Text) {
 		err := s.imageService.ResetCleanupTimer(id)
 		if err != nil {
 			rest.SendErrorJSON(w, r, http.StatusBadRequest, err, "can't renew staged picture cleanup timer", rest.ErrImgNotFound)
@@ -131,7 +131,7 @@ func (s *private) createCommentCtrl(w http.ResponseWriter, r *http.Request) {
 	comment = s.commentFormatter.Format(comment)
 
 	// check if images are valid
-	for _, id := range s.imageService.ExtractPictures(comment.Text) {
+	for _, id := range s.imageService.ExtractImages(comment.Text) {
 		_, err := s.imageService.Load(id)
 		if err != nil {
 			rest.SendErrorJSON(w, r, http.StatusBadRequest, err, "can't load picture from the comment", rest.ErrImgNotFound)

--- a/backend/app/rest/api/rest_public.go
+++ b/backend/app/rest/api/rest_public.go
@@ -218,7 +218,7 @@ func (s *public) findUserCommentsCtrl(w http.ResponseWriter, r *http.Request) {
 	data, err := s.cache.Get(key, func() ([]byte, error) {
 		comments, e := s.dataService.User(siteID, userID, limit, skip, rest.GetUserOrEmpty(r))
 		if e != nil {
-			if strings.Contains(e.Error(), "no comments for user") { // store returns this error when no comments found
+			if strings.Contains(e.Error(), "no comments for user") { // storage returns this error when no comments found
 				resp.Comments, resp.Count = []store.Comment{}, 0
 				return encodeJSONWithHTML(resp)
 			}

--- a/backend/app/store/admin/admin.go
+++ b/backend/app/store/admin/admin.go
@@ -1,4 +1,4 @@
-// Package admin defines and implements store for admin-level data like secret key, list of admins and so on
+// Package admin defines and implements storage for admin-level data like secret key, list of admins and so on
 package admin
 
 import (
@@ -50,7 +50,7 @@ func NewStaticKeyStore(key string) *StaticStore {
 // Key returns static key, same for all sites
 func (s *StaticStore) Key(_ string) (key string, err error) {
 	if s.key == "" {
-		return "", fmt.Errorf("empty key for static key store")
+		return "", fmt.Errorf("empty key for static key storage")
 	}
 	return s.key, nil
 }

--- a/backend/app/store/admin/admin_test.go
+++ b/backend/app/store/admin/admin_test.go
@@ -11,7 +11,7 @@ func TestStaticStore_Get(t *testing.T) {
 		[]string{"123", "xyz"}, "aa@example.com")
 
 	k, err := ks.Key("any")
-	assert.NoError(t, err, "valid store")
+	assert.NoError(t, err, "valid storage")
 	assert.Equal(t, "key123", k, "valid site")
 
 	a, err := ks.Admins("s1")

--- a/backend/app/store/engine/bolt.go
+++ b/backend/app/store/engine/bolt.go
@@ -98,9 +98,9 @@ func (b *BoltDB) Create(comment store.Comment) (commentID string, err error) {
 		if postBkt, err = b.makePostBucket(tx, comment.Locator.URL); err != nil {
 			return err
 		}
-		// check if key already in store, reject doubles
+		// check if key already in storage, reject doubles
 		if postBkt.Get([]byte(comment.ID)) != nil {
-			return fmt.Errorf("key %s already in store", comment.ID)
+			return fmt.Errorf("key %s already in storage", comment.ID)
 		}
 
 		// serialize comment to json []byte for bolt and save
@@ -276,7 +276,7 @@ func (b *BoltDB) Count(req FindRequest) (count int, err error) {
 			usersBkt := tx.Bucket([]byte(userBucketName))
 			userIDBkt := usersBkt.Bucket([]byte(req.UserID))
 			if userIDBkt == nil {
-				return fmt.Errorf("no comments for user %s in store for %s site", req.UserID, req.Locator.SiteID)
+				return fmt.Errorf("no comments for user %s in storage for %s site", req.UserID, req.Locator.SiteID)
 			}
 			stats := userIDBkt.Stats()
 			count = stats.KeyN
@@ -497,7 +497,7 @@ func (b *BoltDB) userComments(siteID, userID string, limit, skip int) (comments 
 		usersBkt := tx.Bucket([]byte(userBucketName))
 		userIDBkt := usersBkt.Bucket([]byte(userID))
 		if userIDBkt == nil {
-			return fmt.Errorf("no comments for user %s in store", userID)
+			return fmt.Errorf("no comments for user %s in storage", userID)
 		}
 
 		c := userIDBkt.Cursor()
@@ -931,7 +931,7 @@ func (b *BoltDB) getPostBucket(tx *bolt.Tx, postURL string) (*bolt.Bucket, error
 	}
 	res := postsBkt.Bucket([]byte(postURL))
 	if res == nil {
-		return nil, fmt.Errorf("no bucket %s in store", postURL)
+		return nil, fmt.Errorf("no bucket %s in storage", postURL)
 	}
 	return res, nil
 }
@@ -944,7 +944,7 @@ func (b *BoltDB) makePostBucket(tx *bolt.Tx, postURL string) (*bolt.Bucket, erro
 	}
 	res, err := postsBkt.CreateBucketIfNotExists([]byte(postURL))
 	if err != nil {
-		return nil, fmt.Errorf("no bucket %s in store: %w", postURL, err)
+		return nil, fmt.Errorf("no bucket %s in storage: %w", postURL, err)
 	}
 	return res, nil
 }

--- a/backend/app/store/engine/bolt_test.go
+++ b/backend/app/store/engine/bolt_test.go
@@ -32,7 +32,7 @@ func TestBoltDB_CreateAndFind(t *testing.T) {
 
 	_, err = b.Create(store.Comment{ID: res[0].ID, Locator: store.Locator{URL: "https://radio-t.com", SiteID: "radio-t"}})
 	assert.Error(t, err)
-	assert.Equal(t, "key id-1 already in store", err.Error())
+	assert.Equal(t, "key id-1 already in storage", err.Error())
 
 	req = FindRequest{Locator: store.Locator{URL: "https://radio-t.com", SiteID: "radio-t-bad"}, Sort: "time"}
 	_, err = b.Find(req)
@@ -119,7 +119,7 @@ func TestBoltDB_Update(t *testing.T) {
 	comment.Locator.SiteID = "radio-t"
 	comment.Locator.URL = "https://radio-t.com-bad"
 	err = b.Update(comment)
-	assert.EqualError(t, err, `no bucket https://radio-t.com-bad in store`)
+	assert.EqualError(t, err, `no bucket https://radio-t.com-bad in storage`)
 }
 
 func TestBoltDB_FindLast(t *testing.T) {
@@ -217,7 +217,7 @@ func TestBoltDB_FindForUser(t *testing.T) {
 
 	req = FindRequest{Locator: store.Locator{SiteID: "radio-t"}, Sort: "-time", UserID: "userZ", Limit: 1, Skip: 1}
 	_, err = b.Find(req)
-	assert.EqualError(t, err, `no comments for user userZ in store`)
+	assert.EqualError(t, err, `no comments for user userZ in storage`)
 }
 
 func TestBoltDB_FindForUserPagination(t *testing.T) {
@@ -317,7 +317,7 @@ func TestBoltDB_CountUser(t *testing.T) {
 
 	req = FindRequest{Locator: store.Locator{SiteID: "radio-t"}, UserID: "userZ"}
 	_, err = b.Count(req)
-	assert.EqualError(t, err, `no comments for user userZ in store for radio-t site`)
+	assert.EqualError(t, err, `no comments for user userZ in storage for radio-t site`)
 }
 
 func TestBoltDB_InfoPost(t *testing.T) {
@@ -716,7 +716,7 @@ func TestBolt_DeleteComment(t *testing.T) {
 
 	delReq.Locator = store.Locator{URL: "https://radio-t.com/bad", SiteID: "radio-t"}
 	err = b.Delete(delReq)
-	assert.EqualError(t, err, `no bucket https://radio-t.com/bad in store`)
+	assert.EqualError(t, err, `no bucket https://radio-t.com/bad in storage`)
 }
 
 func TestBolt_DeleteHard(t *testing.T) {
@@ -830,7 +830,7 @@ func TestBoltAdmin_DeleteUserHard(t *testing.T) {
 	assert.Equal(t, 0, c, "0 count")
 
 	_, err = b.Find(FindRequest{Locator: store.Locator{SiteID: "radio-t"}, UserID: "user1", Limit: 5})
-	assert.EqualError(t, err, "no comments for user user1 in store")
+	assert.EqualError(t, err, "no comments for user user1 in storage")
 
 	comments, err = b.Find(FindRequest{Locator: store.Locator{SiteID: "radio-t"}, Sort: "time"})
 	assert.NoError(t, err)
@@ -870,7 +870,7 @@ func TestBoltAdmin_DeleteUserSoft(t *testing.T) {
 	assert.Equal(t, 0, c, "0 count")
 
 	comments, err = b.Find(FindRequest{Locator: store.Locator{SiteID: "radio-t"}, UserID: "user1", Limit: 5})
-	assert.NoError(t, err, "no comments for user user1 in store")
+	assert.NoError(t, err, "no comments for user user1 in storage")
 	require.Equal(t, 2, len(comments), "2 comments with deleted info")
 	assert.True(t, comments[0].Deleted)
 	assert.True(t, comments[1].Deleted)

--- a/backend/app/store/image/bolt_store.go
+++ b/backend/app/store/image/bolt_store.go
@@ -23,7 +23,7 @@ type Bolt struct {
 	db       *bolt.DB
 }
 
-// NewBoltStorage create bolt image store
+// NewBoltStorage create bolt image storage
 func NewBoltStorage(fileName string, options bolt.Options) (*Bolt, error) {
 	db, err := bolt.Open(fileName, 0o600, &options) //nolint:gocritic //octalLiteral is OK as FileMode
 	if err != nil {

--- a/backend/app/store/image/image.go
+++ b/backend/app/store/image/image.go
@@ -32,7 +32,7 @@ import (
 	"golang.org/x/image/draw"
 )
 
-// Service wraps Store with common functions needed for any store implementation
+// Service wraps Store with common functions needed for any storage implementation
 // It also provides async Submit with func param retrieving all submitting IDs.
 // Submitted IDs committed (i.e. moved from staging to final) on ServiceParams.EditDuration expiration.
 type Service struct {
@@ -56,7 +56,7 @@ type ServiceParams struct {
 	MaxWidth     int
 }
 
-// StoreInfo contains image store meta information
+// StoreInfo contains image storage meta information
 type StoreInfo struct {
 	FirstStagingImageTS time.Time
 }
@@ -64,7 +64,7 @@ type StoreInfo struct {
 // To regenerate mock run from this directory:
 // sh -c "mockery -inpkg -name Store -print > /tmp/image-mock.tmp && mv /tmp/image-mock.tmp image_mock.go"
 
-// Store defines interface for saving and loading pictures.
+// Store defines interface for saving and loading images.
 // Declares two-stage save with Commit. Save stores to staging area and Commit moves to the final location.
 // Two-stage commit scheme is used for not storing images which are uploaded but later never used in the comments,
 // e.g. when somebody uploaded a picture but did not sent the comment.
@@ -141,8 +141,8 @@ func (s *Service) Submit(idsFn func() []string) {
 	s.submitCh <- submitReq{idsFn: idsFn, TS: time.Now()}
 }
 
-// ExtractPictures gets list of images from the doc html and convert from urls to ids, i.e. user/pic.png
-func (s *Service) ExtractPictures(commentHTML string) (ids []string) {
+// ExtractImages gets list of images from the doc html and convert from urls to ids, i.e. user/pic.png
+func (s *Service) ExtractImages(commentHTML string) (ids []string) {
 	doc, err := goquery.NewDocumentFromReader(strings.NewReader(commentHTML))
 	if err != nil {
 		log.Printf("[ERROR] can't parse commentHTML to parse images: %q, error: %v", commentHTML, err)
@@ -181,7 +181,7 @@ func (s *Service) ExtractPictures(commentHTML string) (ids []string) {
 // Cleanup runs periodic cleanup with 1.5*ServiceParams.EditDuration. Blocking loop, should be called inside of goroutine by consumer
 func (s *Service) Cleanup(ctx context.Context) {
 	cleanupTTL := s.EditDuration * 15 / 10 // cleanup images older than 1.5 * EditDuration
-	log.Printf("[INFO] start pictures cleanup, staging ttl=%v", cleanupTTL)
+	log.Printf("[INFO] start images cleanup, staging ttl=%v", cleanupTTL)
 
 	for {
 		select {

--- a/backend/app/store/image/image_test.go
+++ b/backend/app/store/image/image_test.go
@@ -72,11 +72,11 @@ func TestService_WrongFormat(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestService_ExtractPictures(t *testing.T) {
+func TestService_ExtractImages(t *testing.T) {
 	svc := Service{ServiceParams: ServiceParams{ImageAPI: "/blah/", ProxyAPI: "/non_existent"}}
 	html := `blah <img src="/blah/user1/pic1.png"/> foo
 <img src="/blah/user2/pic3.png"/> xyz <p>123</p> <img src="/pic3.png"/> <img src="https://i.ibb.co/0cqqqnD/ezgif-5-3b07b6b97610.png" alt="">`
-	ids := svc.ExtractPictures(html)
+	ids := svc.ExtractImages(html)
 	require.Equal(t, 2, len(ids), "two images")
 	assert.Equal(t, "user1/pic1.png", ids[0])
 	assert.Equal(t, "user2/pic3.png", ids[1])
@@ -88,30 +88,30 @@ func TestService_ExtractPictures(t *testing.T) {
 <p><img src="https://remark42.radio-t.com/api/v1/picture/github_ef0f706a79cc24b17bbbb374cd234a691d034128/bjttt8ahajfmrhsula10.png" alt="bjtr0-201906-08110846-i324c.png"/></p>\n\n<p>
 По форме все верно, это все packages, но по сути это все одна библиотека организованная таким образом. При ее импорте, например посредством go mod, она выглядит как один модуль, т.е.
 <code>github.com/go-pkgz/auth v0.5.2</code>.</p>\n`
-	ids = svc.ExtractPictures(html)
+	ids = svc.ExtractImages(html)
 	require.Equal(t, 1, len(ids), "one image in")
 	assert.Equal(t, "github_ef0f706a79cc24b17bbbb374cd234a691d034128/bjttt8ahajfmrhsula10.png", ids[0])
 
 	// proxied image
 	html = `<img src="https://remark42.radio-t.com/api/v1/img?src=aHR0cHM6Ly9ob21lcGFnZXMuY2FlLndpc2MuZWR1L35lY2U1MzMvaW1hZ2VzL2JvYXQucG5n" alt="cat.png">`
-	ids = svc.ExtractPictures(html)
+	ids = svc.ExtractImages(html)
 	require.Equal(t, 1, len(ids), "one image in")
 	assert.Equal(t, "cached_images/12318fbd4c55e9d177b8b5ae197bc89c5afd8e07-a41fcb00643f28d700504256ec81cbf2e1aac53e", ids[0])
 
 	// bad url
 	html = `<img src=" https://remark42.radio-t.com/api/v1/img">`
-	ids = svc.ExtractPictures(html)
+	ids = svc.ExtractImages(html)
 	require.Empty(t, ids)
 
 	// bad src
 	html = `<img src="https://remark42.radio-t.com/api/v1/img?src=bad">`
-	ids = svc.ExtractPictures(html)
+	ids = svc.ExtractImages(html)
 	require.Empty(t, ids)
 
 	// good src with bad content
 	badURL := base64.URLEncoding.EncodeToString([]byte(" http://foo.bar"))
 	html = fmt.Sprintf(`<img src="https://remark42.radio-t.com/api/v1/img?src=%s">`, badURL)
-	ids = svc.ExtractPictures(html)
+	ids = svc.ExtractImages(html)
 	require.Empty(t, ids)
 }
 

--- a/backend/app/store/service/service.go
+++ b/backend/app/store/service/service.go
@@ -269,7 +269,7 @@ func (s *DataStore) submitImages(comment store.Comment) {
 			log.Printf("[WARN] can't get comment's %s text for image extraction, %v", comment.ID, err)
 			return nil
 		}
-		imgIDs := s.ImageService.ExtractPictures(cc.Text)
+		imgIDs := s.ImageService.ExtractImages(cc.Text)
 		if len(imgIDs) > 0 {
 			log.Printf("[DEBUG] image ids extracted from %s - %+v", comment.ID, imgIDs)
 		}

--- a/backend/app/store/service/service_test.go
+++ b/backend/app/store/service/service_test.go
@@ -1327,7 +1327,7 @@ func TestService_UserCount(t *testing.T) {
 	assert.Equal(t, 1, c)
 
 	_, err = b.UserCount("radio-t", "userBad")
-	assert.EqualError(t, err, "no comments for user userBad in store for radio-t site")
+	assert.EqualError(t, err, "no comments for user userBad in storage for radio-t site")
 }
 
 func TestService_DeleteAll(t *testing.T) {

--- a/site/src/docs/configuration/parameters/index.md
+++ b/site/src/docs/configuration/parameters/index.md
@@ -24,6 +24,7 @@ services:
       - REMARK_URL=https://demo.remark42.com  # URL pointing to your Remark42 server
       - SITE=YOUR_SITE_ID                     # site ID, same as used for `site_id`, see "Setup on your website"
       - SECRET=abcd-123456-xyz-$%^&           # secret key
+      - AUTH_ANON=true                        # anonymous auth, easiest to enable and most accessible for users
       - AUTH_GITHUB_CID=12345667890           # OAuth2 client ID
       - AUTH_GITHUB_CSEC=abcdefg12345678      # OAuth2 client secret
     volumes:
@@ -44,7 +45,7 @@ services:
 | store.rpc.timeout              | STORE_RPC_TIMEOUT              |                          | http timeout (default: 5s)                                |
 | store.rpc.auth_user            | STORE_RPC_AUTH_USER            |                          | basic auth user name                                      |
 | store.rpc.auth_passwd          | STORE_RPC_AUTH_PASSWD          |                          | basic auth user password                                  |
-| admin.type                     | ADMIN_TYPE                     | `shared`                 | type of admin store, `shared` or `rpc`                    |
+| admin.type                     | ADMIN_TYPE                     | `shared`                 | type of admin storage, `shared` or `rpc`                    |
 | admin.rpc.api                  | ADMIN_RPC_API                  |                          | rpc extension api url                                     |
 | admin.rpc.timeout              | ADMIN_RPC_TIMEOUT              |                          | http timeout (default: 5s)                                |
 | admin.rpc.auth_user            | ADMIN_RPC_AUTH_USER            |                          | basic auth user name                                      |
@@ -61,7 +62,7 @@ services:
 | avatar.type                    | AVATAR_TYPE                    | `fs`                     | type of avatar storage, `fs`, `bolt`, or `uri`            |
 | avatar.fs.path                 | AVATAR_FS_PATH                 | `./var/avatars`          | avatars location for `fs` store                           |
 | avatar.bolt.file               | AVATAR_BOLT_FILE               | `./var/avatars.db`       | avatars `bolt` file location                              |
-| avatar.uri                     | AVATAR_URI                     | `./var/avatars`          | avatars store URI                                         |
+| avatar.uri                     | AVATAR_URI                     | `./var/avatars`          | avatars storage URI                                         |
 | avatar.rsz-lmt                 | AVATAR_RESIZE                  | `0` (disabled)           | max image size for resizing avatars on save               |
 | image.type                     | IMAGE_TYPE                     | `fs`                     | type of image storage, `fs`, `bolt`                       |
 | image.fs.path                  | IMAGE_FS_PATH                  | `./var/pictures`         | permanent location of images                              |


### PR DESCRIPTION
Store sometimes was used verb (as "to store") and sometimes as a noun. This commit changes all the nouns to "storage" so that it would be easier to search through the code and documentation.

A picture was sometimes used as a synonym for an image, making it harder to find all references mentioned in the code. This commit changes a few easily changeable places to "image", making it easier to find everything about images with a single search term.