### PR TITLE
Add the ability to change the primary color of the comments widget and other styles

### DIFF
--- a/frontend/apps/remark42/app/common/settings.ts
+++ b/frontend/apps/remark42/app/common/settings.ts
@@ -1,5 +1,6 @@
 import { parseQuery } from 'utils/parse-query';
 import { THEMES, MAX_SHOWN_ROOT_COMMENTS } from './constants';
+import { themeStylingFromUrlSearchParams } from './theme';
 
 function parseNumber(value: unknown) {
   if (typeof value !== 'string') {
@@ -27,3 +28,4 @@ export const url = rawParams.url;
 export const token = rawParams.token;
 export const locale = rawParams.locale || 'en';
 export const noFooter = rawParams.no_footer === 'true';
+export const styling = themeStylingFromUrlSearchParams(rawParams);

--- a/frontend/apps/remark42/app/common/theme.spec.ts
+++ b/frontend/apps/remark42/app/common/theme.spec.ts
@@ -1,0 +1,65 @@
+import { themeStylingFromUrlSearchParams, themeStylingToUrlSearchParams } from './theme';
+
+describe('themeStylingToUrlSearchParams', () => {
+  test('returns an empty object when styling is undefined', () => {
+    expect(themeStylingToUrlSearchParams(undefined)).toEqual({});
+  });
+
+  test('converts primary color string to "colorsPrimary" parameter', () => {
+    const styling = { colors: { primary: '#ff0000' } };
+    const params = themeStylingToUrlSearchParams(styling);
+    expect(params).toEqual({ colorsPrimary: '#ff0000' });
+  });
+
+  test('converts primary color object with light/dark properties to "colorsPrimary", "colorsPrimaryLight", and "colorsPrimaryDark" parameters', () => {
+    const styling = { colors: { primary: { light: '#ffffff', dark: '#000000' } } };
+    const params = themeStylingToUrlSearchParams(styling);
+    expect(params).toEqual({
+      colorsPrimaryLight: '#ffffff',
+      colorsPrimaryDark: '#000000',
+    });
+  });
+});
+
+describe('themeStylingFromUrlSearchParams', () => {
+  it('returns undefined when params is empty', () => {
+    const result = themeStylingFromUrlSearchParams({});
+    expect(result).toBeUndefined();
+  });
+
+  it('returns theme styling object with colors when params contains colorsPrimaryLight and colorsPrimaryDark', () => {
+    const params = {
+      colorsPrimaryLight: '#fff',
+      colorsPrimaryDark: '#000',
+    };
+    const result = themeStylingFromUrlSearchParams(params);
+    expect(result).toEqual({
+      colors: {
+        primary: {
+          light: '#fff',
+          dark: '#000',
+        },
+      },
+    });
+  });
+
+  it('returns theme styling object with colors when params contains colorsPrimary', () => {
+    const params = {
+      colorsPrimary: '#fff',
+    };
+    const result = themeStylingFromUrlSearchParams(params);
+    expect(result).toEqual({
+      colors: {
+        primary: '#fff',
+      },
+    });
+  });
+
+  it('returns undefined when params does not contain colorsPrimary or colorsPrimaryLight and colorsPrimaryDark', () => {
+    const params = {
+      someOtherParam: 'value',
+    };
+    const result = themeStylingFromUrlSearchParams(params);
+    expect(result).toBeUndefined();
+  });
+});

--- a/frontend/apps/remark42/app/common/theme.ts
+++ b/frontend/apps/remark42/app/common/theme.ts
@@ -1,25 +1,41 @@
-import { Color, color, parseColorStr } from 'utils/colors';
+import { color, DualColors, parseColorStr } from 'utils/colors';
 import { isStr, isUnknownDict } from 'utils/types';
 
+// Types
+
 export interface ThemeStyles {
-  colors?: ThemeStyleColors;
+  colors?: ThemeColors;
 }
 
 export const isThemeStyles = (val: unknown): val is ThemeStyles => {
   if (!isUnknownDict(val)) return false;
-  if (val.colors && !isThemeStylesColors(val.colors)) return false;
+  if (val.colors && !isThemeColors(val.colors)) return false;
   return true;
 };
 
-export interface ThemeStyleColors {
-  primary?: string;
+interface ThemeColors {
+  primary?: ThemeColor;
 }
 
-const isThemeStylesColors = (val: unknown): val is ThemeStyleColors => {
+const isThemeColors = (val: unknown): val is ThemeColors => {
   if (!isUnknownDict(val)) return false;
-  if (val.primary && !isStr(val.primary)) return false;
+  if (val.primary && !isThemeColor(val.primary)) return false;
   return true;
 };
+
+type ThemeColor = string | ThemeDualColors;
+
+const isThemeColor = (val: unknown): val is ThemeColor => isStr(val) || isThemeDualColors(val);
+
+interface ThemeDualColors {
+  light: string;
+  dark: string;
+}
+
+const isThemeDualColors = (val: unknown): val is ThemeDualColors =>
+  isUnknownDict(val) && isStr(val.light) && isStr(val.dark);
+
+// Functionality
 
 export const setThemeStyles = (styles: ThemeStyles) => {
   if (styles.colors) {
@@ -27,39 +43,46 @@ export const setThemeStyles = (styles: ThemeStyles) => {
   }
 };
 
-const setColors = (colors: ThemeStyleColors) => {
-  const { primary: primaryStr } = colors;
-
-  // Primary color
-  if (primaryStr) {
-    const primary = parseColorStr(primaryStr);
-    if (primary) {
-      setPrimaryColor(primary);
-    } else {
-      console.error('Invalid primary color format: ', primaryStr);
-    }
+const setColors = (colors: ThemeColors) => {
+  const { primary } = colors;
+  // Primary
+  if (isStr(primary)) {
+    const val = parseColorStr(primary);
+    if (val) {
+      // Generate dark color from light
+      setPrimaryColors({ light: val, dark: color(val).darken(0.1).object() });
+    } else console.error('Invalid primary color format: ', primary);
+  }
+  if (isThemeDualColors(primary)) {
+    const { light, dark } = primary;
+    const lightVal = parseColorStr(light);
+    const darkVal = parseColorStr(dark);
+    if (lightVal && darkVal) {
+      setPrimaryColors({ light: lightVal, dark: darkVal });
+    } else console.error('Invalid primary color format: ', primary);
   }
 };
 
-const setPrimaryColor = (val: Color) => {
+const setPrimaryColors = (val: DualColors) => {
   const rootEl = document.documentElement;
   const darkRootEl = document.querySelector('.root.dark');
-  const primary = color(val); // #0aa, rgb(0, 170, 170)
+  const light = color(val.light); // #0aa, rgb(0, 170, 170)
+  const dark = color(val.dark); // #099, rgb(0, 153, 153)
   /* Numerid variables  */
-  rootEl.style.setProperty('--color9', primary.hex()); // #0aa;
-  rootEl.style.setProperty('--color15', primary.darken(0.1).hex()); // #099, rgb(0, 153, 153)
-  rootEl.style.setProperty('--color33', primary.lighten(0.3).hex()); // #06c5c5, rgb(6,197,197) (equivalent rgb(77, 196, 196));
-  rootEl.style.setProperty('--color40', primary.lighten(0.6).hex()); // #9cdddb, rgb(156,221,219) (equivalent rgb(153, 221, 221));
-  rootEl.style.setProperty('--color43', primary.lighten(0.7).hex()); // #b7dddd, 	rgb(183,221,221)
-  rootEl.style.setProperty('--color42', primary.lighten(0.8).hex()); // #c6efef, rgb(198,239,239)
-  rootEl.style.setProperty('--color48', primary.darken(0.1).alpha(0.6).rgb()); // rgba(37, 156, 154, 0.6)
-  rootEl.style.setProperty('--color47', primary.darken(0.1).alpha(0.4).rgb()); // rgba(37, 156, 154, 0.4)
+  rootEl.style.setProperty('--color9', light.hex()); // #0aa;
+  rootEl.style.setProperty('--color15', light.darken(0.1).hex()); // #099, rgb(0, 153, 153)
+  rootEl.style.setProperty('--color33', light.lighten(0.3).hex()); // #06c5c5, rgb(6,197,197) (equivalent rgb(77, 196, 196));
+  rootEl.style.setProperty('--color40', light.lighten(0.6).hex()); // #9cdddb, rgb(156,221,219) (equivalent rgb(153, 221, 221));
+  rootEl.style.setProperty('--color43', light.lighten(0.7).hex()); // #b7dddd, 	rgb(183,221,221)
+  rootEl.style.setProperty('--color42', light.lighten(0.8).hex()); // #c6efef, rgb(198,239,239)
+  rootEl.style.setProperty('--color48', light.darken(0.1).alpha(0.6).rgb()); // rgba(37, 156, 154, 0.6)
+  rootEl.style.setProperty('--color47', light.darken(0.1).alpha(0.4).rgb()); // rgba(37, 156, 154, 0.4)
   /* Named variables */
-  rootEl.style.setProperty('--primary-color', primary.rgbBody()); // rgb(0, 170, 170)
-  rootEl.style.setProperty('--primary-brighter-color', primary.darken(0.1).rgbBody()); // rgb(0, 153, 153);
-  rootEl.style.setProperty('--primary-darker-color', primary.darken(0.4).rgbBody()); // rgb(0, 102, 102);
+  rootEl.style.setProperty('--primary-color', light.rgbBody()); // rgb(0, 170, 170)
+  rootEl.style.setProperty('--primary-brighter-color', light.darken(0.1).rgbBody()); // rgb(0, 153, 153);
+  rootEl.style.setProperty('--primary-darker-color', light.darken(0.4).rgbBody()); // rgb(0, 102, 102);
   if (darkRootEl instanceof HTMLElement) {
-    darkRootEl.style.setProperty('--primary-color', primary.darken(0.1).rgbBody()); // rgb(0, 153, 153)
-    darkRootEl.style.setProperty('--primary-brighter-color', primary.rgbBody()); // rgb(0, 170, 170)
+    darkRootEl.style.setProperty('--primary-color', dark.rgbBody()); // rgb(0, 153, 153)
+    darkRootEl.style.setProperty('--primary-brighter-color', dark.lighten(0.1).rgbBody()); // rgb(0, 170, 170)
   }
 };

--- a/frontend/apps/remark42/app/common/theme.ts
+++ b/frontend/apps/remark42/app/common/theme.ts
@@ -1,0 +1,62 @@
+import { colorToHexStr, colorToNumStr, colorToRgbStr, darkenColor, lightenColor, parseColorStr } from 'utils/colors';
+import { isStr, isUnknownDict } from 'utils/types';
+
+export interface ThemeStyles {
+  colors?: ThemeStyleColors;
+}
+
+export const isThemeStyles = (val: unknown): val is ThemeStyles => {
+  if (!isUnknownDict(val)) return false;
+  if (val.colors && !isThemeStylesColors(val.colors)) return false;
+  return true;
+};
+
+export interface ThemeStyleColors {
+  primary?: string;
+}
+
+const isThemeStylesColors = (val: unknown): val is ThemeStyleColors => {
+  if (!isUnknownDict(val)) return false;
+  if (val.primary && !isStr(val.primary)) return false;
+  return true;
+};
+
+export const setThemeStyles = (styles: ThemeStyles) => {
+  console.log('[+]: setThemeStyle', styles);
+  if (styles.colors) {
+    setThemeStylesColors(styles.colors);
+  }
+};
+
+const setThemeStylesColors = (colors: ThemeStyleColors) => {
+  const { primary: primaryStr } = colors;
+  const rootEl = document.documentElement;
+  const darkRootEl = document.querySelector('.root.dark');
+  // Primary color
+  if (primaryStr) {
+    const primary = parseColorStr(primaryStr); // #0aa, rgb(0, 170, 170)
+    if (primary) {
+      /* Numerid variables  */
+      rootEl.style.setProperty('--color9', colorToHexStr(primary)); // #0aa;
+      rootEl.style.setProperty('--color15', colorToHexStr(darkenColor(primary, 0.1))); // #099, rgb(0, 153, 153)
+      rootEl.style.setProperty('--color33', colorToHexStr(lightenColor(primary, 0.3))); // #06c5c5, rgb(6,197,197) (equivalent rgb(77, 196, 196));
+      rootEl.style.setProperty('--color40', colorToHexStr(lightenColor(primary, 0.6))); // #9cdddb, rgb(156,221,219) (equivalent rgb(153, 221, 221));
+      rootEl.style.setProperty('--color43', colorToHexStr(lightenColor(primary, 0.7))); // #b7dddd, 	rgb(183,221,221)
+      rootEl.style.setProperty('--color42', colorToHexStr(lightenColor(primary, 0.8))); // #c6efef, rgb(198,239,239)
+      rootEl.style.setProperty('--color48', colorToRgbStr({ ...darkenColor(primary, 0.1), a: 0.6 })); // rgba(37, 156, 154, 0.6)
+      rootEl.style.setProperty('--color47', colorToRgbStr({ ...darkenColor(primary, 0.1), a: 0.4 })); // rgba(37, 156, 154, 0.4)
+      /* Named variables */
+      const dark = darkenColor(primary, 0.1); // rgb(0, 153, 153);
+      const moreDark = darkenColor(primary, 0.4); // rgb(0, 102, 102);
+      rootEl.style.setProperty('--primary-color', colorToNumStr(primary)); // rgb(0, 170, 170)
+      rootEl.style.setProperty('--primary-brighter-color', colorToNumStr(dark)); // rgb(0, 153, 153);
+      rootEl.style.setProperty('--primary-darker-color', colorToNumStr(moreDark)); // rgb(0, 102, 102);
+      if (darkRootEl instanceof HTMLElement) {
+        darkRootEl.style.setProperty('--primary-color', colorToNumStr(dark)); // rgb(0, 153, 153)
+        darkRootEl.style.setProperty('--primary-brighter-color', colorToNumStr(primary)); // rgb(0, 170, 170)
+      }
+    } else {
+      console.error('Invalid primary color format: ', primaryStr);
+    }
+  }
+};

--- a/frontend/apps/remark42/app/common/theme.ts
+++ b/frontend/apps/remark42/app/common/theme.ts
@@ -86,7 +86,6 @@ const setPrimaryColors = (val: DualColors) => {
   // may not be exact, but are fairly close.
   const rootEl = document.documentElement;
   const darkRootEl = document.querySelector(':root body.dark');
-  console.log(darkRootEl);
   const light = color(val.light); // #0aa, rgb(0, 170, 170)
   const dark = color(val.dark); // #099, rgb(0, 153, 153)
 

--- a/frontend/apps/remark42/app/common/theme.ts
+++ b/frontend/apps/remark42/app/common/theme.ts
@@ -1,4 +1,4 @@
-import { colorToHexStr, colorToNumStr, colorToRgbStr, darkenColor, lightenColor, parseColorStr } from 'utils/colors';
+import { Color, color, parseColorStr } from 'utils/colors';
 import { isStr, isUnknownDict } from 'utils/types';
 
 export interface ThemeStyles {
@@ -22,41 +22,44 @@ const isThemeStylesColors = (val: unknown): val is ThemeStyleColors => {
 };
 
 export const setThemeStyles = (styles: ThemeStyles) => {
-  console.log('[+]: setThemeStyle', styles);
   if (styles.colors) {
-    setThemeStylesColors(styles.colors);
+    setColors(styles.colors);
   }
 };
 
-const setThemeStylesColors = (colors: ThemeStyleColors) => {
+const setColors = (colors: ThemeStyleColors) => {
   const { primary: primaryStr } = colors;
-  const rootEl = document.documentElement;
-  const darkRootEl = document.querySelector('.root.dark');
+
   // Primary color
   if (primaryStr) {
-    const primary = parseColorStr(primaryStr); // #0aa, rgb(0, 170, 170)
+    const primary = parseColorStr(primaryStr);
     if (primary) {
-      /* Numerid variables  */
-      rootEl.style.setProperty('--color9', colorToHexStr(primary)); // #0aa;
-      rootEl.style.setProperty('--color15', colorToHexStr(darkenColor(primary, 0.1))); // #099, rgb(0, 153, 153)
-      rootEl.style.setProperty('--color33', colorToHexStr(lightenColor(primary, 0.3))); // #06c5c5, rgb(6,197,197) (equivalent rgb(77, 196, 196));
-      rootEl.style.setProperty('--color40', colorToHexStr(lightenColor(primary, 0.6))); // #9cdddb, rgb(156,221,219) (equivalent rgb(153, 221, 221));
-      rootEl.style.setProperty('--color43', colorToHexStr(lightenColor(primary, 0.7))); // #b7dddd, 	rgb(183,221,221)
-      rootEl.style.setProperty('--color42', colorToHexStr(lightenColor(primary, 0.8))); // #c6efef, rgb(198,239,239)
-      rootEl.style.setProperty('--color48', colorToRgbStr({ ...darkenColor(primary, 0.1), a: 0.6 })); // rgba(37, 156, 154, 0.6)
-      rootEl.style.setProperty('--color47', colorToRgbStr({ ...darkenColor(primary, 0.1), a: 0.4 })); // rgba(37, 156, 154, 0.4)
-      /* Named variables */
-      const dark = darkenColor(primary, 0.1); // rgb(0, 153, 153);
-      const moreDark = darkenColor(primary, 0.4); // rgb(0, 102, 102);
-      rootEl.style.setProperty('--primary-color', colorToNumStr(primary)); // rgb(0, 170, 170)
-      rootEl.style.setProperty('--primary-brighter-color', colorToNumStr(dark)); // rgb(0, 153, 153);
-      rootEl.style.setProperty('--primary-darker-color', colorToNumStr(moreDark)); // rgb(0, 102, 102);
-      if (darkRootEl instanceof HTMLElement) {
-        darkRootEl.style.setProperty('--primary-color', colorToNumStr(dark)); // rgb(0, 153, 153)
-        darkRootEl.style.setProperty('--primary-brighter-color', colorToNumStr(primary)); // rgb(0, 170, 170)
-      }
+      setPrimaryColor(primary);
     } else {
       console.error('Invalid primary color format: ', primaryStr);
     }
+  }
+};
+
+const setPrimaryColor = (val: Color) => {
+  const rootEl = document.documentElement;
+  const darkRootEl = document.querySelector('.root.dark');
+  const primary = color(val); // #0aa, rgb(0, 170, 170)
+  /* Numerid variables  */
+  rootEl.style.setProperty('--color9', primary.hex()); // #0aa;
+  rootEl.style.setProperty('--color15', primary.darken(0.1).hex()); // #099, rgb(0, 153, 153)
+  rootEl.style.setProperty('--color33', primary.lighten(0.3).hex()); // #06c5c5, rgb(6,197,197) (equivalent rgb(77, 196, 196));
+  rootEl.style.setProperty('--color40', primary.lighten(0.6).hex()); // #9cdddb, rgb(156,221,219) (equivalent rgb(153, 221, 221));
+  rootEl.style.setProperty('--color43', primary.lighten(0.7).hex()); // #b7dddd, 	rgb(183,221,221)
+  rootEl.style.setProperty('--color42', primary.lighten(0.8).hex()); // #c6efef, rgb(198,239,239)
+  rootEl.style.setProperty('--color48', primary.darken(0.1).alpha(0.6).rgb()); // rgba(37, 156, 154, 0.6)
+  rootEl.style.setProperty('--color47', primary.darken(0.1).alpha(0.4).rgb()); // rgba(37, 156, 154, 0.4)
+  /* Named variables */
+  rootEl.style.setProperty('--primary-color', primary.rgbBody()); // rgb(0, 170, 170)
+  rootEl.style.setProperty('--primary-brighter-color', primary.darken(0.1).rgbBody()); // rgb(0, 153, 153);
+  rootEl.style.setProperty('--primary-darker-color', primary.darken(0.4).rgbBody()); // rgb(0, 102, 102);
+  if (darkRootEl instanceof HTMLElement) {
+    darkRootEl.style.setProperty('--primary-color', primary.darken(0.1).rgbBody()); // rgb(0, 153, 153)
+    darkRootEl.style.setProperty('--primary-brighter-color', primary.rgbBody()); // rgb(0, 170, 170)
   }
 };

--- a/frontend/apps/remark42/app/common/theme.ts
+++ b/frontend/apps/remark42/app/common/theme.ts
@@ -45,14 +45,15 @@ export const setThemeStyles = (styles: ThemeStyles) => {
 
 const setColors = (colors: ThemeColors) => {
   const { primary } = colors;
-  // Primary
+  // Primary str color
   if (isStr(primary)) {
     const val = parseColorStr(primary);
     if (val) {
-      // Generate dark color from light
+      // Generate dark color from light, make it little bit darker
       setPrimaryColors({ light: val, dark: color(val).darken(0.1).object() });
     } else console.error('Invalid primary color format: ', primary);
   }
+  // Primary dual color
   if (isThemeDualColors(primary)) {
     const { light, dark } = primary;
     const lightVal = parseColorStr(light);
@@ -68,7 +69,12 @@ const setPrimaryColors = (val: DualColors) => {
   const darkRootEl = document.querySelector('.root.dark');
   const light = color(val.light); // #0aa, rgb(0, 170, 170)
   const dark = color(val.dark); // #099, rgb(0, 153, 153)
-  /* Numerid variables  */
+
+  // Lighten and darken percentages are based on the colors provided
+  // in the "styles/custom-properties.css" file. The resulting colors
+  // may not be exact, but are fairly close.
+
+  // Numerid variables
   rootEl.style.setProperty('--color9', light.hex()); // #0aa;
   rootEl.style.setProperty('--color15', light.darken(0.1).hex()); // #099, rgb(0, 153, 153)
   rootEl.style.setProperty('--color33', light.lighten(0.3).hex()); // #06c5c5, rgb(6,197,197) (equivalent rgb(77, 196, 196));
@@ -77,7 +83,7 @@ const setPrimaryColors = (val: DualColors) => {
   rootEl.style.setProperty('--color42', light.lighten(0.8).hex()); // #c6efef, rgb(198,239,239)
   rootEl.style.setProperty('--color48', light.darken(0.1).alpha(0.6).rgb()); // rgba(37, 156, 154, 0.6)
   rootEl.style.setProperty('--color47', light.darken(0.1).alpha(0.4).rgb()); // rgba(37, 156, 154, 0.4)
-  /* Named variables */
+  // Named variables
   rootEl.style.setProperty('--primary-color', light.rgbBody()); // rgb(0, 170, 170)
   rootEl.style.setProperty('--primary-brighter-color', light.darken(0.1).rgbBody()); // rgb(0, 153, 153);
   rootEl.style.setProperty('--primary-darker-color', light.darken(0.4).rgbBody()); // rgb(0, 102, 102);

--- a/frontend/apps/remark42/app/common/theme.ts
+++ b/frontend/apps/remark42/app/common/theme.ts
@@ -3,6 +3,11 @@ import { isStr, isUnknownDict } from 'utils/types';
 
 // Types
 
+/**
+ * An interface representing the styles for a theme.
+ * @interface
+ * @property {ThemeColors} [colors] - An optional object representing the colors for the theme.
+ */
 export interface ThemeStyles {
   colors?: ThemeColors;
 }
@@ -13,6 +18,11 @@ export const isThemeStyles = (val: unknown): val is ThemeStyles => {
   return true;
 };
 
+/**
+ * An interface representing the colors for a theme.
+ * @interface
+ * @property {ThemeColor} [primary] - An optional object representing the primary color for the theme.
+ */
 interface ThemeColors {
   primary?: ThemeColor;
 }
@@ -27,6 +37,12 @@ type ThemeColor = string | ThemeDualColors;
 
 const isThemeColor = (val: unknown): val is ThemeColor => isStr(val) || isThemeDualColors(val);
 
+/**
+ * An interface representing two color values for a theme, one for light mode and one for dark mode.
+ * @interface
+ * @property {string} light - The color value for light mode.
+ * @property {string} dark - The color value for dark mode.
+ */
 interface ThemeDualColors {
   light: string;
   dark: string;
@@ -51,7 +67,7 @@ const setColors = (colors: ThemeColors) => {
     if (val) {
       // Generate dark color from light, make it little bit darker
       setPrimaryColors({ light: val, dark: color(val).darken(0.1).object() });
-    } else console.error('Invalid primary color format: ', primary);
+    } else console.error('Remark42: invalid primary color format: ', primary);
   }
   // Primary dual color
   if (isThemeDualColors(primary)) {
@@ -60,19 +76,18 @@ const setColors = (colors: ThemeColors) => {
     const darkVal = parseColorStr(dark);
     if (lightVal && darkVal) {
       setPrimaryColors({ light: lightVal, dark: darkVal });
-    } else console.error('Invalid primary color format: ', primary);
+    } else console.error('Remark42: invalid primary color format: ', primary);
   }
 };
 
 const setPrimaryColors = (val: DualColors) => {
+  // Lighten and darken percentages are based on the colors provided
+  // in the "styles/custom-properties.css" file. The resulting colors
+  // may not be exact, but are fairly close.
   const rootEl = document.documentElement;
   const darkRootEl = document.querySelector('.root.dark');
   const light = color(val.light); // #0aa, rgb(0, 170, 170)
   const dark = color(val.dark); // #099, rgb(0, 153, 153)
-
-  // Lighten and darken percentages are based on the colors provided
-  // in the "styles/custom-properties.css" file. The resulting colors
-  // may not be exact, but are fairly close.
 
   // Numerid variables
   rootEl.style.setProperty('--color9', light.hex()); // #0aa;

--- a/frontend/apps/remark42/app/common/types.ts
+++ b/frontend/apps/remark42/app/common/types.ts
@@ -126,6 +126,7 @@ export interface Config {
 export type Sorting = '-time' | '+time' | '-active' | '+active' | '-score' | '+score' | '-controversy' | '+controversy';
 export type BlockTTL = 'permanently' | '43200m' | '10080m' | '1440m';
 export type Theme = 'light' | 'dark';
+export const isTheme = (theme: unknown): theme is Theme => theme === 'light' || theme === 'dark';
 
 /**
  * Comment component's edit mode:

--- a/frontend/apps/remark42/app/embed.ts
+++ b/frontend/apps/remark42/app/embed.ts
@@ -3,6 +3,7 @@ import { parseMessage, postMessageToIframe } from 'utils/post-message';
 import { createIframe } from 'utils/create-iframe';
 import type { Theme } from 'common/types';
 import { closeProfile, openProfile } from 'profile';
+import { ThemeStyles } from 'common/theme';
 
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', init);
@@ -114,6 +115,11 @@ function createInstance(config: typeof window.remark_config) {
     postMessageToIframe(iframe, { theme });
   }
 
+  function changeStyles(styles: ThemeStyles) {
+    window.remark_config.styles = styles;
+    postMessageToIframe(iframe, { styles });
+  }
+
   function destroy() {
     window.removeEventListener('message', handleReceiveMessage);
     window.removeEventListener('hashchange', handleHashChange);
@@ -131,9 +137,11 @@ function createInstance(config: typeof window.remark_config) {
 
   // TODO: These do not appear in Chrome DevTools
   window.REMARK42.changeTheme = changeTheme;
+  window.REMARK42.changeStyles = changeStyles;
   window.REMARK42.destroy = () => {
     destroy();
     delete window.REMARK42.changeTheme;
+    delete window.REMARK42.changeStyles;
     delete window.REMARK42.destroy;
   };
 

--- a/frontend/apps/remark42/app/embed.ts
+++ b/frontend/apps/remark42/app/embed.ts
@@ -3,7 +3,7 @@ import { parseMessage, postMessageToIframe } from 'utils/post-message';
 import { createIframe } from 'utils/create-iframe';
 import type { Theme } from 'common/types';
 import { closeProfile, openProfile } from 'profile';
-import { ThemeStyles } from 'common/theme';
+import { ThemeStyling } from 'common/theme';
 
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', init);
@@ -115,9 +115,9 @@ function createInstance(config: typeof window.remark_config) {
     postMessageToIframe(iframe, { theme });
   }
 
-  function changeStyles(styles: ThemeStyles) {
-    window.remark_config.styles = styles;
-    postMessageToIframe(iframe, { styles });
+  function changeStyling(styling: ThemeStyling) {
+    window.remark_config.styling = styling;
+    postMessageToIframe(iframe, { styling });
   }
 
   function destroy() {
@@ -137,11 +137,11 @@ function createInstance(config: typeof window.remark_config) {
 
   // TODO: These do not appear in Chrome DevTools
   window.REMARK42.changeTheme = changeTheme;
-  window.REMARK42.changeStyles = changeStyles;
+  window.REMARK42.changeStyling = changeStyling;
   window.REMARK42.destroy = () => {
     destroy();
     delete window.REMARK42.changeTheme;
-    delete window.REMARK42.changeStyles;
+    delete window.REMARK42.changeStyling;
     delete window.REMARK42.destroy;
   };
 

--- a/frontend/apps/remark42/app/remark.tsx
+++ b/frontend/apps/remark42/app/remark.tsx
@@ -1,19 +1,20 @@
-import { getConfig } from 'common/api';
-import { BASE_URL, NODE_ID } from 'common/constants';
-import { locale, rawParams, theme } from 'common/settings';
-import { StaticStore } from 'common/static-store';
-import { isThemeStyles, setThemeStyles } from 'common/theme';
-import { Profile } from 'components/profile';
-import { ConnectedRoot } from 'components/root';
-import { render } from 'preact';
-import { IntlProvider } from 'react-intl';
-import { Provider } from 'react-redux';
+import { h, render } from 'preact';
 import { bindActionCreators } from 'redux';
-import { store } from 'store';
-import { restoreCollapsedThreads } from 'store/thread/actions';
-import { fetchHiddenUsers } from 'store/user/actions';
+import { Provider } from 'react-redux';
+import { IntlProvider } from 'react-intl';
+
 import { loadLocale } from 'utils/loadLocale';
 import { parseMessage } from 'utils/post-message';
+import { ConnectedRoot } from 'components/root';
+import { Profile } from 'components/profile';
+import { store } from 'store';
+import { NODE_ID, BASE_URL } from 'common/constants';
+import { StaticStore } from 'common/static-store';
+import { getConfig } from 'common/api';
+import { fetchHiddenUsers } from 'store/user/actions';
+import { restoreCollapsedThreads } from 'store/thread/actions';
+import { locale, theme, rawParams } from 'common/settings';
+import { isThemeStyles, setThemeStyles } from 'common/theme';
 
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', init);

--- a/frontend/apps/remark42/app/remark.tsx
+++ b/frontend/apps/remark42/app/remark.tsx
@@ -13,8 +13,8 @@ import { StaticStore } from 'common/static-store';
 import { getConfig } from 'common/api';
 import { fetchHiddenUsers } from 'store/user/actions';
 import { restoreCollapsedThreads } from 'store/thread/actions';
-import { locale, theme, rawParams } from 'common/settings';
-import { isThemeStyles, setThemeStyles } from 'common/theme';
+import { locale, theme, rawParams, styling } from 'common/settings';
+import { isThemeStyling, setThemeStyling } from 'common/theme';
 
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', init);
@@ -38,18 +38,19 @@ async function init(): Promise<void> {
 
   window.addEventListener('message', (evt) => {
     const data = parseMessage(evt);
-
     if (data.theme) {
       setTheme(data.theme);
     }
-
-    if (isThemeStyles(data.styles)) {
-      setThemeStyles(data.styles);
+    if (isThemeStyling(data.styling)) {
+      setThemeStyling(data.styling);
     }
   });
 
   if (theme) {
     setTheme(theme);
+  }
+  if (styling) {
+    setThemeStyling(styling);
   }
 
   boundActions.fetchHiddenUsers();

--- a/frontend/apps/remark42/app/remark.tsx
+++ b/frontend/apps/remark42/app/remark.tsx
@@ -1,19 +1,19 @@
-import { h, render } from 'preact';
-import { bindActionCreators } from 'redux';
-import { Provider } from 'react-redux';
+import { getConfig } from 'common/api';
+import { BASE_URL, NODE_ID } from 'common/constants';
+import { locale, rawParams, theme } from 'common/settings';
+import { StaticStore } from 'common/static-store';
+import { isThemeStyles, setThemeStyles } from 'common/theme';
+import { Profile } from 'components/profile';
+import { ConnectedRoot } from 'components/root';
+import { render } from 'preact';
 import { IntlProvider } from 'react-intl';
-
+import { Provider } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { store } from 'store';
+import { restoreCollapsedThreads } from 'store/thread/actions';
+import { fetchHiddenUsers } from 'store/user/actions';
 import { loadLocale } from 'utils/loadLocale';
 import { parseMessage } from 'utils/post-message';
-import { ConnectedRoot } from 'components/root';
-import { Profile } from 'components/profile';
-import { store } from 'store';
-import { NODE_ID, BASE_URL } from 'common/constants';
-import { StaticStore } from 'common/static-store';
-import { getConfig } from 'common/api';
-import { fetchHiddenUsers } from 'store/user/actions';
-import { restoreCollapsedThreads } from 'store/thread/actions';
-import { locale, theme, rawParams } from 'common/settings';
 
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', init);
@@ -38,17 +38,17 @@ async function init(): Promise<void> {
   window.addEventListener('message', (evt) => {
     const data = parseMessage(evt);
 
-    if (data.theme === 'light') {
-      document.body.classList.remove('dark');
+    if (data.theme) {
+      setTheme(data.theme);
     }
 
-    if (data.theme === 'dark') {
-      document.body.classList.add('dark');
+    if (isThemeStyles(data.styles)) {
+      setThemeStyles(data.styles);
     }
   });
 
-  if (theme === 'dark') {
-    document.body.classList.add('dark');
+  if (theme) {
+    setTheme(theme);
   }
 
   boundActions.fetchHiddenUsers();
@@ -67,3 +67,13 @@ async function init(): Promise<void> {
     node
   );
 }
+
+const setTheme = (theme: string) => {
+  if (theme === 'light') {
+    document.body.classList.remove('dark');
+  }
+
+  if (theme === 'dark') {
+    document.body.classList.add('dark');
+  }
+};

--- a/frontend/apps/remark42/app/remark.tsx
+++ b/frontend/apps/remark42/app/remark.tsx
@@ -15,6 +15,7 @@ import { fetchHiddenUsers } from 'store/user/actions';
 import { restoreCollapsedThreads } from 'store/thread/actions';
 import { locale, theme, rawParams, styling } from 'common/settings';
 import { isThemeStyling, setThemeStyling } from 'common/theme';
+import { Theme } from 'common/types';
 
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', init);
@@ -43,6 +44,7 @@ async function init(): Promise<void> {
     }
     if (isThemeStyling(data.styling)) {
       setThemeStyling(data.styling);
+      store.dispatch({ type: 'STYLING/SET', styling: data.styling });
     }
   });
 
@@ -51,6 +53,7 @@ async function init(): Promise<void> {
   }
   if (styling) {
     setThemeStyling(styling);
+    store.dispatch({ type: 'STYLING/SET', styling });
   }
 
   boundActions.fetchHiddenUsers();
@@ -70,11 +73,10 @@ async function init(): Promise<void> {
   );
 }
 
-const setTheme = (theme: string) => {
+const setTheme = (theme: Theme) => {
   if (theme === 'light') {
     document.body.classList.remove('dark');
   }
-
   if (theme === 'dark') {
     document.body.classList.add('dark');
   }

--- a/frontend/apps/remark42/app/store/actions.ts
+++ b/frontend/apps/remark42/app/store/actions.ts
@@ -1,8 +1,15 @@
 import { COMMENTS_ACTIONS } from './comments/types';
 import { POST_INFO_ACTIONS } from './post-info/types';
+import { STYLING_ACTIONS } from './styling/types';
 import { THEME_ACTIONS } from './theme/types';
 import { THREAD_ACTIONS } from './thread/types';
 import { USER_ACTIONS } from './user/types';
 
 /** Merged store actions */
-export type ACTIONS = COMMENTS_ACTIONS | POST_INFO_ACTIONS | THEME_ACTIONS | THREAD_ACTIONS | USER_ACTIONS;
+export type ACTIONS =
+  | COMMENTS_ACTIONS
+  | POST_INFO_ACTIONS
+  | THEME_ACTIONS
+  | THREAD_ACTIONS
+  | USER_ACTIONS
+  | STYLING_ACTIONS;

--- a/frontend/apps/remark42/app/store/reducers.ts
+++ b/frontend/apps/remark42/app/store/reducers.ts
@@ -3,11 +3,13 @@ import * as postInfo from './post-info/reducers';
 import * as theme from './theme/reducers';
 import * as user from './user/reducers';
 import * as thread from './thread/reducers';
+import * as styling from './styling/reducers';
 
 /** Merged store reducers */
 export const rootProvider = {
   ...comments,
   ...theme,
+  ...styling,
   ...postInfo,
   ...thread,
   ...user,

--- a/frontend/apps/remark42/app/store/styling/actions.ts
+++ b/frontend/apps/remark42/app/store/styling/actions.ts
@@ -1,0 +1,12 @@
+import { ThemeStyling } from 'common/theme';
+
+import { StoreAction } from '../';
+import { STYLING_SET } from './types';
+
+export const setStyling =
+  (styling: ThemeStyling | undefined): StoreAction =>
+  (dispatch) =>
+    dispatch({
+      type: STYLING_SET,
+      styling,
+    });

--- a/frontend/apps/remark42/app/store/styling/reducers.ts
+++ b/frontend/apps/remark42/app/store/styling/reducers.ts
@@ -1,0 +1,17 @@
+import * as settings from 'common/settings';
+import { ThemeStyling } from 'common/theme';
+
+import { STYLING_SET, STYLING_SET_ACTION } from './types';
+
+export function styling(
+  state: ThemeStyling | undefined = settings.styling,
+  action: STYLING_SET_ACTION
+): ThemeStyling | undefined {
+  switch (action.type) {
+    case STYLING_SET: {
+      return action.styling;
+    }
+    default:
+      return state;
+  }
+}

--- a/frontend/apps/remark42/app/store/styling/reducers.ts
+++ b/frontend/apps/remark42/app/store/styling/reducers.ts
@@ -3,13 +3,10 @@ import { ThemeStyling } from 'common/theme';
 
 import { STYLING_SET, STYLING_SET_ACTION } from './types';
 
-export function styling(
-  state: ThemeStyling | undefined = settings.styling,
-  action: STYLING_SET_ACTION
-): ThemeStyling | undefined {
+export function styling(state: ThemeStyling = settings.styling || {}, action: STYLING_SET_ACTION): ThemeStyling {
   switch (action.type) {
     case STYLING_SET: {
-      return action.styling;
+      return action.styling || {};
     }
     default:
       return state;

--- a/frontend/apps/remark42/app/store/styling/types.ts
+++ b/frontend/apps/remark42/app/store/styling/types.ts
@@ -1,0 +1,10 @@
+import { ThemeStyling } from 'common/theme';
+
+export const STYLING_SET = 'STYLING/SET';
+
+export interface STYLING_SET_ACTION {
+  type: typeof STYLING_SET;
+  styling: ThemeStyling | undefined;
+}
+
+export type STYLING_ACTIONS = STYLING_SET_ACTION;

--- a/frontend/apps/remark42/app/styles/custom-properties.css
+++ b/frontend/apps/remark42/app/styles/custom-properties.css
@@ -76,7 +76,7 @@
   --transparent: transparent;
 }
 
-:root .dark {
+:root body.dark {
   --line-color: var(--color36);
   --primary-color: 0, 153, 153;
   --primary-brighter-color: 0, 170, 170;

--- a/frontend/apps/remark42/app/typings/global.d.ts
+++ b/frontend/apps/remark42/app/typings/global.d.ts
@@ -1,5 +1,6 @@
 import 'jest-fetch-mock';
 import type { Theme } from 'common/types';
+import { ThemeStyling } from 'common/theme';
 
 type RemarkConfig = {
   // Hostname of Remark42 server, same as REMARK_URL in backend config, e.g. "https://demo.remark42.com".
@@ -20,8 +21,8 @@ type RemarkConfig = {
   max_last_comments?: number;
   // Optional, 'dark' or 'light', 'light' by default. Changes UI theme.
   theme?: Theme;
-  // Optional, changes theme styles.
-  styles?: ThemeStyle;
+  // Optional, changes theme styling.
+  styling?: ThemeStyling;
   // Optional, 'document.title' by default. Title for current comments page.
   page_title?: string;
   // Optional, 'en' by default. Interface localization.
@@ -47,7 +48,7 @@ declare global {
     remark_config: RemarkConfig;
     REMARK42: {
       changeTheme?: (theme: Theme) => void;
-      changeStyles?: (styles: ThemeStyle) => void;
+      changeStyling?: (styles: ThemeStyling) => void;
       destroy?: () => void;
       createInstance: (remark_config: RemarkConfig) =>
         | {

--- a/frontend/apps/remark42/app/typings/global.d.ts
+++ b/frontend/apps/remark42/app/typings/global.d.ts
@@ -20,6 +20,8 @@ type RemarkConfig = {
   max_last_comments?: number;
   // Optional, 'dark' or 'light', 'light' by default. Changes UI theme.
   theme?: Theme;
+  // Optional, changes theme styles.
+  styles?: ThemeStyle;
   // Optional, 'document.title' by default. Title for current comments page.
   page_title?: string;
   // Optional, 'en' by default. Interface localization.
@@ -45,6 +47,7 @@ declare global {
     remark_config: RemarkConfig;
     REMARK42: {
       changeTheme?: (theme: Theme) => void;
+      changeStyles?: (styles: ThemeStyle) => void;
       destroy?: () => void;
       createInstance: (remark_config: RemarkConfig) =>
         | {

--- a/frontend/apps/remark42/app/utils/colors.spec.ts
+++ b/frontend/apps/remark42/app/utils/colors.spec.ts
@@ -1,0 +1,127 @@
+import { Color, colorToHex, darkenColor, lightenColor, parseColorStr } from './colors';
+
+describe('parseColorStr function', () => {
+  it('should parse a 3-digit hex color code', () => {
+    const colorCode = '#abc';
+    const expectedColor: Color = { r: 170, g: 187, b: 204, a: 1 };
+    const parsedColor = parseColorStr(colorCode);
+    expect(parsedColor).toEqual(expectedColor);
+  });
+
+  it('should parse a 6-digit hex color code', () => {
+    const colorCode = '#abcdef';
+    const expectedColor: Color = { r: 171, g: 205, b: 239, a: 1 };
+    const parsedColor = parseColorStr(colorCode);
+    expect(parsedColor).toEqual(expectedColor);
+  });
+
+  it('should parse an RGB color code', () => {
+    const colorCode = 'rgb(255, 0, 128)';
+    const expectedColor: Color = { r: 255, g: 0, b: 128, a: 1 };
+    const parsedColor = parseColorStr(colorCode);
+    expect(parsedColor).toEqual(expectedColor);
+  });
+
+  it('should parse an RGBA color code', () => {
+    const colorCode = 'rgba(100, 200, 150, 0.5)';
+    const expectedColor: Color = { r: 100, g: 200, b: 150, a: 0.5 };
+    const parsedColor = parseColorStr(colorCode);
+    expect(parsedColor).toEqual(expectedColor);
+  });
+
+  it('should return default color for an invalid color code', () => {
+    const colorCode = 'invalid color';
+    expect(parseColorStr(colorCode)).toEqual(undefined);
+  });
+});
+
+describe('lightenColor', () => {
+  test('should lighten a color by the given amount', () => {
+    const color = { r: 100, g: 150, b: 200, a: 1 }; // rgb(100, 150, 200)
+    const amount = 0.5;
+    const lightenedColor = lightenColor(color, amount); // rgb(178, 203, 228)
+    expect(lightenedColor.r).toBe(178);
+    expect(lightenedColor.g).toBe(203);
+    expect(lightenedColor.b).toBe(228);
+    expect(lightenedColor.a).toBe(1);
+  });
+
+  test('should not change a color if amount is 0', () => {
+    const color = { r: 100, g: 150, b: 200, a: 1 };
+    const amount = 0;
+    const lightenedColor = lightenColor(color, amount);
+    expect(lightenedColor).toEqual(color);
+  });
+
+  test('should not exceed a color value of 255', () => {
+    const color = { r: 200, g: 240, b: 255, a: 1 }; // rgb(200, 240, 255)
+    const amount = 0.5;
+    expect(lightenColor(color, amount)).toEqual({ r: 228, g: 248, b: 255, a: 1 }); // rgb(228, 248, 255)
+  });
+
+  test('should return a new color object', () => {
+    const color = { r: 100, g: 150, b: 200, a: 1 };
+    const amount = 0.5;
+    const lightenedColor = lightenColor(color, amount);
+    expect(lightenedColor).not.toBe(color);
+  });
+});
+
+describe('darkenColor', () => {
+  test('should darken a color by the given amount', () => {
+    const color = { r: 100, g: 150, b: 200, a: 1 };
+    const amount = 0.5;
+    const darkenedColor = darkenColor(color, amount);
+    expect(darkenedColor.r).toBe(50);
+    expect(darkenedColor.g).toBe(75);
+    expect(darkenedColor.b).toBe(100);
+    expect(darkenedColor.a).toBe(1);
+  });
+
+  test('should not change a color if amount is 0', () => {
+    const color = { r: 100, g: 150, b: 200, a: 1 };
+    const amount = 0;
+    const darkenedColor = darkenColor(color, amount);
+    expect(darkenedColor).toEqual(color);
+  });
+
+  test('should not exceed a color value of 255', () => {
+    const color = { r: 200, g: 240, b: 255, a: 1 }; // rgb(200, 240, 255)
+    const amount = 0.5;
+    const darkenedColor = darkenColor(color, amount); // rgb(100, 120, 128)
+    expect(darkenedColor.r).toBe(100);
+    expect(darkenedColor.g).toBe(120);
+    expect(darkenedColor.b).toBe(128);
+    expect(darkenedColor.a).toBe(1);
+  });
+
+  test('should return a new color object', () => {
+    const color = { r: 100, g: 150, b: 200, a: 1 };
+    const amount = 0.5;
+    const darkenedColor = darkenColor(color, amount);
+    expect(darkenedColor).not.toBe(color);
+  });
+});
+
+describe('colorToHex function', () => {
+  it('should convert a color object to a 6-digit hex color code', () => {
+    const color: Color = { r: 255, g: 128, b: 0, a: 1 };
+    const expectedHexCode = '#ff8000';
+    const hexCode = colorToHex(color);
+    expect(hexCode).toBe(expectedHexCode);
+  });
+
+  it('should convert a color object to a 3-digit hex color code', () => {
+    const color: Color = { r: 34, g: 68, b: 102, a: 1 };
+    const expectedHexCode = '#224466';
+    const hexCode = colorToHex(color);
+    expect(hexCode).toBe(expectedHexCode);
+  });
+
+  it('should convert a color object with alpha to an 8-digit hex color code', () => {
+    const color: Color = { r: 0, g: 128, b: 255, a: 0.5 };
+    const expectedHexCode = '#0080ff80';
+    const hexCode = colorToHex(color);
+    expect(hexCode).toBe(expectedHexCode);
+  });
+});

--- a/frontend/apps/remark42/app/utils/colors.spec.ts
+++ b/frontend/apps/remark42/app/utils/colors.spec.ts
@@ -1,4 +1,4 @@
-import { Color, colorToHex, darkenColor, lightenColor, parseColorStr } from './colors';
+import { Color, colorToHexStr, darkenColor, lightenColor, parseColorStr } from './colors';
 
 describe('parseColorStr function', () => {
   it('should parse a 3-digit hex color code', () => {
@@ -103,25 +103,25 @@ describe('darkenColor', () => {
   });
 });
 
-describe('colorToHex function', () => {
+describe('colorToHexStr function', () => {
   it('should convert a color object to a 6-digit hex color code', () => {
     const color: Color = { r: 255, g: 128, b: 0, a: 1 };
     const expectedHexCode = '#ff8000';
-    const hexCode = colorToHex(color);
+    const hexCode = colorToHexStr(color);
     expect(hexCode).toBe(expectedHexCode);
   });
 
   it('should convert a color object to a 3-digit hex color code', () => {
     const color: Color = { r: 34, g: 68, b: 102, a: 1 };
     const expectedHexCode = '#224466';
-    const hexCode = colorToHex(color);
+    const hexCode = colorToHexStr(color);
     expect(hexCode).toBe(expectedHexCode);
   });
 
   it('should convert a color object with alpha to an 8-digit hex color code', () => {
     const color: Color = { r: 0, g: 128, b: 255, a: 0.5 };
     const expectedHexCode = '#0080ff80';
-    const hexCode = colorToHex(color);
+    const hexCode = colorToHexStr(color);
     expect(hexCode).toBe(expectedHexCode);
   });
 });

--- a/frontend/apps/remark42/app/utils/colors.spec.ts
+++ b/frontend/apps/remark42/app/utils/colors.spec.ts
@@ -2,31 +2,19 @@ import { Color, colorToHexStr, darkenColor, lightenColor, parseColorStr } from '
 
 describe('parseColorStr function', () => {
   it('should parse a 3-digit hex color code', () => {
-    const colorCode = '#abc';
-    const expectedColor: Color = { r: 170, g: 187, b: 204, a: 1 };
-    const parsedColor = parseColorStr(colorCode);
-    expect(parsedColor).toEqual(expectedColor);
+    expect(parseColorStr('#abc')).toEqual({ r: 170, g: 187, b: 204, a: 1 });
   });
 
   it('should parse a 6-digit hex color code', () => {
-    const colorCode = '#abcdef';
-    const expectedColor: Color = { r: 171, g: 205, b: 239, a: 1 };
-    const parsedColor = parseColorStr(colorCode);
-    expect(parsedColor).toEqual(expectedColor);
+    expect(parseColorStr('#abcdef')).toEqual({ r: 171, g: 205, b: 239, a: 1 });
   });
 
   it('should parse an RGB color code', () => {
-    const colorCode = 'rgb(255, 0, 128)';
-    const expectedColor: Color = { r: 255, g: 0, b: 128, a: 1 };
-    const parsedColor = parseColorStr(colorCode);
-    expect(parsedColor).toEqual(expectedColor);
+    expect(parseColorStr('rgb(255, 0, 128)')).toEqual({ r: 255, g: 0, b: 128, a: 1 });
   });
 
   it('should parse an RGBA color code', () => {
-    const colorCode = 'rgba(100, 200, 150, 0.5)';
-    const expectedColor: Color = { r: 100, g: 200, b: 150, a: 0.5 };
-    const parsedColor = parseColorStr(colorCode);
-    expect(parsedColor).toEqual(expectedColor);
+    expect(parseColorStr('rgba(100, 200, 150, 0.5)')).toEqual({ r: 100, g: 200, b: 150, a: 0.5 });
   });
 
   it('should return default color for an invalid color code', () => {

--- a/frontend/apps/remark42/app/utils/colors.spec.ts
+++ b/frontend/apps/remark42/app/utils/colors.spec.ts
@@ -1,6 +1,57 @@
-import { Color, colorToHexStr, darkenColor, lightenColor, parseColorStr } from './colors';
+import {
+  Color,
+  color,
+  colorToHexStr,
+  colorToRgbBodyStr,
+  colorToRgbStr,
+  darkenColor,
+  lightenColor,
+  parseColorStr,
+} from './colors';
 
-describe('parseColorStr function', () => {
+describe('color function', () => {
+  it('should return object with properties', () => {
+    const val = color({ r: 100, g: 150, b: 200, a: 1 });
+    expect(val).toHaveProperty('alpha');
+    expect(val).toHaveProperty('lighten');
+    expect(val).toHaveProperty('darken');
+    expect(val).toHaveProperty('hex');
+    expect(val).toHaveProperty('rgb');
+    expect(val).toHaveProperty('rgbBody');
+    expect(val).toHaveProperty('object');
+  });
+
+  it('should throw an error if the color object is invalid', () => {
+    expect(() => color({ r: 100, g: 150, b: 200, a: 1 })).not.toThrow();
+    expect(() => color('invalid value')).toThrow();
+  });
+
+  it('should lighten a color', () => {
+    expect(color('#000').lighten(0.5).hex()).toEqual('#808080');
+  });
+
+  it('should darken a color', () => {
+    expect(color('#fff').darken(0.5).hex()).toEqual('#808080');
+  });
+
+  it('should set the alpha value of a color', () => {
+    expect(color('#000').alpha(0.5).object()).toEqual({ r: 0, g: 0, b: 0, a: 0.5 });
+  });
+
+  it('should convert a color to a hex string', () => {
+    expect(color({ r: 100, g: 150, b: 200, a: 1 }).hex()).toEqual('#6496c8');
+  });
+
+  it('should convert a color to an RGB string', () => {
+    expect(color({ r: 100, g: 150, b: 200, a: 1 }).rgb()).toEqual('rgb(100,150,200)');
+  });
+
+  it('should convert a color to an RGB body string', () => {
+    expect(color({ r: 100, g: 150, b: 200, a: 1 }).rgbBody()).toEqual('100,150,200');
+  });
+});
+
+describe('parseColorStr', () => {
   it('should parse a 3-digit hex color code', () => {
     expect(parseColorStr('#abc')).toEqual({ r: 170, g: 187, b: 204, a: 1 });
   });
@@ -25,9 +76,9 @@ describe('parseColorStr function', () => {
 
 describe('lightenColor', () => {
   test('should lighten a color by the given amount', () => {
-    const color = { r: 100, g: 150, b: 200, a: 1 }; // rgb(100, 150, 200)
+    const val = { r: 100, g: 150, b: 200, a: 1 }; // rgb(100, 150, 200)
     const amount = 0.5;
-    const lightenedColor = lightenColor(color, amount); // rgb(178, 203, 228)
+    const lightenedColor = lightenColor(val, amount); // rgb(178, 203, 228)
     expect(lightenedColor.r).toBe(178);
     expect(lightenedColor.g).toBe(203);
     expect(lightenedColor.b).toBe(228);
@@ -35,31 +86,31 @@ describe('lightenColor', () => {
   });
 
   test('should not change a color if amount is 0', () => {
-    const color = { r: 100, g: 150, b: 200, a: 1 };
+    const val = { r: 100, g: 150, b: 200, a: 1 };
     const amount = 0;
-    const lightenedColor = lightenColor(color, amount);
-    expect(lightenedColor).toEqual(color);
+    const lightenedColor = lightenColor(val, amount);
+    expect(lightenedColor).toEqual(val);
   });
 
   test('should not exceed a color value of 255', () => {
-    const color = { r: 200, g: 240, b: 255, a: 1 }; // rgb(200, 240, 255)
+    const val = { r: 200, g: 240, b: 255, a: 1 }; // rgb(200, 240, 255)
     const amount = 0.5;
-    expect(lightenColor(color, amount)).toEqual({ r: 228, g: 248, b: 255, a: 1 }); // rgb(228, 248, 255)
+    expect(lightenColor(val, amount)).toEqual({ r: 228, g: 248, b: 255, a: 1 }); // rgb(228, 248, 255)
   });
 
   test('should return a new color object', () => {
-    const color = { r: 100, g: 150, b: 200, a: 1 };
+    const val = { r: 100, g: 150, b: 200, a: 1 };
     const amount = 0.5;
-    const lightenedColor = lightenColor(color, amount);
-    expect(lightenedColor).not.toBe(color);
+    const lightenedColor = lightenColor(val, amount);
+    expect(lightenedColor).not.toBe(val);
   });
 });
 
 describe('darkenColor', () => {
   test('should darken a color by the given amount', () => {
-    const color = { r: 100, g: 150, b: 200, a: 1 };
+    const val = { r: 100, g: 150, b: 200, a: 1 };
     const amount = 0.5;
-    const darkenedColor = darkenColor(color, amount);
+    const darkenedColor = darkenColor(val, amount);
     expect(darkenedColor.r).toBe(50);
     expect(darkenedColor.g).toBe(75);
     expect(darkenedColor.b).toBe(100);
@@ -67,49 +118,78 @@ describe('darkenColor', () => {
   });
 
   test('should not change a color if amount is 0', () => {
-    const color = { r: 100, g: 150, b: 200, a: 1 };
+    const val = { r: 100, g: 150, b: 200, a: 1 };
     const amount = 0;
-    const darkenedColor = darkenColor(color, amount);
-    expect(darkenedColor).toEqual(color);
+    const darkenedColor = darkenColor(val, amount);
+    expect(darkenedColor).toEqual(val);
   });
 
-  test('should not exceed a color value of 255', () => {
-    const color = { r: 200, g: 240, b: 255, a: 1 }; // rgb(200, 240, 255)
+  test('should not exceed a color value of 0', () => {
+    const val = { r: 0, g: 20, b: 30, a: 1 };
     const amount = 0.5;
-    const darkenedColor = darkenColor(color, amount); // rgb(100, 120, 128)
-    expect(darkenedColor.r).toBe(100);
-    expect(darkenedColor.g).toBe(120);
-    expect(darkenedColor.b).toBe(128);
-    expect(darkenedColor.a).toBe(1);
+    expect(darkenColor(val, amount)).toEqual({ r: 0, g: 10, b: 15, a: 1 });
   });
 
   test('should return a new color object', () => {
-    const color = { r: 100, g: 150, b: 200, a: 1 };
+    const val = { r: 100, g: 150, b: 200, a: 1 };
     const amount = 0.5;
-    const darkenedColor = darkenColor(color, amount);
-    expect(darkenedColor).not.toBe(color);
+    const darkenedColor = darkenColor(val, amount);
+    expect(darkenedColor).not.toBe(val);
   });
 });
 
-describe('colorToHexStr function', () => {
+describe('colorToHexStr', () => {
   it('should convert a color object to a 6-digit hex color code', () => {
-    const color: Color = { r: 255, g: 128, b: 0, a: 1 };
+    const val: Color = { r: 255, g: 128, b: 0, a: 1 };
     const expectedHexCode = '#ff8000';
-    const hexCode = colorToHexStr(color);
+    const hexCode = colorToHexStr(val);
     expect(hexCode).toBe(expectedHexCode);
   });
 
   it('should convert a color object to a 3-digit hex color code', () => {
-    const color: Color = { r: 34, g: 68, b: 102, a: 1 };
+    const val: Color = { r: 34, g: 68, b: 102, a: 1 };
     const expectedHexCode = '#224466';
-    const hexCode = colorToHexStr(color);
+    const hexCode = colorToHexStr(val);
     expect(hexCode).toBe(expectedHexCode);
   });
 
   it('should convert a color object with alpha to an 8-digit hex color code', () => {
-    const color: Color = { r: 0, g: 128, b: 255, a: 0.5 };
+    const val: Color = { r: 0, g: 128, b: 255, a: 0.5 };
     const expectedHexCode = '#0080ff80';
-    const hexCode = colorToHexStr(color);
+    const hexCode = colorToHexStr(val);
     expect(hexCode).toBe(expectedHexCode);
+  });
+});
+
+describe('colorToRgbStr', () => {
+  it('should convert color object to RGB string', () => {
+    const result = colorToRgbStr({ r: 255, g: 255, b: 255, a: 1 });
+    expect(result).toBe('rgb(255,255,255)');
+  });
+
+  it('should convert color object with alpha to RGBA string', () => {
+    const colorWithAlpha: Color = { r: 255, g: 255, b: 255, a: 0.5 };
+    const result = colorToRgbStr(colorWithAlpha);
+    expect(result).toBe('rgba(255,255,255,0.5)');
+  });
+
+  it('should convert color object with alpha equal to 1 to RGB string', () => {
+    const colorWithAlpha: Color = { r: 255, g: 255, b: 255, a: 1 };
+    const result = colorToRgbStr(colorWithAlpha);
+    expect(result).toBe('rgb(255,255,255)');
+  });
+});
+
+describe('colorToRgbBodyStr', () => {
+  it('should return a string in RGB(A) format', () => {
+    const val: Color = { r: 255, g: 255, b: 255, a: 1 };
+    const result = colorToRgbBodyStr(val);
+    expect(result).toEqual('255,255,255');
+  });
+
+  it('should include alpha channel when it is not 1', () => {
+    const val: Color = { r: 255, g: 255, b: 255, a: 0.5 };
+    const result = colorToRgbBodyStr(val);
+    expect(result).toEqual('255,255,255,0.5');
   });
 });

--- a/frontend/apps/remark42/app/utils/colors.ts
+++ b/frontend/apps/remark42/app/utils/colors.ts
@@ -94,11 +94,25 @@ export const darkenColor = (color: Color, amount: number): Color => {
  * @param {Color} color - The color object to convert to a hexadecimal color code.
  * @returns {string} A hexadecimal color code representation of the input color.
  */
-export const colorToHex = (color: Color): string => {
+export const colorToHexStr = (color: Color): string => {
   const { r, g, b, a } = color;
-  let str = `#${pad(r.toString(16), 2, '0')}${pad(g.toString(16), 2, '0')}${pad(b.toString(16), 2, '0')}`;
+  let str: string = `#${pad(r.toString(16), 2, '0')}${pad(g.toString(16), 2, '0')}${pad(b.toString(16), 2, '0')}`;
   if (a !== 1) {
     str += `${pad(Math.round(a * 255).toString(16), 2, '0')}`;
+  }
+  return str;
+};
+
+export const colorToRgbStr = (color: Color): string => {
+  const { r, g, b, a } = color;
+  return `rgb${a !== 1 ? 'a' : ''}(${r},${g},${b}${a !== 1 ? `,${a}` : ''})`;
+};
+
+export const colorToNumStr = (color: Color): string => {
+  const { r, g, b, a } = color;
+  let str = `${r},${g},${b}`;
+  if (a !== 1) {
+    str += `,${a}`;
   }
   return str;
 };

--- a/frontend/apps/remark42/app/utils/colors.ts
+++ b/frontend/apps/remark42/app/utils/colors.ts
@@ -1,0 +1,111 @@
+/**
+ * Represents a color object with red, green, blue, and alpha values.
+ *
+ * @typedef {Object} Color
+ * @property {number} r - The red component of the color (0-255).
+ * @property {number} g - The green component of the color (0-255).
+ * @property {number} b - The blue component of the color (0-255).
+ * @property {number} a - The alpha component of the color (0-1).
+ */
+export interface Color {
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+}
+
+/**
+ * Parses a color string in the format of a 3-digit or 6-digit hexadecimal color code
+ * or an RGB(A) color code and returns an object representing the color's RGB values.
+ * @param {string} color - The color string to parse.
+ * @returns {Color|undefined} An object representing the color's RGB values, or `undefined` if the color string is invalid.
+ */
+export const parseColorStr = (color: string): Color | undefined => {
+  if (color.charAt(0) === '#') {
+    if (color.length === 4) {
+      const r = parseInt(color.charAt(1) + color.charAt(1), 16);
+      const g = parseInt(color.charAt(2) + color.charAt(2), 16);
+      const b = parseInt(color.charAt(3) + color.charAt(3), 16);
+      return { r, g, b, a: 1 };
+    } else if (color.length === 7) {
+      const r = parseInt(color.substr(1, 2), 16);
+      const g = parseInt(color.substr(3, 2), 16);
+      const b = parseInt(color.substr(5, 2), 16);
+      return { r, g, b, a: 1 };
+    }
+  } else if (color.startsWith('rgb(') && color.endsWith(')')) {
+    const rgbValues = color.substring(4, color.length - 1).split(',');
+    if (rgbValues.length === 3) {
+      const r = parseInt(rgbValues[0], 10);
+      const g = parseInt(rgbValues[1], 10);
+      const b = parseInt(rgbValues[2], 10);
+      return { r, g, b, a: 1 };
+    }
+  } else if (color.startsWith('rgba(') && color.endsWith(')')) {
+    const rgbaValues = color.substring(5, color.length - 1).split(',');
+    if (rgbaValues.length === 4) {
+      const r = parseInt(rgbaValues[0], 10);
+      const g = parseInt(rgbaValues[1], 10);
+      const b = parseInt(rgbaValues[2], 10);
+      const a = parseFloat(rgbaValues[3]);
+      return { r, g, b, a };
+    }
+  }
+  return undefined;
+};
+
+/**
+ * Lightens a given color by a specified amount.
+ *
+ * @param {Color} color - The color to be lightened.
+ * @param {number} amount - The amount by which the color should be lightened.
+ * @returns {Color} A new color object representing the lightened color.
+ */
+export const lightenColor = (color: Color, amount: number): Color => {
+  const { r, g, b, a } = color;
+  const amt = Math.abs(amount);
+  const red = Math.round(Math.min(r + (255 - r) * amt, 255));
+  const green = Math.round(Math.min(g + (255 - g) * amt, 255));
+  const blue = Math.round(Math.min(b + (255 - b) * amt, 255));
+  return { r: red, g: green, b: blue, a };
+};
+
+/**
+ * Darkens a given color by a specified amount.
+ *
+ * @param {Color} color - The color to be darkened.
+ * @param {number} amount - The amount by which the color should be darkened.
+ *   A value of 0 will not change the color, while positive values will darken the color
+ *   and negative values will lighten the color.
+ * @returns {Color} A new color object representing the darkened color.
+ */
+export const darkenColor = (color: Color, amount: number): Color => {
+  const { r, g, b, a } = color;
+  const amt = Math.abs(amount);
+  const red = Math.round(Math.max(r - r * amt, 0));
+  const green = Math.round(Math.max(g - g * amt, 0));
+  const blue = Math.round(Math.max(b - b * amt, 0));
+  return { r: red, g: green, b: blue, a };
+};
+
+/**
+ * Converts a given color object to a hexadecimal color code.
+ *
+ * @param {Color} color - The color object to convert to a hexadecimal color code.
+ * @returns {string} A hexadecimal color code representation of the input color.
+ */
+export const colorToHex = (color: Color): string => {
+  const { r, g, b, a } = color;
+  let str = `#${pad(r.toString(16), 2, '0')}${pad(g.toString(16), 2, '0')}${pad(b.toString(16), 2, '0')}`;
+  if (a !== 1) {
+    str += `${pad(Math.round(a * 255).toString(16), 2, '0')}`;
+  }
+  return str;
+};
+
+const pad = (str: string, len: number, char: string): string => {
+  while (str.length < len) {
+    str = char + str;
+  }
+  return str;
+};

--- a/frontend/apps/remark42/app/utils/colors.ts
+++ b/frontend/apps/remark42/app/utils/colors.ts
@@ -1,5 +1,5 @@
 /**
- * Represents a color object with red, green, blue, and alpha values.
+ * Represents a color with RGBA components.
  *
  * @typedef {Object} Color
  * @property {number} r - The red component of the color (0-255).
@@ -15,12 +15,44 @@ export interface Color {
 }
 
 /**
+ * Creates a color object that provides utility methods for manipulating and converting color values.
+ *
+ * @function
+ * @param {string | Color} inputValue - A string representing a CSS color value, or an object representing a color with RGBA components.
+ * @returns {object} - An object containing utility methods for manipulating and converting color values.
+ * @throws {Error} - If the provided color value is invalid.
+ *
+ * @example
+ * const myColor = color('#ff0000');
+ * const lighterColor = myColor.lighten(0.2).hex(); // returns a hex string representation of the original color, lightened by 20%
+ * const rgbaValue = myColor.rgb(); // returns an RGBA string representation of the original color
+ * const alphaValue = myColor.alpha(0.5).object(); // returns an object representing the original color with its alpha value set to 0.5
+ */
+export const color = (inputValue: string | Color) => {
+  const parts = typeof inputValue === 'string' ? parseColorStr(inputValue) : inputValue;
+  if (!parts) {
+    throw new Error(`Invalid color value: ${inputValue}`);
+  }
+
+  const lighten = (amount: number) => color(lightenColor(parts, amount));
+  const darken = (amount: number) => color(darkenColor(parts, amount));
+  const alpha = (amount: number) => color({ ...parts, a: amount });
+  const hex = () => colorToHexStr(parts);
+  const rgb = () => colorToRgbStr(parts);
+  const rgbBody = () => colorToRgbBodyStr(parts);
+  const object = () => ({ ...parts });
+
+  return { alpha, lighten, darken, hex, rgb, rgbBody, object };
+};
+
+/**
  * Parses a color string in the format of a 3-digit or 6-digit hexadecimal color code
  * or an RGB(A) color code and returns an object representing the color's RGB values.
  * @param {string} color - The color string to parse.
  * @returns {Color|undefined} An object representing the color's RGB values, or `undefined` if the color string is invalid.
  */
-export const parseColorStr = (color: string): Color | undefined => {
+export const parseColorStr = (rawColor: string): Color | undefined => {
+  const color = rawColor.toLowerCase().trim();
   if (color.charAt(0) === '#') {
     if (color.length === 4) {
       const r = parseInt(color.charAt(1) + color.charAt(1), 16);
@@ -103,12 +135,22 @@ export const colorToHexStr = (color: Color): string => {
   return str;
 };
 
+/**
+ * Converts a color object into its equivalent RGB string representation.
+ * @param {Color} color - The color object to convert.
+ * @returns {string} The RGB string representation of the input color object.
+ */
 export const colorToRgbStr = (color: Color): string => {
   const { r, g, b, a } = color;
   return `rgb${a !== 1 ? 'a' : ''}(${r},${g},${b}${a !== 1 ? `,${a}` : ''})`;
 };
 
-export const colorToNumStr = (color: Color): string => {
+/**
+ * Converts a color object into its equivalent RGB(A) body string representation.
+ * @param {Color} color - The color object to convert.
+ * @returns {string} The RGB(A) body string representation of the input color object.
+ */
+export const colorToRgbBodyStr = (color: Color): string => {
   const { r, g, b, a } = color;
   let str = `${r},${g},${b}`;
   if (a !== 1) {

--- a/frontend/apps/remark42/app/utils/colors.ts
+++ b/frontend/apps/remark42/app/utils/colors.ts
@@ -14,6 +14,11 @@ export interface Color {
   a: number;
 }
 
+export interface DualColors {
+  light: Color;
+  dark: Color;
+}
+
 /**
  * Creates a color object that provides utility methods for manipulating and converting color values.
  *

--- a/frontend/apps/remark42/app/utils/create-iframe.ts
+++ b/frontend/apps/remark42/app/utils/create-iframe.ts
@@ -11,7 +11,6 @@ type Params = {
 
 export function createIframe({ __colors__, styles, styling, ...params }: Params) {
   const iframe = document.createElement('iframe');
-  console.log(params);
   const query = new URLSearchParams({
     ...(params as Record<string, string>),
     ...themeStylingToUrlSearchParams(styling),

--- a/frontend/apps/remark42/app/utils/create-iframe.ts
+++ b/frontend/apps/remark42/app/utils/create-iframe.ts
@@ -1,11 +1,21 @@
 import { BASE_URL } from 'common/constants.config';
-import { setStyles, setAttributes, StylesDeclaration } from 'utils/set-dom-props';
+import { ThemeStyling, themeStylingToUrlSearchParams } from 'common/theme';
+import { setAttributes, setStyles, StylesDeclaration } from 'utils/set-dom-props';
 
-type Params = { [key: string]: unknown; __colors__?: Record<string, string>; styles?: StylesDeclaration };
+type Params = {
+  [key: string]: unknown;
+  __colors__?: Record<string, string>;
+  styles?: StylesDeclaration;
+  styling?: ThemeStyling;
+};
 
-export function createIframe({ __colors__, styles, ...params }: Params) {
+export function createIframe({ __colors__, styles, styling, ...params }: Params) {
   const iframe = document.createElement('iframe');
-  const query = new URLSearchParams(params as Record<string, string>).toString();
+  console.log(params);
+  const query = new URLSearchParams({
+    ...(params as Record<string, string>),
+    ...themeStylingToUrlSearchParams(styling),
+  }).toString();
 
   setAttributes(iframe, {
     src: `${BASE_URL}/web/iframe.html?${query}`,

--- a/frontend/apps/remark42/app/utils/post-message.ts
+++ b/frontend/apps/remark42/app/utils/post-message.ts
@@ -1,4 +1,6 @@
-import type { Theme, Profile, ThemeStyles } from 'common/types';
+import { ThemeStyles } from 'common/theme';
+
+import type { Profile, Theme } from 'common/types';
 
 type ParentMessage = {
   inited?: true;

--- a/frontend/apps/remark42/app/utils/post-message.ts
+++ b/frontend/apps/remark42/app/utils/post-message.ts
@@ -1,4 +1,4 @@
-import type { Theme, Profile } from 'common/types';
+import type { Theme, Profile, ThemeStyles } from 'common/types';
 
 type ParentMessage = {
   inited?: true;
@@ -13,6 +13,7 @@ type ChildMessage = {
   hash?: string;
   title?: string;
   theme?: Theme;
+  styles?: ThemeStyles;
   signout?: true;
 };
 

--- a/frontend/apps/remark42/app/utils/post-message.ts
+++ b/frontend/apps/remark42/app/utils/post-message.ts
@@ -1,4 +1,4 @@
-import { ThemeStyles } from 'common/theme';
+import { ThemeStyling } from 'common/theme';
 
 import type { Profile, Theme } from 'common/types';
 
@@ -15,7 +15,7 @@ type ChildMessage = {
   hash?: string;
   title?: string;
   theme?: Theme;
-  styles?: ThemeStyles;
+  styling?: ThemeStyling;
   signout?: true;
 };
 

--- a/frontend/apps/remark42/app/utils/types.spec.ts
+++ b/frontend/apps/remark42/app/utils/types.spec.ts
@@ -1,0 +1,296 @@
+import {
+  isArr,
+  isBool,
+  isBoolOrUndef,
+  isDate,
+  isErr,
+  isFunc,
+  isNull,
+  isNum,
+  isNumArr,
+  isNumArrOrUndef,
+  isNumOrUndef,
+  isStr,
+  isStrArr,
+  isStrOrUndef,
+  isUndef,
+  isUnknownDict,
+  UnknownDict,
+} from './types';
+
+describe('isUnknownDict', () => {
+  test('returns true for an UnknownDict', () => {
+    const obj: UnknownDict = {
+      key1: 'value1',
+      key2: 2,
+      key3: true,
+      key4: null,
+    };
+    expect(isUnknownDict(obj)).toBe(true);
+  });
+
+  test('returns false for a non-object', () => {
+    expect(isUnknownDict('not an object')).toBe(false);
+  });
+
+  test('returns false for null', () => {
+    expect(isUnknownDict(null)).toBe(false);
+  });
+
+  test('returns true for an empty object', () => {
+    const obj = {};
+    expect(isUnknownDict(obj)).toBe(true);
+  });
+});
+
+describe('isStr', () => {
+  test('should return true when passed a string', () => {
+    expect(isStr('hello')).toBe(true);
+  });
+
+  test('should return false when passed a non-string value', () => {
+    expect(isStr(123)).toBe(false);
+    expect(isStr(undefined)).toBe(false);
+    expect(isStr({})).toBe(false);
+    expect(isStr(null)).toBe(false);
+    expect(isStr([])).toBe(false);
+  });
+});
+
+describe('isStrOrUndef', () => {
+  test('should return true when passed a string', () => {
+    expect(isStrOrUndef('hello')).toBe(true);
+  });
+
+  test('should return true when passed undefined', () => {
+    expect(isStrOrUndef(undefined)).toBe(true);
+  });
+
+  test('should return false when passed a non-string value other than undefined', () => {
+    expect(isStrOrUndef(123)).toBe(false);
+    expect(isStrOrUndef({})).toBe(false);
+    expect(isStrOrUndef(null)).toBe(false);
+    expect(isStrOrUndef([])).toBe(false);
+  });
+});
+
+describe('isStrArr', () => {
+  test('should return true when passed an array of strings', () => {
+    expect(isStrArr(['hello', 'world'])).toBe(true);
+  });
+
+  test('should return false when passed an array that contains a non-string value', () => {
+    expect(isStrArr(['hello', 123])).toBe(false);
+    expect(isStrArr(['hello', undefined])).toBe(false);
+    expect(isStrArr(['hello', {}])).toBe(false);
+  });
+
+  test('should return false when passed a non-array value', () => {
+    expect(isStrArr('hello')).toBe(false);
+    expect(isStrArr(123)).toBe(false);
+    expect(isStrArr(undefined)).toBe(false);
+    expect(isStrArr({})).toBe(false);
+    expect(isStrArr(null)).toBe(false);
+  });
+});
+
+describe('isNum', () => {
+  test('returns true for numbers', () => {
+    expect(isNum(5)).toBe(true);
+    expect(isNum(0)).toBe(true);
+    expect(isNum(-10)).toBe(true);
+    expect(isNum(3.14)).toBe(true);
+  });
+
+  test('returns false for non-numbers', () => {
+    expect(isNum('5')).toBe(false);
+    expect(isNum(undefined)).toBe(false);
+    expect(isNum(null)).toBe(false);
+    expect(isNum({ key: 'value' })).toBe(false);
+  });
+});
+
+describe('isNumOrUndef', () => {
+  test('returns true for numbers or undefined', () => {
+    expect(isNumOrUndef(5)).toBe(true);
+    expect(isNumOrUndef(undefined)).toBe(true);
+    expect(isNumOrUndef(null)).toBe(false);
+    expect(isNumOrUndef('5')).toBe(false);
+  });
+
+  test('returns false for other types', () => {
+    expect(isNumOrUndef({ key: 'value' })).toBe(false);
+    expect(isNumOrUndef([1, 2, 3])).toBe(false);
+  });
+});
+
+describe('isNumArr', () => {
+  test('returns true for arrays of numbers', () => {
+    expect(isNumArr([1, 2, 3])).toBe(true);
+    expect(isNumArr([0])).toBe(true);
+    expect(isNumArr([])).toBe(true);
+  });
+
+  test('returns false for non-arrays or arrays of non-numbers', () => {
+    expect(isNumArr(undefined)).toBe(false);
+    expect(isNumArr(null)).toBe(false);
+    expect(isNumArr('1,2,3')).toBe(false);
+    expect(isNumArr([1, '2', 3])).toBe(false);
+    expect(isNumArr([1, null, 3])).toBe(false);
+  });
+});
+
+describe('isNumArrOrUndef', () => {
+  test('returns true for arrays of numbers or undefined', () => {
+    expect(isNumArrOrUndef(undefined)).toBe(true);
+    expect(isNumArrOrUndef([1, 2, 3])).toBe(true);
+  });
+
+  test('returns false for other types', () => {
+    expect(isNumArrOrUndef(null)).toBe(false);
+    expect(isNumArrOrUndef('1,2,3')).toBe(false);
+    expect(isNumArrOrUndef([1, '2', 3])).toBe(false);
+  });
+});
+
+describe('isBool', () => {
+  test('returns true for a boolean value', () => {
+    expect(isBool(true)).toBe(true);
+    expect(isBool(false)).toBe(true);
+  });
+
+  test('returns false for non-boolean values', () => {
+    expect(isBool(1)).toBe(false);
+    expect(isBool('true')).toBe(false);
+    expect(isBool(null)).toBe(false);
+    expect(isBool(undefined)).toBe(false);
+    expect(isBool({})).toBe(false);
+    expect(isBool([])).toBe(false);
+    expect(isBool(() => {})).toBe(false);
+    expect(isBool(new Date())).toBe(false);
+  });
+});
+
+describe('isBoolOrUndef', () => {
+  test('returns true for a boolean value', () => {
+    expect(isBoolOrUndef(true)).toBe(true);
+    expect(isBoolOrUndef(false)).toBe(true);
+  });
+
+  test('returns true for undefined value', () => {
+    expect(isBoolOrUndef(undefined)).toBe(true);
+  });
+
+  test('returns false for non-boolean and non-undefined values', () => {
+    expect(isBoolOrUndef(1)).toBe(false);
+    expect(isBoolOrUndef('true')).toBe(false);
+    expect(isBoolOrUndef(null)).toBe(false);
+    expect(isBoolOrUndef({})).toBe(false);
+    expect(isBoolOrUndef([])).toBe(false);
+    expect(isBoolOrUndef(() => {})).toBe(false);
+    expect(isBoolOrUndef(new Date())).toBe(false);
+  });
+});
+
+describe('isNull', () => {
+  test('returns true for null value', () => {
+    expect(isNull(null)).toBe(true);
+  });
+
+  test('returns false for non-null values', () => {
+    expect(isNull(1)).toBe(false);
+    expect(isNull('null')).toBe(false);
+    expect(isNull(undefined)).toBe(false);
+    expect(isNull({})).toBe(false);
+    expect(isNull([])).toBe(false);
+    expect(isNull(() => {})).toBe(false);
+    expect(isNull(new Date())).toBe(false);
+  });
+});
+
+describe('isUndef', () => {
+  test('returns true for undefined value', () => {
+    expect(isUndef(undefined)).toBe(true);
+  });
+
+  test('returns false for non-undefined values', () => {
+    expect(isUndef(1)).toBe(false);
+    expect(isUndef('undefined')).toBe(false);
+    expect(isUndef(null)).toBe(false);
+    expect(isUndef({})).toBe(false);
+    expect(isUndef([])).toBe(false);
+    expect(isUndef(() => {})).toBe(false);
+    expect(isUndef(new Date())).toBe(false);
+  });
+});
+
+describe('isArr', () => {
+  test('returns true for an array', () => {
+    expect(isArr([])).toBe(true);
+    expect(isArr([1, 2, 3])).toBe(true);
+    expect(isArr(['a', 'b', 'c'])).toBe(true);
+  });
+
+  test('returns false for non-array values', () => {
+    expect(isArr(1)).toBe(false);
+    expect(isArr('array')).toBe(false);
+    expect(isArr(null)).toBe(false);
+    expect(isArr(undefined)).toBe(false);
+    expect(isArr({})).toBe(false);
+    expect(isArr(() => {})).toBe(false);
+    expect(isArr(new Date())).toBe(false);
+  });
+});
+
+describe('isFunc', () => {
+  test('returns true for a function', () => {
+    expect(isFunc(() => {})).toBe(true);
+    // eslint-disable-next-line prefer-arrow-callback
+    expect(isFunc(function () {})).toBe(true);
+  });
+
+  test('returns false for non-function values', () => {
+    expect(isFunc(1)).toBe(false);
+    expect(isFunc('function')).toBe(false);
+    expect(isFunc(null)).toBe(false);
+    expect(isFunc(undefined)).toBe(false);
+    expect(isFunc({})).toBe(false);
+    expect(isFunc([])).toBe(false);
+    expect(isFunc(new Date())).toBe(false);
+    expect(isFunc(new Error())).toBe(false);
+  });
+});
+
+describe('isDate', () => {
+  test('returns true for a Date object', () => {
+    expect(isDate(new Date())).toBe(true);
+  });
+
+  test('returns false for non-Date values', () => {
+    expect(isDate(1)).toBe(false);
+    expect(isDate('date')).toBe(false);
+    expect(isDate(null)).toBe(false);
+    expect(isDate(undefined)).toBe(false);
+    expect(isDate({})).toBe(false);
+    expect(isDate([])).toBe(false);
+    expect(isDate(() => {})).toBe(false);
+    expect(isDate(new Error())).toBe(false);
+  });
+});
+
+describe('isErr', () => {
+  test('returns true for an Error object', () => {
+    expect(isErr(new Error())).toBe(true);
+  });
+
+  test('returns false for non-Error values', () => {
+    expect(isErr(1)).toBe(false);
+    expect(isErr('error')).toBe(false);
+    expect(isErr(null)).toBe(false);
+    expect(isErr(undefined)).toBe(false);
+    expect(isErr({})).toBe(false);
+    expect(isErr([])).toBe(false);
+    expect(isErr(() => {})).toBe(false);
+    expect(isErr(new Date())).toBe(false);
+  });
+});

--- a/frontend/apps/remark42/app/utils/types.ts
+++ b/frontend/apps/remark42/app/utils/types.ts
@@ -1,0 +1,55 @@
+/* This interface defines an object that has keys and values of unknown type. */
+export interface UnknownDict {
+  [index: string]: unknown;
+}
+
+/* Checks if the provided argument is an UnknownDict. */
+export const isUnknownDict = (candidate: unknown): candidate is UnknownDict =>
+  typeof candidate === 'object' && candidate !== null;
+
+/* Checks if a value is of type string */
+export const isStr = (val: unknown): val is string => typeof val === 'string';
+
+/* Checks if a value is of type string or undefined */
+export const isStrOrUndef = (val: unknown): val is string | undefined => isStr(val) || isUndef(val);
+
+/* Checks if a value is an array of strings */
+export const isStrArr = (val: unknown): val is string[] =>
+  isArr(val) && val.reduce<boolean>((memo, itm) => memo && isStr(itm), true);
+
+/* Checks if a value is of type number */
+export const isNum = (val: unknown): val is number => typeof val === 'number';
+
+/* Checks if a value is of type number or undefined */
+export const isNumOrUndef = (val: unknown): val is number => typeof val === 'number' || isUndef(val);
+
+/* Checks if a value is an array of numbers */
+export const isNumArr = (val: unknown): val is number[] =>
+  isArr(val) && val.reduce<boolean>((memo, itm) => isNum(itm) && memo, true);
+
+/* Checks if a value is an array of numbers or undefined */
+export const isNumArrOrUndef = (val: unknown): val is number[] | undefined => isNumArr(val) || isUndef(val);
+
+/* Checks if a value is of type boolean */
+export const isBool = (val: unknown): val is boolean => typeof val === 'boolean';
+
+/* Checks if a value is of type boolean or undefined */
+export const isBoolOrUndef = (val: unknown): val is boolean | undefined => isBool(val) || isUndef(val);
+
+/* Checks if a value is null */
+export const isNull = (val: unknown): val is null => val === null;
+
+/* Checks if a value is undefined */
+export const isUndef = (val: unknown): val is undefined => typeof val === 'undefined';
+
+/* Checks if a value is an array */
+export const isArr = (val: unknown): val is unknown[] => Array.isArray(val);
+
+/* Checks if a value is a function */
+export const isFunc = (val: unknown): val is () => void => !!val && {}.toString.call(val) === '[object Function]';
+
+/* Checks if a value is a Date object */
+export const isDate = (val: unknown): val is Date => val instanceof Date;
+
+/* Checks if a value is an Error object */
+export const isErr = (val: unknown): val is Error => val instanceof Error;

--- a/frontend/apps/remark42/templates/demo.ejs
+++ b/frontend/apps/remark42/templates/demo.ejs
@@ -95,8 +95,7 @@
       <div class="controls">
         <div class="controls__item"><button id="toggle-theme">Toggle theme</button></div>
         <div class="controls__item">
-          <input type="color" id="primary-color-picker" name="primary-color"
-            value="#0aa">
+          <input type="color" id="primary-color-picker" name="primary-color" value="#00aaaa">
           <label for="body">Primary Color</label>
         </div>
       </div>

--- a/frontend/apps/remark42/templates/demo.ejs
+++ b/frontend/apps/remark42/templates/demo.ejs
@@ -96,7 +96,7 @@
         <div class="controls__item"><button id="toggle-theme">Toggle theme</button></div>
         <div class="controls__item">
           <input type="color" id="primary-color-picker" name="primary-color"
-            value="#009999">
+            value="#0aa">
           <label for="body">Primary Color</label>
         </div>
       </div>
@@ -156,6 +156,14 @@
         url: window.location.href,
         components: ['embed', 'counter'],
         theme: theme,
+        styling: {
+          colors: {
+            primary: {
+              light: '#0aa',
+              dark: '#099',
+            },
+          },
+        },
         // locale: "ru",
         // simple_view: true
       };

--- a/frontend/apps/remark42/templates/demo.ejs
+++ b/frontend/apps/remark42/templates/demo.ejs
@@ -48,6 +48,18 @@
         margin-left: 1em;
       }
 
+      .controls {
+        display:flex;
+        flex-direction: row;
+        align-items: center;
+        padding-top: 1rem;
+        padding-bottom: 1rem;
+      }
+
+      .controls__item {
+        margin-right: 1em;
+      }
+
       @media screen and (max-width: 800px) {
         .container {
           padding: 1em;
@@ -80,7 +92,14 @@
           <div class="widget__frame widget__counter-frame">Comments count: <span class="remark42__counter"></span></div>
         </div>
       </div>
-      <p><button id="toggle-theme">Toggle theme</button></p>
+      <div class="controls">
+        <div class="controls__item"><button id="toggle-theme">Toggle theme</button></div>
+        <div class="controls__item">
+          <input type="color" id="primary-color-picker" name="primary-color"
+            value="#009999">
+          <label for="body">Primary Color</label>
+        </div>
+      </div>
       <div id="remark42"></div>
     </div>
 
@@ -121,14 +140,21 @@
         window.REMARK42.changeTheme('dark');
       });
 
+      document.getElementById('primary-color-picker').addEventListener('change', function (e) {
+        e.preventDefault();
+
+        window.REMARK42.changeStyling({
+          colors: {
+            primary: e.target.value,
+          },
+        })
+      });
+
       var remark_config = {
         site_id: 'remark',
         host: '<%= htmlWebpackPlugin.options.REMARK_URL %>',
         url: window.location.href,
         components: ['embed', 'counter'],
-        // __colors__: {
-        //   "--color0": "red",
-        // },
         theme: theme,
         // locale: "ru",
         // simple_view: true


### PR DESCRIPTION
First of all, thank you for this comments engine. I have added it to my blog, and it looks great. However, I have not found a way to change the primary color. The default green color is not the best choice for my website, and it would be better to use blue as the primary color for [https://radio-t.com/](https://radio-t.com/). Therefore, I have decided to add this functionality.

![2023-05-02 14 15 04](https://user-images.githubusercontent.com/1960658/235661988-184e73fd-e5e1-4386-8ccb-e591aa3951da.gif)

This PR adds the ability to change the primary color by using `remark_config`:

```js
var remark_config = {
  // ...other configs
  styling: {
    colors: {
      primary: {
        light: '#0aa',
        dark: '#099',
      },
    },
  },
};
```

Or change it dynamically:

```js
window.REMARK42.changeStyling({
  colors: {
    primary: '#099',
  },
})
```

Initially, I planned to use the `theme` config key for this feature, but it is already used for selecting a theme (light/dark). Although it is possible to use this key with backward compatibility, such as `light`, `dark`, or `{colors: {}}`. But it might overcomplicate the source code. Additionally, the `styles` key is used for iframe's custom styles. Therefore, I decided to use the `styling` key instead.

I saw some commented code which indicated that the initial plan was to add something like a `__colors__` key and allow the user to provide colors by name, such as `--color0`, `--color9`, and so on. However, it might be difficult for the user to change each color in this way. It would be much easier to provide one primary color and generate the required tones.

The config object data structure is designed to be easily extensible in the future, allowing for the addition of properties such as text color, background color, font configurations, and more. However, I have not implemented all of this functionality because I would like to hear your feedback first.

The code applies styles by changing appropriate CSS variables.

The code allows for the application of a single color for both themes (like: `primary: '#099'`) or the use of separate colors for each (`primary: {light: '...', dark: '...'}`). This may not be as useful for the primary color, but it can be very useful for the background color, which might be completely different in those cases.

I've added some utilities to make type checking easier (`app/utils/types.ts`), which I'm using in the type guards, as well as a utility for parsing and working with colors (`app/utils/colors.ts`). This is not difficult to implement, so I decided not to add external dependencies.

Please let me know your thoughts, as I am open to any constructive criticisms or suggestions you may have.