### PR TITLE
ping pnmp version to 7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY ./frontend/apps/remark42/package.json /srv/frontend/apps/remark42/
 RUN \
   if [[ -z "$SKIP_FRONTEND_BUILD" || -z "$SKIP_FRONTEND_TEST" ]]; then \
     apk add --no-cache --update git && \
-    npm i -g pnpm; \
+    npm i -g pnpm@7; \
   fi
 
 RUN --mount=type=cache,id=pnpm,target=/root/.pnpm-store/v3 \

--- a/Dockerfile.artifacts
+++ b/Dockerfile.artifacts
@@ -7,7 +7,7 @@ WORKDIR /srv/frontend
 COPY ./frontend/package.json ./frontend/pnpm-lock.yaml ./frontend/pnpm-workspace.yaml /srv/frontend/
 COPY ./frontend/apps/remark42/package.json /srv/frontend/apps/remark42/package.json
 
-RUN apk add --no-cache --update git && npm i -g pnpm
+RUN apk add --no-cache --update git && npm i -g pnpm@7
 RUN --mount=type=cache,id=pnpm,target=/root/.pnpm-store/v3 pnpm i
 
 FROM frontend-deps AS build-frontend

--- a/frontend/packages/api/README.md
+++ b/frontend/packages/api/README.md
@@ -4,7 +4,7 @@ Implementation of API methods for Remark42
 
 ## Development
 
-- If you don't have `pnpm` installed run `npm i -g pnpm`
+- If you don't have `pnpm` installed run `npm i -g pnpm@7`
 - Install dependencies `pnpm i`
 - Run development mode with `pnpm run dev`
 - Build lib with `pnpm run build`


### PR DESCRIPTION
Previously version 8 was installed once it became available, breaking the pipelines and docker build.