### PR TITLE
add pagination to GET /api/v1/find endpoint

### DIFF
--- a/backend/app/store/comment.go
+++ b/backend/app/store/comment.go
@@ -45,11 +45,13 @@ type Edit struct {
 
 // PostInfo holds summary for given post url
 type PostInfo struct {
-	URL      string    `json:"url,omitempty"` // can be attached to site-wide comments but won't be set then
-	Count    int       `json:"count"`
-	ReadOnly bool      `json:"read_only,omitempty" bson:"read_only,omitempty"` // can be attached to site-wide comments but won't be set then
-	FirstTS  time.Time `json:"first_time,omitempty" bson:"first_time,omitempty"`
-	LastTS   time.Time `json:"last_time,omitempty" bson:"last_time,omitempty"`
+	URL         string    `json:"url,omitempty"` // can be attached to site-wide comments but won't be set then
+	Count       int       `json:"count"`
+	CountLeft   int       `json:"count_left"`                                     // used only with returning search results limited by number, otherwise zero
+	LastComment string    `json:"last_comment,omitempty"`                         // used only with returning search results limited by number
+	ReadOnly    bool      `json:"read_only,omitempty" bson:"read_only,omitempty"` // can be attached to site-wide comments but won't be set then
+	FirstTS     time.Time `json:"first_time,omitempty" bson:"first_time,omitempty"`
+	LastTS      time.Time `json:"last_time,omitempty" bson:"last_time,omitempty"`
 }
 
 // BlockedUser holds id and ts for blocked user

--- a/backend/app/store/service/tree_test.go
+++ b/backend/app/store/service/tree_test.go
@@ -37,14 +37,14 @@ func TestMakeTree(t *testing.T) {
 		{Locator: loc, ID: "611", ParentID: "61", Deleted: true},
 	}
 
-	res := MakeTree(comments, "time")
+	res := MakeTree(comments, "time", 0, "")
 	resJSON, err := json.Marshal(&res)
 	require.NoError(t, err)
 
 	expJSON := mustLoadJSONFile(t, "testdata/tree.json")
 	assert.Equal(t, expJSON, resJSON)
 
-	res = MakeTree([]store.Comment{}, "time")
+	res = MakeTree([]store.Comment{}, "time", 0, "")
 	assert.Equal(t, &Tree{}, res)
 }
 
@@ -75,7 +75,7 @@ func TestMakeEmptySubtree(t *testing.T) {
 		{Locator: loc, ID: "3", Timestamp: ts(48, 1), Deleted: true}, // deleted top level
 	}
 
-	res := MakeTree(comments, "time")
+	res := MakeTree(comments, "time", 0, "")
 	resJSON, err := json.Marshal(&res)
 	require.NoError(t, err)
 	t.Log(string(resJSON))
@@ -104,50 +104,50 @@ func TestTreeSortNodes(t *testing.T) {
 		{ID: "5", Deleted: true, Timestamp: time.Date(2017, 12, 25, 19, 47, 22, 150, time.UTC)},
 	}
 
-	res := MakeTree(comments, "+active")
+	res := MakeTree(comments, "+active", 0, "")
 	assert.Equal(t, "2", res.Nodes[0].Comment.ID)
 	t.Log(res.Nodes[0].Comment.ID, res.Nodes[0].tsModified)
 
-	res = MakeTree(comments, "-active")
+	res = MakeTree(comments, "-active", 0, "")
 	t.Log(res.Nodes[0].Comment.ID, res.Nodes[0].tsModified)
 	assert.Equal(t, "1", res.Nodes[0].Comment.ID)
 
-	res = MakeTree(comments, "+time")
+	res = MakeTree(comments, "+time", 0, "")
 	t.Log(res.Nodes[0].Comment.ID, res.Nodes[0].tsModified)
 	assert.Equal(t, "1", res.Nodes[0].Comment.ID)
 
-	res = MakeTree(comments, "-time")
+	res = MakeTree(comments, "-time", 0, "")
 	assert.Equal(t, "6", res.Nodes[0].Comment.ID)
 
-	res = MakeTree(comments, "score")
+	res = MakeTree(comments, "score", 0, "")
 	assert.Equal(t, "4", res.Nodes[0].Comment.ID)
 	assert.Equal(t, "3", res.Nodes[1].Comment.ID)
 	assert.Equal(t, "6", res.Nodes[2].Comment.ID)
 	assert.Equal(t, "1", res.Nodes[3].Comment.ID)
 
-	res = MakeTree(comments, "+score")
+	res = MakeTree(comments, "+score", 0, "")
 	assert.Equal(t, "4", res.Nodes[0].Comment.ID)
 
-	res = MakeTree(comments, "-score")
+	res = MakeTree(comments, "-score", 0, "")
 	assert.Equal(t, "2", res.Nodes[0].Comment.ID)
 	assert.Equal(t, "1", res.Nodes[1].Comment.ID)
 	assert.Equal(t, "3", res.Nodes[2].Comment.ID)
 	assert.Equal(t, "6", res.Nodes[3].Comment.ID)
 
-	res = MakeTree(comments, "+controversy")
+	res = MakeTree(comments, "+controversy", 0, "")
 	assert.Equal(t, "3", res.Nodes[0].Comment.ID)
 	assert.Equal(t, "6", res.Nodes[1].Comment.ID)
 	assert.Equal(t, "2", res.Nodes[2].Comment.ID)
 	assert.Equal(t, "4", res.Nodes[3].Comment.ID)
 	assert.Equal(t, "1", res.Nodes[4].Comment.ID)
 
-	res = MakeTree(comments, "-controversy")
+	res = MakeTree(comments, "-controversy", 0, "")
 	assert.Equal(t, "1", res.Nodes[0].Comment.ID)
 	assert.Equal(t, "4", res.Nodes[1].Comment.ID)
 	assert.Equal(t, "2", res.Nodes[2].Comment.ID)
 	assert.Equal(t, "3", res.Nodes[3].Comment.ID)
 
-	res = MakeTree(comments, "undefined")
+	res = MakeTree(comments, "undefined", 0, "")
 	t.Log(res.Nodes[0].Comment.ID, res.Nodes[0].tsModified)
 	assert.Equal(t, "1", res.Nodes[0].Comment.ID)
 }
@@ -160,7 +160,7 @@ func BenchmarkTree(b *testing.B) {
 	assert.NoError(b, err)
 
 	for i := 0; i < b.N; i++ {
-		res := MakeTree(comments, "time")
+		res := MakeTree(comments, "time", 0, "")
 		assert.NotNil(b, res)
 	}
 }

--- a/backend/remark.rest
+++ b/backend/remark.rest
@@ -5,6 +5,12 @@ GET {{host}}/api/v1/find?site={{site}}&sort=-time&format=tree&url={{url}}
 ### find request with plain
 GET {{host}}/api/v1/find?site={{site}}&sort=-controversy&format=plain&url={{url}}
 
+### find 10 first comments for given URL
+GET {{host}}/api/v1/find?site={{site}}&sort=-controversy&format=plain&url={{url}}&limit=10
+
+### find 10 comments after given comment ID (3665976683 in this example) for given URL
+GET {{host}}/api/v1/find?site={{site}}&sort=-controversy&format=plain&url={{url}}&limit=10&after=3665976683
+
 ### find request with plain. dev token for secret=12345, not admin
 GET {{host}}/api/v1/find?site={{site}}&sort=-controversy&format=plain&url={{url}}
 X-JWT: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJyZW1hcmsiLCJleHAiOjE5NzYwNTY3NTYsImp0aSI6IjJlOGJmMTE5OTI0MjQxMDRjYjFhZGRlODllMWYwNGFiMTg4YWZjMzQiLCJpYXQiOjE1NzYwNTY0NTYsImlzcyI6InJlbWFyazQyIiwidXNlciI6eyJuYW1lIjoiZGV2X3VzZXIiLCJpZCI6ImRldl91c2VyIiwicGljdHVyZSI6Imh0dHA6Ly8xMjcuMC4wLjE6ODA4MC9hcGkvdjEvYXZhdGFyL2NjZmEyYWJkMDE2Njc2MDViNGUxZmM0ZmNiOTFiMWUxYWYzMjMyNDAuaW1hZ2UiLCJhdHRycyI6eyJhZG1pbiI6dHJ1ZSwiYmxvY2tlZCI6ZmFsc2V9fX0.6Qt5s2enBMRC-Jmsua01yViVYI95Dx6BPBMaNjj36d4


### PR DESCRIPTION
`format=tree` pagination provides top-level comments with all replies and returns the last top-level comment as `last_comment` to be used as `offset` for the next page. If comments and replies overflow the limit, the one stepping out of the limit will not be returned. If the first comment and its replies after the given offset overflow the limit, it will be returned with all the replies.

`format=plain` pagination works by providing all comments and returning the last comment as `last_comment` to be used as `offset` for the next page.

Requires #1685 to be merged first. Backend part for #782.