### PR TITLE
Deprecate secret CLI param requirement from all commands but "server"

### DIFF
--- a/backend/app/cmd/avatar.go
+++ b/backend/app/cmd/avatar.go
@@ -19,6 +19,7 @@ type AvatarCommand struct {
 
 	migrator AvatarMigrator
 	CommonOpts
+	DeprecatedSharedSecret
 }
 
 // AvatarMigrator defines interface for migration

--- a/backend/app/cmd/avatar_test.go
+++ b/backend/app/cmd/avatar_test.go
@@ -16,10 +16,12 @@ func TestAvatar_Execute(t *testing.T) {
 
 	// from fs to bolt
 	cmd := AvatarCommand{migrator: &avatarMigratorMock{retCount: 100}}
-	cmd.SetCommon(CommonOpts{RemarkURL: "", SharedSecret: "123456"})
+	cmd.SetCommon(CommonOpts{RemarkURL: ""})
 	p := flags.NewParser(&cmd, flags.Default)
 	_, err := p.ParseArgs([]string{"--src.type=fs", "--src.fs.path=/tmp/ava-test", "--dst.type=bolt",
-		"--dst.bolt.file=/tmp/ava-test.db"})
+		"--dst.bolt.file=/tmp/ava-test.db",
+		"--secret=12345", // deprecated, but must not fail the command execution
+	})
 	require.NoError(t, err)
 	defer os.Remove("/tmp/ava-test.db")
 	err = cmd.Execute(nil)
@@ -27,7 +29,7 @@ func TestAvatar_Execute(t *testing.T) {
 
 	// failed
 	cmd = AvatarCommand{migrator: &avatarMigratorMock{retCount: 0, retError: fmt.Errorf("failed blah")}}
-	cmd.SetCommon(CommonOpts{RemarkURL: "", SharedSecret: "123456"})
+	cmd.SetCommon(CommonOpts{RemarkURL: ""})
 	p = flags.NewParser(&cmd, flags.Default)
 	_, err = p.ParseArgs([]string{"--src.type=fs", "--src.fs.path=/tmp/ava-test", "--dst.type=bolt",
 		"--dst.bolt.file=/tmp/ava-test2.db"})

--- a/backend/app/cmd/backup.go
+++ b/backend/app/cmd/backup.go
@@ -19,6 +19,7 @@ type BackupCommand struct {
 
 	SupportCmdOpts
 	CommonOpts
+	DeprecatedSharedSecret
 }
 
 // Execute runs export with ExportCommand parameters, entry point for "export" command

--- a/backend/app/cmd/backup_test.go
+++ b/backend/app/cmd/backup_test.go
@@ -21,9 +21,11 @@ func TestBackup_Execute(t *testing.T) {
 	defer ts.Close()
 
 	cmd := BackupCommand{}
-	cmd.SetCommon(CommonOpts{RemarkURL: ts.URL, SharedSecret: "123456"})
+	cmd.SetCommon(CommonOpts{RemarkURL: ts.URL})
 	p := flags.NewParser(&cmd, flags.Default)
-	_, err := p.ParseArgs([]string{"--site=remark", "--path=/tmp", "--file={{.SITE}}-test.export", "--admin-passwd=secret"})
+	_, err := p.ParseArgs([]string{"--site=remark", "--path=/tmp", "--file={{.SITE}}-test.export", "--admin-passwd=secret",
+		"--secret=12345", // deprecated, but must not fail the command execution
+	})
 	require.NoError(t, err)
 	err = cmd.Execute(nil)
 	assert.NoError(t, err)
@@ -44,7 +46,7 @@ func TestBackup_ExecuteFailedStatus(t *testing.T) {
 	defer ts.Close()
 
 	cmd := BackupCommand{}
-	cmd.SetCommon(CommonOpts{RemarkURL: ts.URL, SharedSecret: "123456"})
+	cmd.SetCommon(CommonOpts{RemarkURL: ts.URL})
 
 	p := flags.NewParser(&cmd, flags.Default)
 	_, err := p.ParseArgs([]string{"--site=remark", "--path=/tmp", "--file={{.SITE}}-test.export", "--admin-passwd=secret"})
@@ -62,7 +64,7 @@ func TestBackup_ExecuteFailedWrite(t *testing.T) {
 	defer ts.Close()
 
 	cmd := BackupCommand{}
-	cmd.SetCommon(CommonOpts{RemarkURL: ts.URL, SharedSecret: "123456"})
+	cmd.SetCommon(CommonOpts{RemarkURL: ts.URL})
 
 	p := flags.NewParser(&cmd, flags.Default)
 	_, err := p.ParseArgs([]string{"--site=remark", "--path=/tmp",

--- a/backend/app/cmd/cleanup.go
+++ b/backend/app/cmd/cleanup.go
@@ -24,6 +24,7 @@ type CleanupCommand struct {
 
 	SupportCmdOpts
 	CommonOpts
+	DeprecatedSharedSecret
 }
 
 var (

--- a/backend/app/cmd/cleanup_test.go
+++ b/backend/app/cmd/cleanup_test.go
@@ -65,9 +65,11 @@ func TestCleanup_postsInRange(t *testing.T) {
 	defer ts.Close()
 
 	cmd := CleanupCommand{}
-	cmd.SetCommon(CommonOpts{RemarkURL: ts.URL, SharedSecret: "123456"})
+	cmd.SetCommon(CommonOpts{RemarkURL: ts.URL})
 	p := flags.NewParser(&cmd, flags.Default)
-	_, err := p.ParseArgs([]string{"--site=remark", "--bword=bad1", "--bword=bad2", "--buser=bu_", "--admin-passwd=secret"})
+	_, err := p.ParseArgs([]string{"--site=remark", "--bword=bad1", "--bword=bad2", "--buser=bu_", "--admin-passwd=secret",
+		"--secret=12345", // deprecated, but must not fail the command execution
+	})
 	require.NoError(t, err)
 	posts, err := cmd.postsInRange("20181218", "20181219")
 	assert.NoError(t, err)
@@ -88,7 +90,7 @@ func TestCleanup_listComments(t *testing.T) {
 	defer ts.Close()
 
 	cmd := CleanupCommand{}
-	cmd.SetCommon(CommonOpts{RemarkURL: ts.URL, SharedSecret: "123456"})
+	cmd.SetCommon(CommonOpts{RemarkURL: ts.URL})
 	p := flags.NewParser(&cmd, flags.Default)
 	_, err := p.ParseArgs([]string{"--site=remark", "--bword=bad1", "--bword=bad2", "--buser=bu_", "--admin-passwd=secret"})
 	require.NoError(t, err)
@@ -114,7 +116,7 @@ func TestCleanup_ExecuteSpam(t *testing.T) {
 	defer ts.Close()
 
 	cmd := CleanupCommand{}
-	cmd.SetCommon(CommonOpts{RemarkURL: ts.URL, SharedSecret: "123456"})
+	cmd.SetCommon(CommonOpts{RemarkURL: ts.URL})
 	p := flags.NewParser(&cmd, flags.Default)
 	_, err := p.ParseArgs([]string{"--site=remark", "--bword=bad1", "--bword=bad2", "--buser=bu_",
 		"--from=20181217", "--to=20181218", "--admin-passwd=secret"})
@@ -133,7 +135,7 @@ func TestCleanup_ExecuteTitle(t *testing.T) {
 	defer ts.Close()
 
 	cmd := CleanupCommand{}
-	cmd.SetCommon(CommonOpts{RemarkURL: ts.URL, SharedSecret: "123456"})
+	cmd.SetCommon(CommonOpts{RemarkURL: ts.URL})
 	p := flags.NewParser(&cmd, flags.Default)
 	_, err := p.ParseArgs([]string{"--site=remark", "--title", "--from=20181217", "--to=20181218", "--admin-passwd=secret"})
 	require.NoError(t, err)

--- a/backend/app/cmd/cmd.go
+++ b/backend/app/cmd/cmd.go
@@ -26,9 +26,13 @@ type CommonOptionsCommander interface {
 
 // CommonOpts sets externally from main, shared across all commands
 type CommonOpts struct {
-	RemarkURL    string
-	SharedSecret string
-	Revision     string
+	RemarkURL string
+	Revision  string
+}
+
+// DeprecatedSharedSecret is unused option preserved for compatibility
+type DeprecatedSharedSecret struct {
+	SharedSecret string `long:"secret" env:"SECRET" description:"[deprecated] not used in this command, preserved for compatibility"`
 }
 
 // SupportCmdOpts is set of commands shared among similar commands like backup/restore and such.
@@ -51,7 +55,6 @@ type DeprecatedFlag struct {
 // The method called by main for each command
 func (c *CommonOpts) SetCommon(commonOpts CommonOpts) {
 	c.RemarkURL = strings.TrimSuffix(commonOpts.RemarkURL, "/") // allow RemarkURL with trailing /
-	c.SharedSecret = commonOpts.SharedSecret
 	c.Revision = commonOpts.Revision
 }
 

--- a/backend/app/cmd/import.go
+++ b/backend/app/cmd/import.go
@@ -19,6 +19,7 @@ type ImportCommand struct {
 
 	SupportCmdOpts
 	CommonOpts
+	DeprecatedSharedSecret
 }
 
 // Execute runs import with ImportCommand parameters, entry point for "import" command

--- a/backend/app/cmd/import_test.go
+++ b/backend/app/cmd/import_test.go
@@ -28,16 +28,18 @@ func TestImport_Execute(t *testing.T) {
 	defer ts.Close()
 
 	cmd := ImportCommand{}
-	cmd.SetCommon(CommonOpts{RemarkURL: ts.URL, SharedSecret: "123456"})
+	cmd.SetCommon(CommonOpts{RemarkURL: ts.URL})
 
 	p := flags.NewParser(&cmd, flags.Default)
-	_, err := p.ParseArgs([]string{"--site=remark", "--file=testdata/import.txt", "--admin-passwd=secret"})
+	_, err := p.ParseArgs([]string{"--site=remark", "--file=testdata/import.txt", "--admin-passwd=secret",
+		"--secret=12345", // deprecated, but must not fail the command execution
+	})
 	require.NoError(t, err)
 	err = cmd.Execute(nil)
 	assert.NoError(t, err)
 
 	cmd = ImportCommand{}
-	cmd.SetCommon(CommonOpts{RemarkURL: ts.URL, SharedSecret: "123456"})
+	cmd.SetCommon(CommonOpts{RemarkURL: ts.URL})
 
 	p = flags.NewParser(&cmd, flags.Default)
 	_, err = p.ParseArgs([]string{"--site=remark", "--file=testdata/import.txt.gz", "--admin-passwd=secret"})
@@ -55,7 +57,7 @@ func TestImport_ExecuteFailed(t *testing.T) {
 	defer ts.Close()
 
 	cmd := ImportCommand{}
-	cmd.SetCommon(CommonOpts{RemarkURL: ts.URL, SharedSecret: "123456"})
+	cmd.SetCommon(CommonOpts{RemarkURL: ts.URL})
 	p := flags.NewParser(&cmd, flags.Default)
 	_, err := p.ParseArgs([]string{"--site=remark", "--file=testdata/import-no.txt", "--admin-passwd=secret"})
 	require.NoError(t, err)
@@ -65,7 +67,7 @@ func TestImport_ExecuteFailed(t *testing.T) {
 	assert.Contains(t, err.Error(), "no such file or directory")
 
 	cmd = ImportCommand{}
-	cmd.SetCommon(CommonOpts{RemarkURL: "http://127.0.0.1:12345", SharedSecret: "123456"})
+	cmd.SetCommon(CommonOpts{RemarkURL: "http://127.0.0.1:12345"})
 	p = flags.NewParser(&cmd, flags.Default)
 	_, err = p.ParseArgs([]string{"--site=remark", "--file=testdata/import.txt", "--admin-passwd=secret"})
 	require.NoError(t, err)
@@ -81,7 +83,7 @@ func TestImport_ExecuteFailed(t *testing.T) {
 	}))
 	defer ts2.Close()
 	cmd = ImportCommand{}
-	cmd.SetCommon(CommonOpts{RemarkURL: ts2.URL, SharedSecret: "123456"})
+	cmd.SetCommon(CommonOpts{RemarkURL: ts2.URL})
 	p = flags.NewParser(&cmd, flags.Default)
 	_, err = p.ParseArgs([]string{"--site=remark", "--file=testdata/import.txt", "--admin-passwd=secret"})
 	require.NoError(t, err)
@@ -104,7 +106,7 @@ func TestImport_ExecuteTimeout(t *testing.T) {
 	defer ts.Close()
 
 	cmd := ImportCommand{}
-	cmd.SetCommon(CommonOpts{RemarkURL: ts.URL, SharedSecret: "123456"})
+	cmd.SetCommon(CommonOpts{RemarkURL: ts.URL})
 
 	p := flags.NewParser(&cmd, flags.Default)
 	_, err := p.ParseArgs([]string{"--site=remark", "--file=testdata/import.txt", "--timeout=300ms", "--admin-passwd=secret"})

--- a/backend/app/cmd/remap.go
+++ b/backend/app/cmd/remap.go
@@ -17,6 +17,7 @@ type RemapCommand struct {
 
 	SupportCmdOpts
 	CommonOpts
+	DeprecatedSharedSecret
 }
 
 // Execute runs (re)mapper with RemapCommand parameters, entry point for "remap" command

--- a/backend/app/cmd/remap_test.go
+++ b/backend/app/cmd/remap_test.go
@@ -25,10 +25,12 @@ func TestRemap_Execute(t *testing.T) {
 	defer ts.Close()
 
 	cmd := RemapCommand{}
-	cmd.SetCommon(CommonOpts{RemarkURL: ts.URL, SharedSecret: "123456"})
+	cmd.SetCommon(CommonOpts{RemarkURL: ts.URL})
 
 	p := flags.NewParser(&cmd, flags.Default)
-	_, err := p.ParseArgs([]string{"--site=remark", "--file=testdata/remap_urls.txt", "--admin-passwd=secret"})
+	_, err := p.ParseArgs([]string{"--site=remark", "--file=testdata/remap_urls.txt", "--admin-passwd=secret",
+		"--secret=12345", // deprecated, but must not fail the command execution
+	})
 	require.NoError(t, err)
 	err = cmd.Execute(nil)
 	assert.NoError(t, err)

--- a/backend/app/cmd/restore.go
+++ b/backend/app/cmd/restore.go
@@ -13,6 +13,7 @@ type RestoreCommand struct {
 
 	SupportCmdOpts
 	CommonOpts
+	DeprecatedSharedSecret
 }
 
 // Execute runs import with RestoreCommand parameters, entry point for "restore" command

--- a/backend/app/cmd/restore_test.go
+++ b/backend/app/cmd/restore_test.go
@@ -27,10 +27,12 @@ func TestRestore_Execute(t *testing.T) {
 	defer ts.Close()
 
 	cmd := RestoreCommand{}
-	cmd.SetCommon(CommonOpts{RemarkURL: ts.URL, SharedSecret: "123456"})
+	cmd.SetCommon(CommonOpts{RemarkURL: ts.URL})
 
 	p := flags.NewParser(&cmd, flags.Default)
-	_, err := p.ParseArgs([]string{"--site=remark", "--path=testdata", "--file=import.txt", "--admin-passwd=secret"})
+	_, err := p.ParseArgs([]string{"--site=remark", "--path=testdata", "--file=import.txt", "--admin-passwd=secret",
+		"--secret=12345", // deprecated, but must not fail the command execution
+	})
 	require.NoError(t, err)
 	err = cmd.Execute(nil)
 	assert.NoError(t, err)

--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -58,6 +58,7 @@ type ServerCommand struct {
 	SSL        SSLGroup        `group:"ssl" namespace:"ssl" env-namespace:"SSL"`
 	ImageProxy ImageProxyGroup `group:"image-proxy" namespace:"image-proxy" env-namespace:"IMAGE_PROXY"`
 
+	SharedSecret     string        `long:"secret" env:"SECRET" required:"true" description:"the shared secret key used to sign JWT, should be a random, long, hard-to-guess string"`
 	Sites            []string      `long:"site" env:"SITE" default:"remark" description:"site names" env-delim:","`
 	AnonymousVote    bool          `long:"anon-vote" env:"ANON_VOTE" description:"enable anonymous votes (works only with VOTES_IP enabled)"`
 	AdminPasswd      string        `long:"admin-passwd" env:"ADMIN_PASSWD" default:"" description:"admin basic auth password"`

--- a/backend/app/main.go
+++ b/backend/app/main.go
@@ -23,8 +23,7 @@ type Opts struct {
 	CleanupCmd cmd.CleanupCommand `command:"cleanup"`
 	RemapCmd   cmd.RemapCommand   `command:"remap"`
 
-	RemarkURL    string `long:"url" env:"REMARK_URL" required:"true" description:"url to remark"`
-	SharedSecret string `long:"secret" env:"SECRET" required:"true" description:"the shared secret key used to sign JWT, should be a random, long, hard-to-guess string"`
+	RemarkURL string `long:"url" env:"REMARK_URL" required:"true" description:"url to remark"`
 
 	Dbg bool `long:"dbg" env:"DEBUG" description:"debug mode"`
 }
@@ -41,9 +40,8 @@ func main() {
 		// commands implements CommonOptionsCommander to allow passing set of extra options defined for all commands
 		c := command.(cmd.CommonOptionsCommander)
 		c.SetCommon(cmd.CommonOpts{
-			RemarkURL:    opts.RemarkURL,
-			SharedSecret: opts.SharedSecret,
-			Revision:     revision,
+			RemarkURL: opts.RemarkURL,
+			Revision:  revision,
 		})
 		logDeprecatedParams(c.HandleDeprecatedFlags())
 		err := c.Execute(args)


### PR DESCRIPTION
It was planned to be used in the import, restore, and backup commands, but later, Umputun ditched that idea. After that, one less CLI option to set for all the commands other than `server`.

Backwards compatibility preserved: providing the secret won't fail the command execution.