### PR TITLE
Make docker build work on tag again

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -3,7 +3,6 @@ name: build
 on:
   push:
     branches:
-      - master
     tags:
     paths:
       - ".github/workflows/ci-build.yml"


### PR DESCRIPTION
Based on #1514 we know that build is not triggered anymore for tags, this is most likely the fix.