### PR TITLE
Improve frontend configuration parameters documentation

### DIFF
--- a/frontend/apps/remark42/app/typings/global.d.ts
+++ b/frontend/apps/remark42/app/typings/global.d.ts
@@ -2,18 +2,39 @@ import 'jest-fetch-mock';
 import type { Theme } from 'common/types';
 
 type RemarkConfig = {
+  // Hostname of Remark42 server, same as REMARK_URL in backend config, e.g. "https://demo.remark42.com".
   host?: string;
+  // The SITE that you passed to Remark42 instance on start of backend.
   site_id: string;
+  // Optional, 'window.location.origin + window.location.pathname' by default.
+  // URL to the page with comments, it is used as unique identificator for comments thread
+  //
+  // Note that if you use query parameters as significant part of URL(the one that actually changes content on page)
+  // you will have to configure URL manually to keep query params, as 'window.location.origin + window.location.pathname'
+  // doesn't contain query params and hash. For example, default URL for 'https://example/com/example-post?id=1#hash'
+  // would be 'https://example/com/example-post'
   url?: string;
+  // Optional, '15' by default. Maximum number of comments that is rendered on mobile version.
   max_shown_comments?: number;
-  theme?: Theme;
-  page_title?: string;
-  locale?: string;
-  show_email_subscription?: boolean;
+  // Optional, '15' by default. Maximum number of comments in the last comments widget.
   max_last_comments?: number;
-  __colors__?: Record<string, string>;
+  // Optional, 'dark' or 'light', 'light' by default. Changes UI theme.
+  theme?: Theme;
+  // Optional, 'document.title' by default. Title for current comments page.
+  page_title?: string;
+  // Optional, 'en' by default. Interface localization.
+  locale?: string;
+  // Optional, 'true' by default. Enables email subscription feature in interface when enable it from backend side,
+  // if you set this param in 'false' you will get notifications email notifications as admin but your users
+  // won't have interface for subscription
+  show_email_subscription?: boolean;
+  // Optional, 'true' by default. Enables RSS subscription feature in interface.
+  show_rss_subscription?: boolean;
+  // Optional, 'false' by default. Overrides the parameter from the backend minimized UI with basic info only.
   simple_view?: boolean;
+  // Optional, 'false' by default. Hides footer with signature and links to Remark42.
   no_footer?: boolean;
+  __colors__?: Record<string, string>;
 };
 
 declare global {

--- a/site/src/docs/configuration/frontend/index.md
+++ b/site/src/docs/configuration/frontend/index.md
@@ -13,14 +13,15 @@ title: Frontend Configuration
   - `'embed'` – basic comments widget
   - `'last-comments'` – last comments widget, see [Last Comments](#last-comments-widget) section below
   - `'counter'` – counter widget, see [Counter](#counter-widget) section below
-- **`max_shown_comments`**`: number` (optional, `15` by default) – maximum number of comments that is renered on mobile version
+- **`max_shown_comments`**`: number` (optional, `15` by default) – maximum number of comments that is rendered on mobile version
+- **`max_last_comments`**`: number` (optional, `15` by default) – maximum number of comments in the last comments widget
 - **`theme`**`: 'light' | 'dark'` (optional, `'light'` by default) – changes UI theme
 - **`page_title`**`: string` (optional, `document.title` by default) – title for current comments page
 - **`locale`**`: enum` (optional, `'en'` by default) – interface localization, [check possible localizations](#locales)
 - **`show_email_subscription`**`: boolean` (optional, `true` by default) – enables email subscription feature in interface when enable it from backend side, if you set this param in `false` you will get notifications email notifications as admin but your users won't have interface for subscription
 - **`show_rss_subscription`**`: boolean` (optional, `true` by default) – enables RSS subscription feature in interface
 - **`simple_view`**`: boolean` (optional, `false` by default) – overrides the parameter from the backend minimized UI with basic info only
-- **`no_footer`**`: boolean` (optional, `false` by default) – hides footer with signatue and links to remark42
+- **`no_footer`**`: boolean` (optional, `false` by default) – hides footer with signature and links to Remark42
 
 Example with all of the params:
 


### PR DESCRIPTION
Variables were documented in the documentation but not in the code, and max_last_comments needed to be documented.

Resolved #764.