### PR TITLE
fix: sort select background in dark mode

### DIFF
--- a/frontend/apps/remark42/app/components/select/select.module.css
+++ b/frontend/apps/remark42/app/components/select/select.module.css
@@ -17,6 +17,7 @@
 }
 
 .select {
+  background-color: rgb(var(--primary-background-color));
   position: absolute;
   top: 0;
   left: 0;


### PR DESCRIPTION
Fix sort select background in dark mode in order to see the text clearly. 

![image](https://user-images.githubusercontent.com/29678177/180341239-1210d0de-bc9f-4829-96f9-b637e055945b.png)
