### PR TITLE
Add missing env_delim to ALLOWED_HOSTS parameter

### DIFF
--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -79,7 +79,7 @@ type ServerCommand struct {
 	EnableEmoji      bool          `long:"emoji" env:"EMOJI" description:"enable emoji"`
 	SimpleView       bool          `long:"simple-view" env:"SIMPLE_VIEW" description:"minimal comment editor mode"`
 	ProxyCORS        bool          `long:"proxy-cors" env:"PROXY_CORS" description:"disable internal CORS and delegate it to proxy"`
-	AllowedHosts     []string      `long:"allowed-hosts" env:"ALLOWED_HOSTS" description:"limit hosts/sources allowed to embed comments"`
+	AllowedHosts     []string      `long:"allowed-hosts" env:"ALLOWED_HOSTS" description:"limit hosts/sources allowed to embed comments" env-delim:","`
 	SubscribersOnly  bool          `long:"subscribers-only" env:"SUBSCRIBERS_ONLY" description:"enable commenting only for Patreon subscribers"`
 	DisableSignature bool          `long:"disable-signature" env:"DISABLE_SIGNATURE" description:"disable server signature in headers"`
 


### PR DESCRIPTION
Fix for a bug potentially affecting #1139.

Before:
```
# with ALLOWED_HOSTS=domain1 domain2
# header
Content-Security-Policy: frame-ancestors domain1 domain2;
# with ALLOWED_HOSTS=domain1,domain2
# header
Content-Security-Policy: frame-ancestors domain1,domain2;
# console
Unrecognized Content-Security-Policy directive 'domain2'.
```
After:
```
# with ALLOWED_HOSTS=domain1,domain2 or ALLOWED_HOSTS=domain1 domain2
# header
Content-Security-Policy: frame-ancestors domain1 domain2;
```