### PR TITLE
clarify frontend files cache policy

### DIFF
--- a/backend/app/rest/api/rest.go
+++ b/backend/app/rest/api/rest.go
@@ -491,6 +491,8 @@ func addFileServer(r chi.Router, embedFS embed.FS, webRoot, version string) {
 			http.NotFound(w, r)
 			return
 		}
+		// without it it would be set to "max-age=3600, no-cache" which is redundant
+		w.Header().Set("Cache-Control", "no-cache")
 		webFS.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
Previously Cache-Control was set to "max-age=3600, no-cache", but max-age is not used in case no-cache is set.

cc @Ivan-Chupin for review.

Addresses https://github.com/umputun/remark42/discussions/1549#discussioncomment-4750537.