### PR TITLE
Allow dashes in site ID when validating email auth request

### DIFF
--- a/backend/app/rest/api/rest.go
+++ b/backend/app/rest/api/rest.go
@@ -651,7 +651,7 @@ func subscribersOnly(enable bool) func(http.Handler) http.Handler {
 func validEmailAuth() func(http.Handler) http.Handler {
 
 	reUser := regexp.MustCompile(`^[\p{L}\d\s_]{4,64}$`) // matches ui side validation, adding min/max limitation
-	reSite := regexp.MustCompile(`^[a-zA-Z\d\s_]{1,64}$`)
+	reSite := regexp.MustCompile(`^[a-zA-Z\d\s_-]{1,64}$`)
 
 	return func(h http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {

--- a/backend/app/rest/api/rest_test.go
+++ b/backend/app/rest/api/rest_test.go
@@ -372,12 +372,13 @@ func TestRest_subscribersOnly(t *testing.T) {
 	}
 }
 
-func Test_validEmaiAuth(t *testing.T) {
+func Test_validEmailAuth(t *testing.T) {
 	tbl := []struct {
 		req    string
 		status int
 	}{
 		{"/auth/email/login?site=remark42&address=umputun%example.com&user=someone", http.StatusOK},
+		{"/auth/email/login?site=site-with-dash_and_underscore&address=umputun%example.com&user=someone", http.StatusOK},
 		{"/auth/email/login?site=remark42&address=umputun%example.com&user=someone+blah", http.StatusOK},
 		{"/auth/email/login?site=remark42&address=umputun%example.com&user=Евгений+Умпутун", http.StatusOK},
 		{"/auth/email/login?site=remark42&address=umputun%example.com&user=12", http.StatusForbidden},


### PR DESCRIPTION
As discovered in #1477, dashes are expected to work in the site ID and do work everywhere but in email auth. That change makes the behaviour consistent: site ID now allows dashes.

Resolves #1477.