### PR TITLE
removes .git from build layer, emulates GH build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@
 /.vscode/
 /.idea/
 /bin/
+/.git/
 
 # source files
 docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM umputun/baseimage:buildgo-v1.8.0 as build-backend
+FROM umputun/baseimage:buildgo-v1.9.1 as build-backend
 
 ARG CI
 ARG GITHUB_REF
@@ -8,7 +8,6 @@ ARG SKIP_BACKEND_TEST
 ARG BACKEND_TEST_TIMEOUT
 
 ADD backend /build/backend
-ADD .git/ /build/backend/.git/
 WORKDIR /build/backend
 
 ENV GOFLAGS="-mod=vendor"

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN if [ -z "$SKIP_FRONTEND_BUILD" ] ; then \
     ; fi
 RUN rm -rf ./node_modules
 
-FROM umputun/baseimage:app-v1.8.0
+FROM umputun/baseimage:app-v1.9.1
 
 WORKDIR /srv
 

--- a/Dockerfile.artifacts
+++ b/Dockerfile.artifacts
@@ -22,17 +22,17 @@ RUN cd /srv/frontend && \
     npm run build && \
     rm -rf ./node_modules
 
-FROM umputun/baseimage:buildgo-latest as build-backend
+FROM umputun/baseimage:buildgo-v1.9.1 as build-backend
 
 ARG GITHUB_TOKEN
+ARG GITHUB_REF
+ARG GITHUB_SHA
 ENV SKIP_BACKEND_TEST=true
 
 WORKDIR /build/backend
 ADD backend /build/backend
 ADD README.md /build/
 ADD LICENSE /build/
-
-ADD .git/ /build/backend/.git/
 
 COPY --from=build-frontend /srv/frontend/public/ web
 

--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,9 @@ frontend:
 	docker-compose -f compose-dev-frontend.yml build
 
 rundev:
-	docker pull umputun/baseimage:buildgo-latest
-	SKIP_BACKEND_TEST=true SKIP_FRONTEND_TEST=true docker-compose -f compose-private.yml build
+	docker pull umputun/baseimage:buildgo-v1.9.1
+	SKIP_BACKEND_TEST=true SKIP_FRONTEND_TEST=true GITHUB_REF=$(GITHUB_REF) GITHUB_SHA=$(GITHUB_SHA) CI=true \
+ 		docker-compose -f compose-private.yml build
 	docker-compose -f compose-private.yml up
 
 .PHONY: bin backend

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 OS=linux
 ARCH=amd64
+GITHUB_REF=$(shell git rev-parse --symbolic-full-name HEAD)
+GITHUB_SHA=$(shell git rev-parse --short HEAD)
 
 bin:
 	docker build -f Dockerfile.artifacts -t remark42.bin .
@@ -9,15 +11,18 @@ bin:
 	docker rm -f remark42.bin
 
 docker:
-	docker build -t umputun/remark42 --build-arg SKIP_FRONTEND_TEST=true --build-arg SKIP_BACKEND_TEST=true .
+	docker build -t umputun/remark42 --build-arg GITHUB_REF=$(GITHUB_REF) --build-arg GITHUB_SHA=$(GITHUB_SHA) \
+		--build-arg CI=true --build-arg SKIP_FRONTEND_TEST=true --build-arg SKIP_BACKEND_TEST=true .
 
 dockerx:
-	docker buildx build --build-arg SKIP_FRONTEND_TEST=true --build-arg SKIP_BACKEND_TEST=true \
-		  --progress=plain --platform linux/amd64,linux/arm/v7,linux/arm64 \
-		  -t ghcr.io/umputun/remark42:master -t umputun/remark42:master .
+	docker buildx build --build-arg GITHUB_REF=$(GITHUB_REF) --build-arg GITHUB_SHA=$(GITHUB_SHA) --build-arg CI=true \
+		--build-arg SKIP_FRONTEND_TEST=true --build-arg SKIP_BACKEND_TEST=true \
+		--progress=plain --platform linux/amd64,linux/arm/v7,linux/arm64 \
+		-t ghcr.io/umputun/remark42:master -t umputun/remark42:master .
 
 release:
-	docker build -f Dockerfile.artifacts --no-cache --pull -t remark42.bin .
+	docker build -f Dockerfile.artifacts --no-cache --pull --build-arg CI=true \
+ 		--build-arg GITHUB_REF=$(GITHUB_REF) --build-arg GITHUB_SHA=$(GITHUB_SHA) -t remark42.bin .
 	- @docker rm -f remark42.bin 2>/dev/null || exit 0
 	- @mkdir -p bin
 	docker run -d --name=remark42.bin remark42.bin
@@ -25,6 +30,7 @@ release:
 	docker cp remark42.bin:/artifacts/remark42.linux-386.tar.gz bin/remark42.linux-386.tar.gz
 	docker cp remark42.bin:/artifacts/remark42.linux-arm64.tar.gz bin/remark42.linux-arm64.tar.gz
 	docker cp remark42.bin:/artifacts/remark42.darwin-amd64.tar.gz bin/remark42.darwin-amd64.tar.gz
+	docker cp remark42.bin:/artifacts/remark42.darwin-arm64.tar.gz bin/remark42.darwin-arm64.tar.gz
 	docker cp remark42.bin:/artifacts/remark42.freebsd-amd64.tar.gz bin/remark42.freebsd-amd64.tar.gz
 	docker cp remark42.bin:/artifacts/remark42.windows-amd64.zip bin/remark42.windows-amd64.zip
 	docker rm -f remark42.bin

--- a/compose-dev-backend.yml
+++ b/compose-dev-backend.yml
@@ -15,7 +15,9 @@ services:
         - SKIP_BACKEND_TEST
         - BACKEND_TEST_TIMEOUT
         - SKIP_FRONTEND_TEST=true
-
+        - CI
+        - GITHUB_REF
+        - GITHUB_SHA
     image: umputun/remark42:dev
     container_name: "remark42-dev"
     hostname: "remark42-dev"


### PR DESCRIPTION
_this related to the discussion in #269_

Remove .git from the docker build context and pass both GITHUB_REF and GITHUB_SHA from the make. It uses an [updated baseimage](https://github.com/umputun/baseimage/commit/40677b819d9b4b2082a5d0e826a46a312a88dfc8) defaulting to "local" if no git repo

