### PR TITLE
Switch from telegram_bot_username to telegram_notifications in /config endpoint

### DIFF
--- a/backend/app/rest/api/rest.go
+++ b/backend/app/rest/api/rest.go
@@ -59,16 +59,16 @@ type Rest struct {
 		Low      int
 		Critical int
 	}
-	UpdateLimiter       float64
-	EmailNotifications  bool
-	TelegramBotUsername string
-	EmojiEnabled        bool
-	SimpleView          bool
-	ProxyCORS           bool
-	SendJWTHeader       bool
-	AllowedAncestors    []string // sets Content-Security-Policy "frame-ancestors ..."
-	SubscribersOnly     bool
-	DisableSignature    bool // prevent signature from being added to headers
+	UpdateLimiter         float64
+	EmailNotifications    bool
+	TelegramNotifications bool
+	EmojiEnabled          bool
+	SimpleView            bool
+	ProxyCORS             bool
+	SendJWTHeader         bool
+	AllowedAncestors      []string // sets Content-Security-Policy "frame-ancestors ..."
+	SubscribersOnly       bool
+	DisableSignature      bool // prevent signature from being added to headers
 
 	SSLConfig   SSLConfig
 	httpsServer *http.Server
@@ -414,44 +414,44 @@ func (s *Rest) configCtrl(w http.ResponseWriter, r *http.Request) {
 	emails, _ := s.DataService.AdminStore.Email(siteID)
 
 	cnf := struct {
-		Version             string   `json:"version"`
-		EditDuration        int      `json:"edit_duration"`
-		AdminEdit           bool     `json:"admin_edit"`
-		MaxCommentSize      int      `json:"max_comment_size"`
-		Admins              []string `json:"admins"`
-		AdminEmail          string   `json:"admin_email"`
-		Auth                []string `json:"auth_providers"`
-		AnonVote            bool     `json:"anon_vote"`
-		LowScore            int      `json:"low_score"`
-		CriticalScore       int      `json:"critical_score"`
-		PositiveScore       bool     `json:"positive_score"`
-		ReadOnlyAge         int      `json:"readonly_age"`
-		MaxImageSize        int      `json:"max_image_size"`
-		EmailNotifications  bool     `json:"email_notifications"`
-		TelegramBotUsername string   `json:"telegram_bot_username"`
-		EmojiEnabled        bool     `json:"emoji_enabled"`
-		SimpleView          bool     `json:"simple_view"`
-		SendJWTHeader       bool     `json:"send_jwt_header"`
-		SubscribersOnly     bool     `json:"subscribers_only"`
+		Version               string   `json:"version"`
+		EditDuration          int      `json:"edit_duration"`
+		AdminEdit             bool     `json:"admin_edit"`
+		MaxCommentSize        int      `json:"max_comment_size"`
+		Admins                []string `json:"admins"`
+		AdminEmail            string   `json:"admin_email"`
+		Auth                  []string `json:"auth_providers"`
+		AnonVote              bool     `json:"anon_vote"`
+		LowScore              int      `json:"low_score"`
+		CriticalScore         int      `json:"critical_score"`
+		PositiveScore         bool     `json:"positive_score"`
+		ReadOnlyAge           int      `json:"readonly_age"`
+		MaxImageSize          int      `json:"max_image_size"`
+		EmailNotifications    bool     `json:"email_notifications"`
+		TelegramNotifications bool     `json:"telegram_notifications"`
+		EmojiEnabled          bool     `json:"emoji_enabled"`
+		SimpleView            bool     `json:"simple_view"`
+		SendJWTHeader         bool     `json:"send_jwt_header"`
+		SubscribersOnly       bool     `json:"subscribers_only"`
 	}{
-		Version:             s.Version,
-		EditDuration:        int(s.DataService.EditDuration.Seconds()),
-		AdminEdit:           s.DataService.AdminEdits,
-		MaxCommentSize:      s.DataService.MaxCommentSize,
-		Admins:              admins,
-		AdminEmail:          emails,
-		LowScore:            s.ScoreThresholds.Low,
-		CriticalScore:       s.ScoreThresholds.Critical,
-		PositiveScore:       s.DataService.PositiveScore,
-		ReadOnlyAge:         s.ReadOnlyAge,
-		MaxImageSize:        s.ImageService.MaxSize,
-		EmailNotifications:  s.EmailNotifications,
-		TelegramBotUsername: s.TelegramBotUsername,
-		EmojiEnabled:        s.EmojiEnabled,
-		AnonVote:            s.AnonVote,
-		SimpleView:          s.SimpleView,
-		SendJWTHeader:       s.SendJWTHeader,
-		SubscribersOnly:     s.SubscribersOnly,
+		Version:               s.Version,
+		EditDuration:          int(s.DataService.EditDuration.Seconds()),
+		AdminEdit:             s.DataService.AdminEdits,
+		MaxCommentSize:        s.DataService.MaxCommentSize,
+		Admins:                admins,
+		AdminEmail:            emails,
+		LowScore:              s.ScoreThresholds.Low,
+		CriticalScore:         s.ScoreThresholds.Critical,
+		PositiveScore:         s.DataService.PositiveScore,
+		ReadOnlyAge:           s.ReadOnlyAge,
+		MaxImageSize:          s.ImageService.MaxSize,
+		EmailNotifications:    s.EmailNotifications,
+		TelegramNotifications: s.TelegramNotifications,
+		EmojiEnabled:          s.EmojiEnabled,
+		AnonVote:              s.AnonVote,
+		SimpleView:            s.SimpleView,
+		SendJWTHeader:         s.SendJWTHeader,
+		SubscribersOnly:       s.SubscribersOnly,
 	}
 
 	cnf.Auth = []string{}

--- a/backend/app/rest/api/rest_test.go
+++ b/backend/app/rest/api/rest_test.go
@@ -301,7 +301,7 @@ func TestRest_cacheControl(t *testing.T) {
 	for i, tt := range tbl {
 		tt := tt
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			req := httptest.NewRequest("GET", tt.url, nil)
+			req := httptest.NewRequest("GET", tt.url, http.NoBody)
 			w := httptest.NewRecorder()
 
 			h := cacheControl(tt.exp, tt.version)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
@@ -329,7 +329,7 @@ func TestRest_frameAncestors(t *testing.T) {
 	for i, tt := range tbl {
 		tt := tt
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			req := httptest.NewRequest("GET", "http://example.com", nil)
+			req := httptest.NewRequest("GET", "http://example.com", http.NoBody)
 			w := httptest.NewRecorder()
 
 			h := frameAncestors(tt.hosts)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
@@ -363,7 +363,7 @@ func TestRest_subscribersOnly(t *testing.T) {
 	for i, tt := range tbl {
 		tt := tt
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			req := httptest.NewRequest("GET", "http://example.com", nil)
+			req := httptest.NewRequest("GET", "http://example.com", http.NoBody)
 			if tt.setUser {
 				req = token.SetUserInfo(req, tt.user)
 			}

--- a/frontend/apps/remark42/app/__stubs__/static-config.ts
+++ b/frontend/apps/remark42/app/__stubs__/static-config.ts
@@ -16,7 +16,7 @@ beforeEach(() => {
     simple_view: false,
     anon_vote: false,
     email_notifications: false,
-    telegram_bot_username: '',
+    telegram_notifications: false,
     emoji_enabled: true,
   };
 });

--- a/frontend/apps/remark42/app/common/static-store.ts
+++ b/frontend/apps/remark42/app/common/static-store.ts
@@ -27,7 +27,7 @@ export const StaticStore: StaticStoreType = {
     simple_view: false,
     anon_vote: false,
     email_notifications: false,
-    telegram_bot_username: '',
+    telegram_notifications: false,
     emoji_enabled: false,
   },
 };

--- a/frontend/apps/remark42/app/common/types.ts
+++ b/frontend/apps/remark42/app/common/types.ts
@@ -119,7 +119,7 @@ export interface Config {
   simple_view: boolean;
   anon_vote: boolean;
   email_notifications: boolean;
-  telegram_bot_username: string;
+  telegram_notifications: boolean;
   emoji_enabled: boolean;
 }
 

--- a/frontend/packages/api/clients/public.ts
+++ b/frontend/packages/api/clients/public.ts
@@ -17,7 +17,7 @@ export interface Config {
 	simple_view: boolean
 	anon_vote: boolean
 	email_notifications: boolean
-	telegram_bot_username: string
+	telegram_notifications: boolean
 	emoji_enabled: boolean
 }
 


### PR DESCRIPTION
Bot username is returned as an answer to subscribe request, so knowing it in advance is unnecessary. Needed for #830.