### PR TITLE
Add compose files to dockerignore, remove defaults from frontend compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,11 @@
 
 # source files
 docker-compose.yml
+compose-dev-backend.yml
+compose-dev-frontend.yml
+compose-private-backend.yml
+compose-private-frontend.yml
+compose-private.yml
 rest-client.env.json
 
 # generated files
@@ -23,4 +28,3 @@ debug.test
 *.test
 remark42
 /backend/var/
-compose-private-backend.yml

--- a/compose-dev-frontend.yml
+++ b/compose-dev-frontend.yml
@@ -37,8 +37,6 @@ services:
       - ADMIN_PASSWD=password
       - AUTH_DEV=true # activate local oauth "dev"
       - ADMIN_SHARED_ID=dev_user # set admin flag for default user on local oauth2
-      - POSITIVE_SCORE=false # restricts comment's score to be only positive
-      - EDIT_TIME=5m # edit window
       - AUTH_ANON=true
       - AUTH_EMAIL_ENABLE=true
     volumes:


### PR DESCRIPTION
Before that change, docker would create a new image on docker-compose file changes.

Frontend docker-compose file change removes options set to the same values as their default values.