### PR TITLE
Move common options to cmd.go

### DIFF
--- a/backend/app/cmd/backup.go
+++ b/backend/app/cmd/backup.go
@@ -14,11 +14,10 @@ import (
 // BackupCommand set of flags and command for export
 // ExportPath used as a separate element to leverage BACKUP_PATH. If ExportFile has a path (i.e. with /) BACKUP_PATH ignored.
 type BackupCommand struct {
-	ExportPath  string        `short:"p" long:"path" env:"BACKUP_PATH" default:"./var/backup" description:"export path"`
-	ExportFile  string        `short:"f" long:"file" default:"userbackup-{{.SITE}}-{{.TS}}.gz" description:"file name"`
-	Site        string        `short:"s" long:"site" env:"SITE" default:"remark" description:"site name"`
-	Timeout     time.Duration `long:"timeout" default:"60m" description:"export (backup) timeout"`
-	AdminPasswd string        `long:"admin-passwd" env:"ADMIN_PASSWD" required:"true" description:"admin basic auth password"`
+	ExportPath string `short:"p" long:"path" env:"BACKUP_PATH" default:"./var/backup" description:"export path"`
+	ExportFile string `short:"f" long:"file" default:"userbackup-{{.SITE}}-{{.TS}}.gz" description:"file name"`
+
+	SupportCmdOpts
 	CommonOpts
 }
 

--- a/backend/app/cmd/cleanup.go
+++ b/backend/app/cmd/cleanup.go
@@ -15,14 +15,14 @@ import (
 
 // CleanupCommand set of flags and command for cleanup
 type CleanupCommand struct {
-	Site        string   `short:"s" long:"site" env:"SITE" default:"remark" description:"site name"`
-	Dry         bool     `long:"dry" description:"dry mode, will not remove comments"`
-	From        string   `long:"from" description:"from yyyymmdd"`
-	To          string   `long:"to" description:"from yyyymmdd"`
-	BadWords    []string `short:"w" long:"bword" description:"bad word(s)"`
-	BadUsers    []string `short:"u" long:"buser" description:"bad user(s)"`
-	AdminPasswd string   `long:"admin-passwd" env:"ADMIN_PASSWD" required:"true" description:"admin basic auth password"`
-	SetTitle    bool     `long:"title" description:"title mode, will not remove comments, but reset titles to page's title'"`
+	Dry      bool     `long:"dry" description:"dry mode, will not remove comments"`
+	From     string   `long:"from" description:"from yyyymmdd"`
+	To       string   `long:"to" description:"from yyyymmdd"`
+	BadWords []string `short:"w" long:"bword" description:"bad word(s)"`
+	BadUsers []string `short:"u" long:"buser" description:"bad user(s)"`
+	SetTitle bool     `long:"title" description:"title mode, will not remove comments, but reset titles to page's title'"`
+
+	SupportCmdOpts
 	CommonOpts
 }
 

--- a/backend/app/cmd/cmd.go
+++ b/backend/app/cmd/cmd.go
@@ -31,6 +31,14 @@ type CommonOpts struct {
 	Revision     string
 }
 
+// SupportCmdOpts is set of commands shared among similar commands like backup/restore and such.
+// Order of fields defines the help command output order.
+type SupportCmdOpts struct {
+	Site        string        `short:"s" long:"site" env:"SITE" default:"remark" description:"site name"`
+	AdminPasswd string        `long:"admin-passwd" env:"ADMIN_PASSWD" default:"" description:"admin basic auth password"`
+	Timeout     time.Duration `long:"timeout" default:"60m" description:"timeout for the command run"`
+}
+
 // DeprecatedFlag contains information about deprecated option
 type DeprecatedFlag struct {
 	Old       string

--- a/backend/app/cmd/import.go
+++ b/backend/app/cmd/import.go
@@ -8,18 +8,16 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"time"
 
 	log "github.com/go-pkgz/lgr"
 )
 
 // ImportCommand set of flags and command for import
 type ImportCommand struct {
-	InputFile   string        `short:"f" long:"file" description:"input file name" required:"true"`
-	Provider    string        `short:"p" long:"provider" default:"disqus" choice:"disqus" choice:"wordpress" choice:"commento" description:"import format"` //nolint
-	Site        string        `short:"s" long:"site" env:"SITE" default:"remark" description:"site name"`
-	Timeout     time.Duration `long:"timeout" default:"60m" description:"import timeout"`
-	AdminPasswd string        `long:"admin-passwd" env:"ADMIN_PASSWD" required:"true" description:"admin basic auth password"`
+	InputFile string `short:"f" long:"file" description:"input file name" required:"true"`
+	Provider  string `short:"p" long:"provider" default:"disqus" choice:"disqus" choice:"wordpress" choice:"commento" description:"import format"` //nolint
+
+	SupportCmdOpts
 	CommonOpts
 }
 

--- a/backend/app/cmd/remap.go
+++ b/backend/app/cmd/remap.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"time"
 
 	log "github.com/go-pkgz/lgr"
 )
@@ -14,10 +13,9 @@ import (
 // RemapCommand set of flags and command for change linkage between comments to
 // different urls based on given rules (input file)
 type RemapCommand struct {
-	Site        string        `short:"s" long:"site" env:"SITE" default:"remark" description:"site name"`
-	InputFile   string        `short:"f" long:"file" description:"input file name" required:"true"`
-	AdminPasswd string        `long:"admin-passwd" env:"ADMIN_PASSWD" required:"true" description:"admin basic auth password"`
-	Timeout     time.Duration `long:"timeout" default:"60m" description:"remap timeout"`
+	InputFile string `short:"f" long:"file" description:"input file name" required:"true"`
+
+	SupportCmdOpts
 	CommonOpts
 }
 

--- a/backend/app/cmd/restore.go
+++ b/backend/app/cmd/restore.go
@@ -11,9 +11,7 @@ type RestoreCommand struct {
 	ImportPath string `short:"p" long:"path" env:"BACKUP_PATH" default:"./var/backup" description:"export path"`
 	ImportFile string `short:"f" long:"file" default:"userbackup-{{.SITE}}-{{.YYYYMMDD}}.gz" description:"file name" required:"true"`
 
-	Site        string        `short:"s" long:"site" env:"SITE" default:"remark" description:"site name"`
-	Timeout     time.Duration `long:"timeout" default:"60m" description:"import timeout"`
-	AdminPasswd string        `long:"admin-passwd" env:"ADMIN_PASSWD" required:"true" description:"admin basic auth password"`
+	SupportCmdOpts
 	CommonOpts
 }
 
@@ -29,12 +27,10 @@ func (rc *RestoreCommand) Execute(args []string) error {
 		return err
 	}
 	importer := ImportCommand{
-		InputFile:   fname,
-		Site:        rc.Site,
-		Provider:    "native",
-		Timeout:     rc.Timeout,
-		AdminPasswd: rc.AdminPasswd,
-		CommonOpts:  rc.CommonOpts,
+		InputFile:      fname,
+		Provider:       "native",
+		SupportCmdOpts: rc.SupportCmdOpts,
+		CommonOpts:     rc.CommonOpts,
 	}
 	return importer.Execute(args)
 }


### PR DESCRIPTION
Timeout, admin password and site id are set in many commands, and we need to take care of synchronising the descriptions and flags between them.

This change moves these standard options to cmd.go importing them in the same manner CommonOpts imported by all commands already.