### PR TITLE
Prefer unused PreferServerCipherSuites param

### DIFF
--- a/backend/app/rest/api/ssl.go
+++ b/backend/app/rest/api/ssl.go
@@ -111,15 +111,11 @@ func (s *Rest) getRemarkHost() string {
 
 func (s *Rest) makeTLSConfig() *tls.Config {
 	return &tls.Config{
-		PreferServerCipherSuites: true,
 		CipherSuites: []uint16{
 			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-			// tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-			// tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
 			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-			// tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
 		},
 		MinVersion: tls.VersionTLS12,
 		CurvePreferences: []tls.CurveID{


### PR DESCRIPTION
This is not used since 1.17, https://github.com/golang/go/commit/9d0819b27ca248f9949e7cf6bf7cb9fe7cf574e8