### PR TITLE
Bump docker-compose.yml for the site to work with dev properly

### DIFF
--- a/site/docker-compose.yml
+++ b/site/docker-compose.yml
@@ -1,15 +1,8 @@
 version: '2'
 services:
-  build:
-    image: remark42-site
-    build: .
-
-    volumes:
-      - ./build:/site/build
-
-  # Runs dev evn for the site
+  # Runs dev env for the site
   server:
-    image: remark42-site
+    image: remark42-site:dev
     build:
       dockerfile: Dockerfile.dev
       context: .

--- a/site/src/docs/manuals/subdomain/index.md
+++ b/site/src/docs/manuals/subdomain/index.md
@@ -4,7 +4,7 @@ title: Configure Instance without Subdomain
 
 ## How to configure remark42 without a subdomain
 
-All README examples show configurations with remark42 on its own subdomain, i.e., `https://remark42.example.com`. However, it is possible and sometimes desirable to run remark42 without a subdomain, but just under some path, i.e., `https://example.com/remark42`.
+All documentation examples show configurations with remark42 on its own subdomain, i.e., `https://remark42.example.com`. However, it is possible and sometimes desirable to run remark42 without a subdomain, but just under some path, i.e., `https://example.com/remark42`.
 
 - The frontend URL looks like this: `s.src = 'https://example.com/remark42/web/embed.js;`
 


### PR DESCRIPTION
Previously, an image built for the `build` service was then used for `server`, and changes were invisible to the user before the container rebuild.

After that change, the useless static `build` service is deleted, Dockerfile is only used in the CI pipeline, and only the `server` service is left in docker-compose for the user to test and see documentation changes locally in real-time.

Resolves #1178