### PR TITLE
Extract error message from API response for preview.

### DIFF
--- a/frontend/apps/remark42/app/components/comment-form/comment-form.tsx
+++ b/frontend/apps/remark42/app/components/comment-form/comment-form.tsx
@@ -180,8 +180,8 @@ export class CommentForm extends Component<Props, State> {
     this.props
       .getPreview(text)
       .then((preview) => this.setState({ preview }))
-      .catch(() => {
-        this.setState({ isErrorShown: true, errorMessage: null });
+      .catch((e) => {
+        this.setState({ isErrorShown: true, errorMessage: extractErrorMessageFromResponse(e, this.props.intl) });
       });
   };
 


### PR DESCRIPTION
### Change Log
- For preview errors, only `isErrorShown` is set to `true` and `errorMessage` is not provided. Hence the comment form shows `Something went wrong. Please try again a bit later.` (generic message) by default for all preview errors.
- Refactored the exception handling to derive error message from the response code (similar to `send` method). Now both Send and Preview shows the same error message.

Resolves: https://github.com/umputun/remark42/issues/1673