### PR TITLE
Allow title extraction only from full match of AllowedHosts

### DIFF
--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -634,8 +634,9 @@ func (s *ServerCommand) newServerApp(ctx context.Context) (*serverApp, error) {
 	}, nil
 }
 
-// Extract second level domains from s.RemarkURL and s.AllowedHosts.
-// It can be and IP like http//127.0.0.1 in which case we need to use whole IP as domain
+// Extract domains from s.AllowedHosts and second level domain from s.RemarkURL.
+// It can be and IP like http://127.0.0.1 in which case we need to use whole IP as domain
+// Beware, if s.RemarkURL is in third-level domain like https://example.co.uk, co.uk will be returned.
 func (s *ServerCommand) getAllowedDomains() []string {
 	rawDomains := s.AllowedHosts
 	rawDomains = append(rawDomains, s.RemarkURL)
@@ -662,8 +663,10 @@ func (s *ServerCommand) getAllowedDomains() []string {
 			continue
 		}
 
-		// if domain is not IP and has more than two levels, extract second level domain
-		if net.ParseIP(domain) == nil && len(strings.Split(domain, ".")) > 2 {
+		// Only for RemarkURL if domain is not IP and has more than two levels, extract second level domain.
+		// For AllowedHosts we don't do this as they are exact list of domains which can host comments, but
+		// RemarkURL might be on a subdomain and we must allow parent domain to be used for TitleExtract.
+		if rawURL == s.RemarkURL && net.ParseIP(domain) == nil && len(strings.Split(domain, ".")) > 2 {
 			domain = strings.Join(strings.Split(domain, ".")[len(strings.Split(domain, "."))-2:], ".")
 		}
 

--- a/backend/app/cmd/server_test.go
+++ b/backend/app/cmd/server_test.go
@@ -739,7 +739,7 @@ func Test_getAllowedDomains(t *testing.T) {
 		{ServerCommand{AllowedHosts: []string{}, CommonOpts: CommonOpts{RemarkURL: "bad hostname"}}, []string{}},
 		{ServerCommand{AllowedHosts: []string{}, CommonOpts: CommonOpts{RemarkURL: "not_a_hostname"}}, []string{}},
 		// test removal of 'self', multiple AllowedHosts. No deduplication is expected
-		{ServerCommand{AllowedHosts: []string{"'self'", "example.org", "test.example.org", "remark42.com"}, CommonOpts: CommonOpts{RemarkURL: "https://example.org"}}, []string{"example.org", "example.org", "remark42.com", "example.org"}},
+		{ServerCommand{AllowedHosts: []string{"'self'", "example.org", "test.example.org", "remark42.com"}, CommonOpts: CommonOpts{RemarkURL: "https://example.org"}}, []string{"example.org", "test.example.org", "remark42.com", "example.org"}},
 	}
 	for i, tt := range tbl {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {


### PR DESCRIPTION
Previously, we extracted the second-level domain, but it doesn't make sense for a list of domains defined explicitly to display the comments.

Relates to #1677.