### PR TITLE
docs: link readme for frontend/backend dev

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,1 @@
+../site/src/docs/contributing/backend/index.md

--- a/frontend/apps/remark42/README.md
+++ b/frontend/apps/remark42/README.md
@@ -1,1 +1,1 @@
-Please refer to [documentation](https://remark42.com/docs/contributing/development/frontend/).
+../../../site/src/docs/contributing/frontend/index.md


### PR DESCRIPTION
symlink for md files shows the doc right if they are placed there

https://github.com/umputun/remark42/tree/docs/link-frontend-dev-readme/frontend/apps/remark42
https://github.com/umputun/remark42/tree/docs/link-frontend-dev-readme/backend
