### PR TITLE
fix iframe resize on auth dropdown opening

### DIFF
--- a/frontend/apps/remark42/app/components/auth/auth.hooks.ts
+++ b/frontend/apps/remark42/app/components/auth/auth.hooks.ts
@@ -70,9 +70,7 @@ export function useDropdown(disableClosing?: boolean) {
   useEffect(() => {
     const dropdownElement = rootRef.current;
 
-    if (!dropdownElement || !showDropdown) {
-      handleChangeIframeSize(document.body);
-
+    if (!dropdownElement) {
       return;
     }
 

--- a/frontend/apps/remark42/webpack.config.js
+++ b/frontend/apps/remark42/webpack.config.js
@@ -223,6 +223,9 @@ module.exports = (_, { mode, analyze }) => {
       { path: '/api', target: REMARK_API_BASE_URL, changeOrigin: true },
       { path: '/auth', target: REMARK_API_BASE_URL, changeOrigin: true },
     ],
+    client: {
+      overlay: false,
+    },
   };
 
   const plugins = [


### PR DESCRIPTION
Mutation observer was listening for all of the elements. When Auth dropdown appears it renders images and triggering height recalculations.
Resize trigger on image load was introduced in favor of resizing iframe for users with slow internet (when images load later and we need to resize iframe accordingly)

Solution:
Listen to mutations only on block with comments.
Plus remove unnecessary triggers.