### PR TITLE
fix: Gap between buttons and markdown tip

### DIFF
--- a/frontend/apps/remark42/app/components/comment-form/__actions/comment-form__actions.css
+++ b/frontend/apps/remark42/app/components/comment-form/__actions/comment-form__actions.css
@@ -5,4 +5,5 @@
   flex-wrap: wrap;
   justify-content: space-between;
   min-height: 30px;
+  gap: 12px;
 }


### PR DESCRIPTION
Fir of [this issue](https://github.com/umputun/remark42/issues/1599)

<img width="324" alt="image" src="https://github.com/umputun/remark42/assets/18248628/69b0f27c-a0c8-42eb-bb04-5baa7b2f70b9">
