### PR TITLE
Disqus avatars - straightforward approach

### DIFF
--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -523,7 +523,7 @@ func (s *ServerCommand) newServerApp(ctx context.Context) (*serverApp, error) {
 	migr := &api.Migrator{
 		Cache:             loadingCache,
 		NativeImporter:    &migrator.Native{DataStore: dataService},
-		DisqusImporter:    &migrator.Disqus{DataStore: dataService},
+		DisqusImporter:    &migrator.Disqus{DataStore: dataService, AvatarSaver: authenticator.AvatarProxy()},
 		WordPressImporter: &migrator.WordPress{DataStore: dataService},
 		CommentoImporter:  &migrator.Commento{DataStore: dataService},
 		NativeExporter:    &migrator.Native{DataStore: dataService},


### PR DESCRIPTION
The most straightforward fix for avatars import ( https://github.com/umputun/remark42/issues/990 ) mostly to start discussion of possible approaches. 

I don't like current fix but I don't see another way without code duplication or refactoring of auth package.

The best way that I see it's split  `backend/vendor/github.com/go-pkgz/auth/avatar/avatar.go` file to 2 structs, `Proxy` and `AvatarSaver`. 

First of all,  because they have different responsibility, `Proxy` works with paths, and `AvatarSaver` should declare rules how to save avatar. Even if we will look use cases, proxy and AvatarSaver parts uses in different scenarios. 

AvatarSaver can use Proxy to save avatar, but it shouldn't be same struct.
Also will needed to provide possibility to pass `Proxy` and `AvatarSaver` instances as parameters of auth package. If talk about `AvatarSaver` maybe we need provide possibility to pass it in runtime (as a param to save method).

This approach will provide possibility to declare different save mechanism for different providers. 
Each third party api can have different ratelimits, etc, and maybe even different protocols, not http. With this approach we will be able to configure it specifically for each API.

Will be glad to hear other ideas.

Just FYI, I am new in golang.