### PR TITLE
Call admin store with a proper key

### DIFF
--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -1107,7 +1107,7 @@ func (s *ServerCommand) getAuthenticator(ds *service.DataStore, avas avatar.Stor
 		SameSiteCookie: s.parseSameSite(s.Auth.SameSite),
 		SecureCookies:  strings.HasPrefix(s.RemarkURL, "https://"),
 		SecretReader: token.SecretFunc(func(aud string) (string, error) { // get secret per site
-			return admns.Key("")
+			return admns.Key(aud)
 		}),
 		ClaimsUpd: token.ClaimsUpdFunc(func(c token.Claims) token.Claims { // set attributes, on new token or refresh
 			if c.User == nil {

--- a/backend/app/store/service/service.go
+++ b/backend/app/store/service/service.go
@@ -981,9 +981,9 @@ func (s *DataStore) prepVotes(c store.Comment, user store.User) store.Comment {
 }
 
 // get secret for given siteID
-// Note: secret shared across sites, but some sites can be disabled.
+// Note: siteID ignored for the default admin.Static store
 func (s *DataStore) getSecret(siteID string) (secret string, err error) {
-	if secret, err = s.AdminStore.Key("any"); err != nil {
+	if secret, err = s.AdminStore.Key(siteID); err != nil {
 		return "", fmt.Errorf("can't get secret for site %s: %w", siteID, err)
 	}
 


### PR DESCRIPTION
Previously it was set to fixed strings, likely a test artefact.

Resolves #1499.