### PR TITLE
RSS: Fix snippet generation for parent comment

### DIFF
--- a/backend/app/rest/api/rest_test.go
+++ b/backend/app/rest/api/rest_test.go
@@ -301,7 +301,7 @@ func TestRest_cacheControl(t *testing.T) {
 	for i, tt := range tbl {
 		tt := tt
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			req := httptest.NewRequest("GET", tt.url, nil)
+			req := httptest.NewRequest("GET", tt.url, http.NoBody)
 			w := httptest.NewRecorder()
 
 			h := cacheControl(tt.exp, tt.version)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
@@ -329,7 +329,7 @@ func TestRest_frameAncestors(t *testing.T) {
 	for i, tt := range tbl {
 		tt := tt
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			req := httptest.NewRequest("GET", "http://example.com", nil)
+			req := httptest.NewRequest("GET", "http://example.com", http.NoBody)
 			w := httptest.NewRecorder()
 
 			h := frameAncestors(tt.hosts)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
@@ -363,7 +363,7 @@ func TestRest_subscribersOnly(t *testing.T) {
 	for i, tt := range tbl {
 		tt := tt
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			req := httptest.NewRequest("GET", "http://example.com", nil)
+			req := httptest.NewRequest("GET", "http://example.com", http.NoBody)
 			if tt.setUser {
 				req = token.SetUserInfo(req, tt.user)
 			}

--- a/backend/app/store/comment.go
+++ b/backend/app/store/comment.go
@@ -146,13 +146,17 @@ func (c *Comment) Snippet(limit int) string {
 	if size < limit {
 		return cleanText
 	}
-	snippet := []rune(cleanText)[:size]
+	snippet := []rune(cleanText)[:limit]
 	// go back in snippet and found the first space
 	for i := len(snippet) - 1; i >= 0; i-- {
 		if snippet[i] == ' ' {
 			snippet = snippet[:i]
 			break
 		}
+	}
+	// Don't add a space if comment is just a one single word which has been truncated.
+	if len(snippet) == limit {
+		return string(snippet) + "..."
 	}
 	return string(snippet) + " ..."
 }

--- a/backend/app/store/comment_test.go
+++ b/backend/app/store/comment_test.go
@@ -196,8 +196,8 @@ func TestComment_Snippet(t *testing.T) {
 		{0, "", ""},
 		{-1, "test\nblah", "test blah"},
 		{5, "test\nblah", "test ..."},
-		{5, "xyz12345 xxx", "xyz12345 ..."},
-		{10, "xyz12345 xxx\ntest 123456", "xyz12345 xxx test ..."},
+		{5, "xyz12345 xxx", "xyz12..."},
+		{10, "xyz12345 xxx\ntest 123456", "xyz12345 ..."},
 	}
 
 	for i, tt := range tbl {


### PR DESCRIPTION
PR fixes the following issues with snippet generation for parent comments in RSS (couldn't find existing issues to tag them...):

1) Current implementation simply removes the last word, without truncating up to limit length.
2) In case if even the first word (e.g. magnet link or some base64) is too long don't add extra space.

STR:
1) Run dev version (https://remark42.com/docs/contributing/backend/)
2) Write very long comment (chatgpt helps :))
3) Reply to the comment
4) Check RSS

ER:
Text of original comment in reply item is truncated to 300 chars.

AR:
Only the last word is truncated.