### PR TITLE
Fix directory name in CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # review when someone opens a pull request.
 
 *             @umputun
-frontent/*    @akellbl4 @Mavrin
+frontend/*    @akellbl4 @Mavrin


### PR DESCRIPTION
This PR fixes the wrong directory name in CODEOWNERS file here: https://github.com/umputun/remark42/blob/master/.github/CODEOWNERS#L6

Signed-off-by: Avinal Kumar <avinal.xlvii@gmail.com>
