### PR TITLE
Hardcode dockerhub username and ghcr.io repo for site docker push

### DIFF
--- a/.github/workflows/ci-site.yml
+++ b/.github/workflows/ci-site.yml
@@ -45,7 +45,7 @@ jobs:
           echo GITHUB_REF - $ref
           echo ${GITHUB_PACKAGE_TOKEN} | docker login ghcr.io -u ${USERNAME} --password-stdin
           docker buildx build --push --no-cache --platform linux/amd64,linux/arm/v7,linux/arm64 \
-            -t ghcr.io/${USERNAME}/remark42-site:${ref} .
+            -t ghcr.io/umputun/remark42-site:${ref} .
 
       - name: deploy tagged (latest) to ghcr.io and dockerhub
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
@@ -60,7 +60,7 @@ jobs:
           echo "GITHUB_REF=$ref, GITHUB_SHA=${GITHUB_SHA}"
           echo ${GITHUB_PACKAGE_TOKEN} | docker login ghcr.io -u ${USERNAME} --password-stdin
           docker buildx build --push --no-cache --platform linux/amd64,linux/arm/v7,linux/arm64 \
-            -t ghcr.io/${USERNAME}/remark42-site:${ref} -t ghcr.io/${USERNAME}/remark42-site:latest .
+            -t ghcr.io/umputun/remark42-site:${ref} -t ghcr.io/${USERNAME}/remark42-site:latest .
 
       - name: remote site deployment from master
         if: ${{ github.ref == 'refs/heads/master' }}


### PR DESCRIPTION
Currently, such a build most likely has access to secrets but fails due to the wrong username logging with DockerHub when rebase and merge is done by anyone but @umputun.

I missed this one during #1436, which resulted in a site push error after @akellbl4 merged site-related PR in https://github.com/umputun/remark42/commit/86dae37c5d6f52893f99f0f896b6a809f22af160.