### PR TITLE
Return docker build for frontend and backend code outside in CI

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -39,6 +39,20 @@ jobs:
       - name: available platforms
         run: echo ${{ steps.buildx.outputs.platforms }}
 
+      - name: build docker image without pushing (only outside master)
+        if: ${{ github.ref != 'refs/heads/master' }}
+        run: |
+          docker buildx build \
+              --build-arg SKIP_BACKEND_TEST=true --build-arg SKIP_FRONTEND_TEST=true \
+              --platform linux/amd64 .
+
+      - name: build example docker image without pushing (only outside master)
+        if: ${{ github.ref != 'refs/heads/master' }}
+        run: |
+          docker buildx build \
+              --build-arg SKIP_BACKEND_TEST=true --build-arg SKIP_FRONTEND_TEST=true \
+              --platform linux/amd64 -f backend/_example/memory_store/Dockerfile .
+
       - name: build and deploy master image to ghcr.io and dockerhub
         if: ${{ github.ref == 'refs/heads/master' }}
         env:

--- a/.github/workflows/ci-site.yml
+++ b/.github/workflows/ci-site.yml
@@ -44,7 +44,7 @@ jobs:
           echo GITHUB_REF - $ref
           echo ${GITHUB_PACKAGE_TOKEN} | docker login ghcr.io -u ${USERNAME} --password-stdin
           docker buildx build --push --no-cache --platform linux/amd64,linux/arm/v7,linux/arm64 \
-            -t ghcr.io/${USERNAME}/remark24-site:${ref} .
+            -t ghcr.io/${USERNAME}/remark42-site:${ref} .
 
       - name: deploy tagged (latest) to ghcr.io and dockerhub
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
@@ -59,7 +59,7 @@ jobs:
           echo "GITHUB_REF=$ref, GITHUB_SHA=${GITHUB_SHA}"
           echo ${GITHUB_PACKAGE_TOKEN} | docker login ghcr.io -u ${USERNAME} --password-stdin
           docker buildx build --push --no-cache --platform linux/amd64,linux/arm/v7,linux/arm64 \
-            -t ghcr.io/${USERNAME}/remark24-site:${ref} -t ghcr.io/${USERNAME}/remark24-site:latest .
+            -t ghcr.io/${USERNAME}/remark42-site:${ref} -t ghcr.io/${USERNAME}/remark42-site:latest .
 
       - name: remote site deployment from master
         if: ${{ github.ref == 'refs/heads/master' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM umputun/baseimage:buildgo-v1.9.1 as build-backend
+FROM umputun/baseimage:buildgo-v1.9.2 as build-backend
 
 ARG CI
 ARG GITHUB_REF
@@ -25,7 +25,7 @@ RUN \
         cat /profile.cov_tmp | grep -v "_mock.go" > /profile.cov ; \
         golangci-lint run --config ../.golangci.yml ./... ; \
     else \
-    	echo "skip backend tests and linter" \
+        echo "skip backend tests and linter" \
     ; fi
 
 RUN \
@@ -37,6 +37,7 @@ FROM --platform=$BUILDPLATFORM node:16.15.1-alpine as build-frontend-deps
 
 ARG CI
 ARG SKIP_FRONTEND_BUILD
+ARG SKIP_FRONTEND_TEST
 ENV HUSKY_SKIP_INSTALL=true
 
 WORKDIR /srv/frontend
@@ -47,7 +48,7 @@ RUN \
      npm i -g pnpm; \
    fi
 
- RUN --mount=type=cache,id=pnpm,target=/root/.pnpm-store/v3 \
+RUN --mount=type=cache,id=pnpm,target=/root/.pnpm-store/v3 \
    if [[ -z "$SKIP_FRONTEND_BUILD" || -z "$SKIP_FRONTEND_TEST" ]]; then \
      pnpm i; \
    fi
@@ -70,20 +71,20 @@ RUN \
 
 RUN \
   if [ -z "$SKIP_FRONTEND_TEST" ]; then \
-    echo 'Skip frontend test'; \
-  else \
     pnpm lint test check; \
+  else \
+    echo 'Skip frontend test'; \
   fi
 
 RUN \
   if [ -z "$SKIP_FRONTEND_BUILD" ]; then \
-    mkdir public; \
-    echo 'Skip frontend build'; \
-  else \
     pnpm build; \
+  else \
+    mkdir -p public; \
+    echo 'Skip frontend build'; \
   fi
 
-FROM umputun/baseimage:app-v1.9.1
+FROM umputun/baseimage:app-v1.9.2
 
 WORKDIR /srv
 

--- a/Dockerfile.artifacts
+++ b/Dockerfile.artifacts
@@ -2,13 +2,12 @@ FROM node:16.15.1-alpine as build-frontend-deps
 
 ARG CI
 
-ENV SKIP_FRONTEND_TEST=true
 ENV CI=true
 
 ADD frontend/package.json /srv/frontend/package.json
 ADD frontend/pnpm-lock.yaml /srv/frontend/pnpm-lock.yaml
+WORKDIR /srv/frontend
 RUN
-	cd /srv/frontend && \
 	apk add --no-cache --update git && \
 	npm i -g pnpm && \
 	pnpm i
@@ -17,21 +16,18 @@ FROM node:16.15.1-alpine as build-frontend
 
 ARG CI
 ARG NODE_ENV=production
-ENV SKIP_FRONTEND_TEST=true
 ENV HUSKY_SKIP_INSTALL=true
 
 COPY --from=build-frontend-deps /srv/frontend/node_modules /srv/frontend/node_modules
-ADD frontend /srv/frontend
-RUN cd /srv/frontend && \
-    npm run build && \
+WORKDIR /srv/frontend
+RUN npm run build && \
     rm -rf ./node_modules
 
-FROM umputun/baseimage:buildgo-v1.9.1 as build-backend
+FROM umputun/baseimage:buildgo-v1.9.2 as build-backend
 
 ARG GITHUB_TOKEN
 ARG GITHUB_REF
 ARG GITHUB_SHA
-ENV SKIP_BACKEND_TEST=true
 
 WORKDIR /build/backend
 ADD backend /build/backend

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ dockerx:
 
 release:
 	docker build -f Dockerfile.artifacts --no-cache --pull --build-arg CI=true \
- 		--build-arg GITHUB_REF=$(GITHUB_REF) --build-arg GITHUB_SHA=$(GITHUB_SHA) -t remark42.bin .
+		--build-arg GITHUB_REF=$(GITHUB_REF) --build-arg GITHUB_SHA=$(GITHUB_SHA) -t remark42.bin .
 	- @docker rm -f remark42.bin 2>/dev/null || exit 0
 	- @mkdir -p bin
 	docker run -d --name=remark42.bin remark42.bin
@@ -45,9 +45,8 @@ frontend:
 	docker-compose -f compose-dev-frontend.yml build
 
 rundev:
-	docker pull umputun/baseimage:buildgo-v1.9.1
 	SKIP_BACKEND_TEST=true SKIP_FRONTEND_TEST=true GITHUB_REF=$(GITHUB_REF) GITHUB_SHA=$(GITHUB_SHA) CI=true \
- 		docker-compose -f compose-private.yml build
+		docker-compose -f compose-private.yml build
 	docker-compose -f compose-private.yml up
 
 .PHONY: bin backend

--- a/backend/_example/memory_store/Dockerfile
+++ b/backend/_example/memory_store/Dockerfile
@@ -1,12 +1,11 @@
-FROM umputun/baseimage:buildgo-latest as build-backend
+FROM umputun/baseimage:buildgo-v1.9.2 as build-backend
 
 ADD backend /build/backend
 WORKDIR /build/backend/_example/memory_store
 
 RUN go build -o /build/bin/memory_store -ldflags "-X main.revision=0.0.0 -s -w"
 
-
-FROM umputun/baseimage:app-latest
+FROM umputun/baseimage:app-v1.9.2
 
 WORKDIR /srv
 COPY --from=build-backend /build/bin/memory_store /srv/memory_store

--- a/backend/app/store/service/service_test.go
+++ b/backend/app/store/service/service_test.go
@@ -1457,7 +1457,7 @@ func TestService_ResubmitStagingImages(t *testing.T) {
 
 	mockStoreEmpty.AssertNumberOfCalls(t, "Info", 1)
 
-	// 	error from image storage
+	// error from image storage
 	mockStoreError := image.MockStore{}
 	imgSvcError := image.NewService(&mockStoreError,
 		image.ServiceParams{

--- a/site/src/includes/components/head.njk
+++ b/site/src/includes/components/head.njk
@@ -8,7 +8,7 @@
 	{% if title %}
 		<title>{{ title }} | {{ site.name }}</title>
 	{% else %}
-  	<title>{{ renderData.title or site.name }}</title>
+		<title>{{ renderData.title or site.name }}</title>
 	{% endif %}
   <meta name="description" content="{{ metaDescription or renderData.metaDescription or site.description }}">
   <link rel="stylesheet" href="/style.css?v={% version %}"/>


### PR DESCRIPTION
Previously we built a Docker image just for the test, but the introduction of multi-arch build in 9fbf0952 build also meant the push of the image, so it was restricted only to the master branch. This change re-introduces the Docker image build outside the master branch, which is helpful in pull requests.

We recently had a few frontend PRs which broke the Docker image build silently, and that change prevents it from happening.