### PR TITLE
Update documentation to support Caddy V2

### DIFF
--- a/site/src/docs/manuals/subdomain/index.md
+++ b/site/src/docs/manuals/subdomain/index.md
@@ -58,17 +58,15 @@ The `nginx.conf` would then look something like:
 
 ### Caddy configuration
 
-Example of Caddy configuration (`Caddyfile`) running remark42 service on `example.com/remark42/`:
+Example of Caddy configuration (`Caddyfile`) running remark42 service on `example.com/remark42/`, proxying
+requests under the path /remark42 through to the docker container:
 
 ```
-https://example.com {
-        log {
-                output file /var/log/caddy/example.com.access.log
-        }
-        root * /home/example/web
-        handle_path /remark42* {
-                reverse_proxy  localhost:8080
-        }
-        file_server
+example.com {
+  ... other Caddy config for example.com ...
+
+  handle_path /remark42* {
+    reverse_proxy remark42:8080
+  }
 }
 ```

--- a/site/src/docs/manuals/subdomain/index.md
+++ b/site/src/docs/manuals/subdomain/index.md
@@ -61,17 +61,14 @@ The `nginx.conf` would then look something like:
 Example of Caddy configuration (`Caddyfile`) running remark42 service on `example.com/remark42/`:
 
 ```
-example.com {
-	gzip
-	tls mail@example.com
-
-	root /srv/www
-	log  /logs/access.log
-
-	# remark42
-	proxy /remark42/ http://remark42:8080/ {
-		without /remark42
-		transparent
-	}
+https://example.com {
+        log {
+                output file /var/log/caddy/example.com.access.log
+        }
+        root * /home/example/web
+        handle_path /remark42* {
+                reverse_proxy  localhost:8080
+        }
+        file_server
 }
 ```

--- a/site/src/docs/manuals/subdomain/index.md
+++ b/site/src/docs/manuals/subdomain/index.md
@@ -58,15 +58,40 @@ The `nginx.conf` would then look something like:
 
 ### Caddy configuration
 
-Example of Caddy configuration (`Caddyfile`) running remark42 service on `example.com/remark42/`, proxying
+Example of Caddy 2 configuration (`Caddyfile`) running remark42 service on `example.com/remark42/`, proxying
 requests under the path /remark42 through to the docker container:
 
 ```
 example.com {
-  ... other Caddy config for example.com ...
+  root * /srv/www
 
+  log {
+    output file /logs/example.com.access.log
+  }
+
+  # remark42
   handle_path /remark42* {
     reverse_proxy remark42:8080
   }
+  
+  file_server
+}
+```
+
+If you are using a legacy version (v1) of Caddy, the following configuration would be appropriate:
+
+```
+example.com {
+	gzip
+	tls mail@example.com
+
+	root /srv/www
+	log  /logs/example.com.access.log
+
+	# remark42
+	proxy /remark42/ http://remark42:8080/ {
+		without /remark42
+		transparent
+	}
 }
 ```


### PR DESCRIPTION
* Change Caddy example config to be compatible with Caddy V2 config format 
* Caddy V2 was released in 2020 and most new users are likely to be using that
* Existing config snippet is not compatible with V2 at all
