### PR TITLE
Bump buildgo to 1.9.2 to be consistent with other baseimage usages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN \
     echo 'Skip frontend build'; \
   fi
 
-FROM umputun/baseimage:buildgo-v1.9.1 as build-backend
+FROM umputun/baseimage:buildgo-v1.9.2 as build-backend
 
 ARG CI
 ARG GITHUB_REF


### PR DESCRIPTION
I've updated everything to 1.9.2 but missed just one place. This PR fixes that.