### PR TITLE
Telegram QR styling

### DIFF
--- a/frontend/apps/remark42/.size-limit.js
+++ b/frontend/apps/remark42/.size-limit.js
@@ -5,7 +5,7 @@ module.exports = [
   },
   {
     path: 'public/remark.mjs',
-    limit: '75 KB',
+    limit: '76 KB',
   },
   {
     path: 'public/remark.css',

--- a/frontend/apps/remark42/app/components/auth/auth.module.css
+++ b/frontend/apps/remark42/app/components/auth/auth.module.css
@@ -197,9 +197,11 @@
 }
 
 .telegramQR {
+  background-color: var(--white-color);
+  box-sizing: border-box;
   display: block;
   margin: 12px auto;
-  width: 75%;
+  padding: 10px;
 }
 
 .telegram {

--- a/frontend/apps/remark42/app/components/auth/auth.module.css
+++ b/frontend/apps/remark42/app/components/auth/auth.module.css
@@ -197,7 +197,7 @@
 }
 
 .telegramQR {
-  background-color: var(--white-color);
+  background-color: rgb(var(--white-color));
   box-sizing: border-box;
   display: block;
   margin: 12px auto;


### PR DESCRIPTION
Issue #1622 

Changes:
- 1/1 aspect ratio
- white border around (for easier scan)

Before:
<img width="289" alt="Screenshot 2023-06-27 at 22 00 13" src="https://github.com/umputun/remark42/assets/18248628/1efff9b2-43a0-4ff8-be11-625814823046">

After:
<img width="288" alt="Screenshot 2023-06-27 at 22 14 36" src="https://github.com/umputun/remark42/assets/18248628/ddfb199c-7e3c-4a7c-8ec2-cca3ff9106a9">
