### PR TITLE
Do not run size limit job outside of PRs

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -150,6 +150,7 @@ jobs:
   size-limit:
     name: Size limit
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     env:
       CI_JOB_NUMBER: 1
     steps:


### PR DESCRIPTION
Currently, this step emits the "Error: No PR found. Only pull_request workflows are supported." message when run on the master branch commits (after the merge), so the change prevents it from being run there.

Resolves #1433.