### PR TITLE
fix styles around admin controls

### DIFF
--- a/frontend/apps/remark42/app/components/auth-panel/__column/auth-panel__column.css
+++ b/frontend/apps/remark42/app/components/auth-panel/__column/auth-panel__column.css
@@ -1,3 +1,18 @@
+.auth-panel__column_separated > * + * {
+  position: relative;
+  display: inline-block;
+  margin-left: 20px;
+
+  &::before {
+    position: absolute;
+    left: -15px;
+    display: inline-block;
+    width: 10px;
+    text-align: center;
+    content: '•';
+  }
+}
+
 .auth-panel__column:last-child {
   margin-left: 8px;
   text-align: right;

--- a/frontend/apps/remark42/app/components/auth-panel/__readonly-label/auth-panel__readonly-label.css
+++ b/frontend/apps/remark42/app/components/auth-panel/__readonly-label/auth-panel__readonly-label.css
@@ -1,8 +1,0 @@
-.auth-panel__readonly-label {
-  margin-right: 0.3rem;
-}
-
-.auth-panel__readonly-label::after {
-  content: '•';
-  margin-left: 0.3rem;
-}

--- a/frontend/apps/remark42/app/components/auth-panel/auth-panel.css
+++ b/frontend/apps/remark42/app/components/auth-panel/auth-panel.css
@@ -3,5 +3,5 @@
   justify-content: space-between;
   font-size: 14px;
   line-height: 16px;
-  align-items: baseline;
+  align-items: center;
 }

--- a/frontend/apps/remark42/app/components/auth-panel/auth-panel.tsx
+++ b/frontend/apps/remark42/app/components/auth-panel/auth-panel.tsx
@@ -156,13 +156,11 @@ class AuthPanelComponent extends Component<Props, State> {
         <div className="auth-panel__column">{user ? this.renderAuthorized(user) : read_only && <Auth />}</div>
         {this.renderThirdPartyWarning()}
         {this.renderCookiesWarning()}
-        <div className="auth-panel__column">
-          {isSettingsLabelVisible && this.renderSettingsLabel()}
-          {isSettingsLabelVisible && ' • '}
-          {isAdmin && this.renderReadOnlySwitch()}
-          {isAdmin && read_only && ' • '}
+        <div className="auth-panel__column auth-panel__column_separated">
+          {isSettingsLabelVisible && <span>{this.renderSettingsLabel()}</span>}
+          {isAdmin && <span>{this.renderReadOnlySwitch()}</span>}
           {!isAdmin && read_only && (
-            <span className="auth-panel__readonly-label">
+            <span>
               <FormattedMessage id="authPanel.read-only" defaultMessage="Read-only" />
             </span>
           )}

--- a/frontend/apps/remark42/app/components/auth-panel/index.ts
+++ b/frontend/apps/remark42/app/components/auth-panel/index.ts
@@ -1,6 +1,5 @@
 import './auth-panel.css';
 
-import './__readonly-label/auth-panel__readonly-label.css';
 import './__column/auth-panel__column.css';
 
 export * from './auth-panel';


### PR DESCRIPTION
### Before
<img width="306" alt="Screenshot 2023-10-28 at 2 11 51 AM" src="https://github.com/umputun/remark42/assets/2330682/6425e057-6adf-4097-8610-7c5af28e60ea">


### After
<img width="340" alt="Screenshot 2023-10-28 at 2 12 01 AM" src="https://github.com/umputun/remark42/assets/2330682/82948692-bd40-47c2-a6d9-3d0b4351e6fa">

<img width="842" alt="Screenshot 2023-10-28 at 2 16 18 AM" src="https://github.com/umputun/remark42/assets/2330682/b979942a-2990-453a-9e7d-230f9f755a3a">


<img width="839" alt="Screenshot 2023-10-28 at 2 24 29 AM" src="https://github.com/umputun/remark42/assets/2330682/3703bed0-2994-4043-961d-ebf8113c1076">
