### PR TITLE
Remove duplicate type definitions from function signatures

### DIFF
--- a/backend/app/migrator/backup.go
+++ b/backend/app/migrator/backup.go
@@ -83,7 +83,7 @@ func (ab AutoBackup) removeOldBackupFiles() {
 			backFiles = append(backFiles, info)
 		}
 	}
-	sort.Slice(backFiles, func(i int, j int) bool { return backFiles[i].Name() < backFiles[j].Name() })
+	sort.Slice(backFiles, func(i, j int) bool { return backFiles[i].Name() < backFiles[j].Name() })
 
 	if len(backFiles) > ab.KeepMax {
 		for i := 0; i < len(backFiles)-ab.KeepMax; i++ {

--- a/backend/app/migrator/migrator.go
+++ b/backend/app/migrator/migrator.go
@@ -38,7 +38,7 @@ type MapperMaker func(reader io.Reader) (Mapper, error)
 type Store interface {
 	Create(comment store.Comment) (commentID string, err error)
 	Find(locator store.Locator, sort string, user store.User) ([]store.Comment, error)
-	List(siteID string, limit int, skip int) ([]store.PostInfo, error)
+	List(siteID string, limit, skip int) ([]store.PostInfo, error)
 	DeleteAll(siteID string) error
 	Metas(siteID string) (umetas []service.UserMetaData, pmetas []service.PostMetaData, err error)
 	SetMetas(siteID string, umetas []service.UserMetaData, pmetas []service.PostMetaData) error

--- a/backend/app/notify/notify.go
+++ b/backend/app/notify/notify.go
@@ -34,8 +34,8 @@ type Destination interface {
 // Store defines the minimal interface accessing stored comments used by notifier
 type Store interface {
 	Get(locator store.Locator, id string, user store.User) (store.Comment, error)
-	GetUserEmail(siteID string, userID string) (string, error)
-	GetUserTelegram(siteID string, userID string) (string, error)
+	GetUserEmail(siteID, userID string) (string, error)
+	GetUserTelegram(siteID, userID string) (string, error)
 }
 
 // used for email and telegram retrieval from user details

--- a/backend/app/rest/api/admin.go
+++ b/backend/app/rest/api/admin.go
@@ -29,15 +29,15 @@ type admin struct {
 
 type adminStore interface {
 	Delete(locator store.Locator, commentID string, mode store.DeleteMode) error
-	DeleteUser(siteID string, userID string, mode store.DeleteMode) error
-	DeleteUserDetail(siteID string, userID string, detail engine.UserDetail) error
+	DeleteUser(siteID, userID string, mode store.DeleteMode) error
+	DeleteUserDetail(siteID, userID string, detail engine.UserDetail) error
 	User(siteID, userID string, limit, skip int, user store.User) ([]store.Comment, error)
-	IsBlocked(siteID string, userID string) bool
-	SetBlock(siteID string, userID string, status bool, ttl time.Duration) error
+	IsBlocked(siteID, userID string) bool
+	SetBlock(siteID, userID string, status bool, ttl time.Duration) error
 	BlockedUsers(siteID string) ([]store.BlockedUser, error)
 	Info(locator store.Locator, readonlyAge int) (store.PostInfo, error)
 	SetTitle(locator store.Locator, commentID string) (comment store.Comment, err error)
-	SetVerified(siteID string, userID string, status bool) error
+	SetVerified(siteID, userID string, status bool) error
 	SetReadOnly(locator store.Locator, status bool) error
 	SetPin(locator store.Locator, commentID string, status bool) error
 }

--- a/backend/app/rest/api/rest_private.go
+++ b/backend/app/rest/api/rest_private.go
@@ -58,15 +58,15 @@ type privStore interface {
 	Vote(req service.VoteReq) (comment store.Comment, err error)
 	Get(locator store.Locator, commentID string, user store.User) (store.Comment, error)
 	User(siteID, userID string, limit, skip int, user store.User) ([]store.Comment, error)
-	GetUserEmail(siteID string, userID string) (string, error)
-	SetUserEmail(siteID string, userID string, value string) (string, error)
-	GetUserTelegram(siteID string, userID string) (string, error)
-	SetUserTelegram(siteID string, userID string, value string) (string, error)
-	DeleteUserDetail(siteID string, userID string, detail engine.UserDetail) error
+	GetUserEmail(siteID, userID string) (string, error)
+	SetUserEmail(siteID, userID, value string) (string, error)
+	GetUserTelegram(siteID, userID string) (string, error)
+	SetUserTelegram(siteID, userID, value string) (string, error)
+	DeleteUserDetail(siteID, userID string, detail engine.UserDetail) error
 	ValidateComment(c *store.Comment) error
-	IsVerified(siteID string, userID string) bool
+	IsVerified(siteID, userID string) bool
 	IsReadOnly(locator store.Locator) bool
-	IsBlocked(siteID string, userID string) bool
+	IsBlocked(siteID, userID string) bool
 	Info(locator store.Locator, readonlyAge int) (store.PostInfo, error)
 }
 

--- a/backend/app/rest/api/rest_public.go
+++ b/backend/app/rest/api/rest_public.go
@@ -40,7 +40,7 @@ type pubStore interface {
 	User(siteID, userID string, limit, skip int, user store.User) ([]store.Comment, error)
 	UserCount(siteID, userID string) (int, error)
 	Count(locator store.Locator) (int, error)
-	List(siteID string, limit int, skip int) ([]store.PostInfo, error)
+	List(siteID string, limit, skip int) ([]store.PostInfo, error)
 	Info(locator store.Locator, readonlyAge int) (store.PostInfo, error)
 
 	ValidateComment(c *store.Comment) error

--- a/backend/app/store/admin/admin.go
+++ b/backend/app/store/admin/admin.go
@@ -78,5 +78,5 @@ func (s *StaticStore) Enabled(site string) (ok bool, err error) {
 	return false, nil
 }
 
-// OnEvent doesn nothing for StaticStore
+// OnEvent does nothing for StaticStore
 func (s *StaticStore) OnEvent(_ string, _ EventType) error { return nil }

--- a/backend/app/store/image/fs_store_test.go
+++ b/backend/app/store/image/fs_store_test.go
@@ -180,7 +180,7 @@ func TestFsStore_Cleanup(t *testing.T) {
 	svc, teardown := prepareImageTest(t)
 	defer teardown()
 
-	save := func(file string, user string) (filePath string) {
+	save := func(file, user string) (filePath string) {
 		id := path.Join(user, file)
 		err := svc.Save(id, gopherPNGBytes())
 		require.NoError(t, err)

--- a/backend/app/store/service/tree_test.go
+++ b/backend/app/store/service/tree_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestMakeTree(t *testing.T) {
 	loc := store.Locator{URL: "url", SiteID: "site"}
-	ts := func(min int, sec int) time.Time { return time.Date(2017, 12, 25, 19, min, sec, 0, time.UTC) }
+	ts := func(min, sec int) time.Time { return time.Date(2017, 12, 25, 19, min, sec, 0, time.UTC) }
 
 	// unsorted by purpose
 	comments := []store.Comment{
@@ -54,7 +54,7 @@ func TestMakeTree(t *testing.T) {
 
 func TestMakeEmptySubtree(t *testing.T) {
 	loc := store.Locator{URL: "url", SiteID: "site"}
-	ts := func(min int, sec int) time.Time { return time.Date(2017, 12, 25, 19, min, sec, 0, time.UTC) }
+	ts := func(min, sec int) time.Time { return time.Date(2017, 12, 25, 19, min, sec, 0, time.UTC) }
 
 	// unsorted by purpose
 	comments := []store.Comment{


### PR DESCRIPTION
I haven't found a linter for these, so I had to catch these manually. I found #757 to fix one of these, and I thought it would be good to fix everything at once.