### PR TITLE
Fix makefile and dockerfile

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Build & run containers
         id: tests
-        run: COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose -f compose-e2e-test.yml up --build --quiet-pull --exit-code-from tests
+        run: COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose -f compose-e2e-test.yml up --build --quiet-pull --exit-code-from tests
 
       - uses: actions/upload-artifact@v2
         if: always()

--- a/Dockerfile.artifacts
+++ b/Dockerfile.artifacts
@@ -4,7 +4,7 @@ ENV CI=true
 
 WORKDIR /srv/frontend
 
-COPY ./frontend/package.json ./frontend/pnpm-lock.yaml ./frontend/pnpm-workspace.yaml /srv/frontend
+COPY ./frontend/package.json ./frontend/pnpm-lock.yaml ./frontend/pnpm-workspace.yaml /srv/frontend/
 COPY ./frontend/apps/remark42/package.json /srv/frontend/apps/remark42/package.json
 
 RUN apk add --no-cache --update git && npm i -g pnpm

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ bin:
 	docker rm -f remark42.bin
 
 docker:
-	docker build -t umputun/remark42 --build-arg GITHUB_REF=$(GITHUB_REF) --build-arg GITHUB_SHA=$(GITHUB_SHA) \
+	DOCKER_BUILDKIT=1 docker build -t umputun/remark42 --build-arg GITHUB_REF=$(GITHUB_REF) --build-arg GITHUB_SHA=$(GITHUB_SHA) \
 		--build-arg CI=true --build-arg SKIP_FRONTEND_TEST=true --build-arg SKIP_BACKEND_TEST=true .
 
 dockerx:

--- a/site/src/docs/manuals/subdomain/index.md
+++ b/site/src/docs/manuals/subdomain/index.md
@@ -19,7 +19,7 @@ All README examples show configurations with remark42 on its own subdomain, i.e.
 
 Both Nginx and Caddy configuration below rely on remark42 available on hostname `remark42`, which is achieved by having `container_name: remark42` in docker-compose.
 
-Example `docker-compose.yaml`:
+Example `docker-compose.yml`:
 
 ```yaml
 version: "2"


### PR DESCRIPTION
Here are multiple changes to commands run by Makefile based on my attempts to run it on an Oracle Linux machine with the latest Docker.

The only known problem left is happening with `make bin`, `make dockerx` and `make release`:

```
[opc@terrty-net ~/remark42]$ make bin
Step 7/29 : RUN --mount=type=cache,id=pnpm,target=/root/.pnpm-store/v3 pnpm i
the --mount option requires BuildKit. Refer to https://docs.docker.com/go/buildkit/ to learn how to build images with BuildKit enabled
make: *** [Makefile:7: bin] Error 1
```