### PR TITLE
[site] fix: anchor offset

### DIFF
--- a/site/.eleventy.js
+++ b/site/.eleventy.js
@@ -50,7 +50,7 @@ function getMarkdownLib() {
 		.use(markdownItAnchor, {
 			permalink: markdownItAnchor.permalink.linkInsideHeader({
 				placement: 'before',
-				class: '',
+				class: 'header-anchor',
 				symbol: '',
 			}),
 		})

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -198,9 +198,5 @@
 	@apply pointer-events-none;
 }
 .header-anchor::before {
-	@apply content-[''];
-	@apply block;
-	@apply h-16;
-	@apply -mt-16;
-	@apply invisible;
+	@apply content-[''] block h-24 -mt-24 invisible md:h-16 md:-mt-16;
 }

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -195,15 +195,12 @@
 }
 
 .header-anchor {
-	pointer-events: none;
+	@apply pointer-events-none;
 }
 .header-anchor::before {
-	content: '';
-	display: block;
-	height: 75px;
-	margin-top: -75px;
-	visibility: hidden;
-}
-.header-anchor:focus-visible {
-	outline: none;
+	@apply content-[''];
+	@apply block;
+	@apply h-16;
+	@apply -mt-16;
+	@apply invisible;
 }

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -193,3 +193,17 @@
 .token.space:before {
 	color: #3c526d;
 }
+
+.header-anchor {
+	pointer-events: none;
+}
+.header-anchor::before {
+	content: '';
+	display: block;
+	height: 75px;
+	margin-top: -75px;
+	visibility: hidden;
+}
+.header-anchor:focus-visible {
+	outline: none;
+}


### PR DESCRIPTION
Anchor offset when navigating through an anchor.
It's now scrolling a bit further, to make a section-header also visible on the screen.
(Previously, selected section-header was hidden under the global page-header)

<img width="905" alt="image" src="https://github.com/umputun/remark42/assets/18248628/3b97f974-d752-4765-9e28-e407b84fced8">

Unfortunately, I don't know how to get rid of the outline, when navigation through an anchor, as it's applied to the parent of styled element. The only way I see here - modify markdown-it-anchor sources (or use some different approach here)
