### PR TITLE
Do not sanitise the original comment markdown

### DIFF
--- a/backend/app/rest/api/rest_private_test.go
+++ b/backend/app/rest/api/rest_private_test.go
@@ -56,7 +56,6 @@ func TestRest_Create(t *testing.T) {
 
 // based on issue https://github.com/umputun/remark42/issues/1292
 func TestRest_CreateFilteredCode(t *testing.T) {
-	t.Skip("not yet fixed")
 	ts, _, teardown := startupT(t)
 	defer teardown()
 

--- a/site/src/docs/contributing/api/index.md
+++ b/site/src/docs/contributing/api/index.md
@@ -28,7 +28,7 @@ type Comment struct {
     ID          string    `json:"id"`      // comment ID, read only
     ParentID    string    `json:"pid"`     // parent ID
     Text        string    `json:"text"`    // comment text, after md processing
-    Orig        string    `json:"orig"`    // original comment text
+    Orig        string    `json:"orig"`    // original comment text in Markdown, should never be rendered as HTML as-is!
     User        User      `json:"user"`    // user info, read only
     Locator     Locator   `json:"locator"` // post locator
     Score       int       `json:"score"`   // comment score, read only
@@ -83,7 +83,9 @@ type EditRequest struct {
 
 - `GET /api/v1/last/{max}?site=site-id&since=ts-msec` - get up to `{max}` last comments, `since` (epoch time, milliseconds) is optional
 - `GET /api/v1/id/{id}?site=site-id` - get comment by `comment id`
-- `GET /api/v1/comments?site=site-id&user=id&limit=N` - get comment by `user id`, returns `response` object
+- `GET /api/v1/comments?site=site-id&user=id&limit=N` - get comment by `user id`, returns `response` object.
+
+**Important**: original comment text in Markdown in the `orig` field should never be rendered as HTML as-is, only `text` containing HTML is sanitized and safe for render.
 
 ```go
 type response struct {


### PR DESCRIPTION
Previously it was sanitised using the HTML sanitiser, but it had proven troublesome and unnecessary. Remark42 rendered the markdown into proper HTML, but then some pieces of it (like cited HTML code inside the code block, marked by backticks) were cut out, which then showed the incorrect markdown to a user when they were editing the comment.

For example, the comment "\`foo\<bar\>\`" became "foo" after sanitising, and despite the proper render user saw only "foo" when editing the comment.

After this change, the initial comment markdown is preserved unaltered. It could contain dangerous HTML with JS, which I assume shouldn't be a problem as it's never rendered as HTML but instead supposed to be converted to HTML by the interpreter. In Remark42, it's stored in a comment.Text field and sanitised and thus safe.

I've left information about the potential danger of rendering the original markdown as-is without an interpreter in all relevant places I could find.

Resolves #1292.