### PR TITLE
Fix unsubscribe template filename

### DIFF
--- a/backend/app/rest/api/rest_private.go
+++ b/backend/app/rest/api/rest_private.go
@@ -552,7 +552,7 @@ func (s *private) emailUnsubscribeCtrl(w http.ResponseWriter, r *http.Request) {
 		}
 		return string(file)
 	}
-	tmplstr := MustRead("unsubscribe.html.tmpl")
+	tmplstr := MustRead("email_unsubscribe.html.tmpl")
 	tmpl := template.Must(template.New("unsubscribe").Parse(tmplstr))
 	msg := bytes.Buffer{}
 	MustExecute(tmpl, &msg, nil)


### PR DESCRIPTION
Current behavior on click on `http://127.0.0.1:8080/email/unsubscribe.html?site=remark&tkn=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJyZW1hcmsiLCJleHAiOjQ4MTI0ODAzNDMsImlzcyI6InJlbWFyazQyIiwibmJmIjoxNjU4ODgwMjgzLCJoYW5kc2hha2UiOnsiaWQiOiJkZXZfdXNlcjo6cGFza2FsLjA3QGdtYWlsLmNvbSJ9fQ.SFwJAS0fv39Bx_L59mVrIbvP0WzuEiUfY_0ROYvgNd0`:
```
remark42-dev  | 2022/07/26 20:17:51.490 [INFO]  {rest/middleware.go:63 rest.Recoverer.func1.1.1} request panic for /email/unsubscribe.html?site=remark&tkn=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJyZW1hcmsiLCJleHAiOjQ4MTI0ODAzNDMsImlzcyI6InJlbWFyazQyIiwibmJmIjoxNjU4ODgwMjgzLCJoYW5kc2hha2UiOnsiaWQiOiJkZXZfdXNlcjo6cGFza2FsLjA3QGdtYWlsLmNvbSJ9fQ.SFwJAS0fv39Bx_L59mVrIbvP0WzuEiUfY_0ROYvgNd0 from 172.20.0.1:58808, open unsubscribe.html.tmpl: no such file or directory
remark42-dev  | 2022/07/26 20:17:51.492 [INFO]  {rest/middleware.go:65 rest.Recoverer.func1.1.1} goroutine 146 [running]:
remark42-dev  | runtime/debug.Stack()
remark42-dev  |         /usr/local/go/src/runtime/debug/stack.go:24 +0x68
```
After change: no error, probably something like that as the token is not valid:
<img width="417" alt="image" src="https://user-images.githubusercontent.com/712534/181139625-27d77424-f4ac-49bb-8a38-b7f5e49c02b0.png">
