### PR TITLE
Don't enable telegram user notifications alongside auth

### DIFF
--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -967,7 +967,8 @@ func (s *ServerCommand) makeNotifyService(dataStore *service.DataStore, destinat
 	if destinations == nil {
 		destinations = []notify.Destination{}
 	}
-	if telegram != nil {
+	// it's possible that telegram notification service was created for auth but should not be used for notifications
+	if telegram != nil && (contains("telegram", s.Notify.Users) || contains("telegram", s.Notify.Admins)) {
 		destinations = append(destinations, telegram)
 	}
 


### PR DESCRIPTION
Before that change, enabling Telegram auth also enabled Telegram user notifications.