### PR TITLE
Remove the unused DataStore.Put method

### DIFF
--- a/backend/app/store/service/service.go
+++ b/backend/app/store/service/service.go
@@ -154,12 +154,6 @@ func (s *DataStore) Get(locator store.Locator, commentID string, user store.User
 	return s.alterComment(c, user), nil
 }
 
-// Put updates comment, mutable parts only
-func (s *DataStore) Put(locator store.Locator, comment store.Comment) error {
-	comment.Locator = locator
-	return s.Engine.Update(comment)
-}
-
 // GetUserEmail gets user email
 func (s *DataStore) GetUserEmail(siteID, userID string) (string, error) {
 	res, err := s.Engine.UserDetail(engine.UserDetailRequest{


### PR DESCRIPTION
It was initially done in #757, cutting into a separate change.