### PR TITLE
disable color-scheme on remark iframe

### DIFF
--- a/frontend/apps/remark42/app/utils/create-iframe.ts
+++ b/frontend/apps/remark42/app/utils/create-iframe.ts
@@ -25,6 +25,7 @@ export function createIframe({ __colors__, styles, ...params }: Params) {
     padding: 0,
     margin: 0,
     overflow: 'hidden',
+    colorScheme: 'none',
     ...styles,
   });
 


### PR DESCRIPTION
In order to prevent problems like so https://github.com/umputun/remark42/pull/1421 we need to disable `color-scheme` for the iframe.
We can remove this line when support for `color-scheme` is implemented inside widget.


Issue for full support: https://github.com/umputun/remark42/issues/1430