### PR TITLE
Remove mod=vendor from go build directives as it's no longer actual

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -46,7 +46,6 @@ jobs:
           $GITHUB_WORKSPACE/golangci-lint --config ${GITHUB_WORKSPACE}/backend/.golangci.yml run --out-format=github-actions ./...
         working-directory: backend/app
         env:
-          GOFLAGS: "-mod=vendor"
           TZ: "America/Chicago"
 
       - name: test and lint examples

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,8 +57,6 @@ ARG BACKEND_TEST_TIMEOUT
 ADD backend /build/backend
 WORKDIR /build/backend
 
-ENV GOFLAGS="-mod=vendor"
-
 # install gcc in order to be able to go test package with -race
 RUN apk --no-cache add gcc libc-dev
 

--- a/Dockerfile.artifacts
+++ b/Dockerfile.artifacts
@@ -43,7 +43,6 @@ RUN \
 
 RUN \
   version=$("/script/version.sh") && echo "version=${version}" && \
-    export GOFLAGS="-mod=vendor" && \
     GOOS=linux GOARCH=amd64 go build -o remark42.linux-amd64 -ldflags "-X main.revision=${version} -s -w" ./app && \
     GOOS=linux GOARCH=386 go build -o remark42.linux-386 -ldflags "-X main.revision=${version} -s -w" ./app && \
     GOOS=linux GOARCH=arm go build -o remark42.linux-arm -ldflags "-X main.revision=${version} -s -w" ./app && \

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ release:
 	docker rm -f remark42.bin
 
 race_test:
-	cd backend/app && go test -race -mod=vendor -timeout=60s -count 1 ./...
+	cd backend/app && go test -race -timeout=60s -count 1 ./...
 
 backend:
 	docker-compose -f compose-dev-backend.yml build

--- a/backend/app/store/engine/engine.go
+++ b/backend/app/store/engine/engine.go
@@ -11,7 +11,7 @@ import (
 	"github.com/umputun/remark42/backend/app/store"
 )
 
-// NOTE: mockery works from linked to go-path and with GOFLAGS='-mod=vendor' go generate
+// NOTE: mockery works from linked to go-path and with go generate
 //go:generate sh -c "mockery -inpkg -name Interface -print > /tmp/engine-mock.tmp && mv /tmp/engine-mock.tmp engine_mock.go"
 
 // Interface defines methods provided by low-level storage engine


### PR DESCRIPTION
It's a default in the presence of the vendor folder since Go 1.14, https://go.dev/ref/mod