### PR TITLE
Fix Commento top-level comments import

### DIFF
--- a/backend/app/migrator/commento.go
+++ b/backend/app/migrator/commento.go
@@ -110,6 +110,12 @@ func (d *Commento) convert(r io.Reader, siteID string) (ch chan store.Comment) {
 				continue
 			}
 
+			parentID := comment.ParentHex
+			// comments with ParentHex == "root" are top-level comments
+			if parentID == "root" {
+				parentID = ""
+			}
+
 			c := store.Comment{
 				ID: comment.CommentHex,
 				Locator: store.Locator{
@@ -119,7 +125,7 @@ func (d *Commento) convert(r io.Reader, siteID string) (ch chan store.Comment) {
 				User:      u,
 				Text:      comment.Markdown,
 				Timestamp: comment.CreationDate,
-				ParentID:  comment.ParentHex,
+				ParentID:  parentID,
 				Imported:  true,
 			}
 

--- a/backend/app/rest/api/testdata/commento.json
+++ b/backend/app/rest/api/testdata/commento.json
@@ -1,0 +1,116 @@
+{
+  "version": 1,
+  "comments": [
+    {
+      "commentHex": "e7a2ef4b4aa1414a7ee65a989889aaecd9d5e7e3bca598ea7a967b4dbcaa8e11",
+      "domain": "example.com",
+      "url": "https://example.com/example",
+      "commenterHex": "018407e4b12b35f43b1d804d82607b341bef80c4325dd047d93f2cbb439cff85",
+      "markdown": "",
+      "html": "",
+      "parentHex": "root",
+      "score": 0,
+      "state": "approved",
+      "creationDate": "2022-10-25T07:25:46.807555Z",
+      "direction": 0,
+      "deleted": false
+    },
+    {
+      "commentHex": "a29e741145daceb4ca5b3e5e279e05b56f73c04703d93b944718ef757e15317f",
+      "domain": "example.com",
+      "url": "https://example.com/example",
+      "commenterHex": "018407e4b12b35f43b1d804d82607b341bef80c4325dd047d93f2cbb439cff85",
+      "markdown": "",
+      "html": "",
+      "parentHex": "root",
+      "score": 0,
+      "state": "approved",
+      "creationDate": "2023-07-26T12:24:55.058552Z",
+      "direction": 0,
+      "deleted": false
+    },
+    {
+      "commentHex": "46baf36433830a4e8bda1de56290cf5fd74c08bfa844fee4ec1744985dc77010",
+      "domain": "example.com",
+      "url": "https://example.com/example",
+      "commenterHex": "018407e4b12b35f43b1d804d82607b341bef80c4325dd047d93f2cbb439cff85",
+      "markdown": "",
+      "html": "",
+      "parentHex": "root",
+      "score": 0,
+      "state": "approved",
+      "creationDate": "2023-10-31T11:03:25.403282Z",
+      "direction": 0,
+      "deleted": false
+    },
+    {
+      "commentHex": "6d3bb64ff73b5f9d6a959212ffde472a51abf8bdefaa5ed843659796bceef9de",
+      "domain": "example.com",
+      "url": "https://example.com/example",
+      "commenterHex": "018407e4b12b35f43b1d804d82607b341bef80c4325dd047d93f2cbb439cff85",
+      "markdown": "",
+      "html": "",
+      "parentHex": "46baf36433830a4e8bda1de56290cf5fd74c08bfa844fee4ec1744985dc77010",
+      "score": 0,
+      "state": "approved",
+      "creationDate": "2023-11-01T22:23:47.112062Z",
+      "direction": 0,
+      "deleted": false
+    },
+    {
+      "commentHex": "23fcfcd03745ed71a9d23a9b59387a313df57e5c0faad8ba5dc96112766312c5",
+      "domain": "example.com",
+      "url": "https://example.com/example",
+      "commenterHex": "018407e4b12b35f43b1d804d82607b341bef80c4325dd047d93f2cbb439cff85",
+      "markdown": "",
+      "html": "",
+      "parentHex": "root",
+      "score": 0,
+      "state": "approved",
+      "creationDate": "2023-10-23T12:33:03.370182Z",
+      "direction": 0,
+      "deleted": false
+    },
+    {
+      "commentHex": "d0ad6f11cf0c5f8e17457a378a6bb789f412c6b7ef7ada4ae06ec8451f7a18aa",
+      "domain": "example.com",
+      "url": "https://example.com/example",
+      "commenterHex": "018407e4b12b35f43b1d804d82607b341bef80c4325dd047d93f2cbb439cff85",
+      "markdown": "",
+      "html": "",
+      "parentHex": "root",
+      "score": 0,
+      "state": "approved",
+      "creationDate": "2023-10-18T01:18:38.193625Z",
+      "direction": 0,
+      "deleted": false
+    },
+    {
+      "commentHex": "098960fd01c1fc7c0d3ea428f52fab97ea5c18aa52f3565bba679224daddc687",
+      "domain": "example.com",
+      "url": "https://example.com/example",
+      "commenterHex": "018407e4b12b35f43b1d804d82607b341bef80c4325dd047d93f2cbb439cff85",
+      "markdown": "",
+      "html": "",
+      "parentHex": "23fcfcd03745ed71a9d23a9b59387a313df57e5c0faad8ba5dc96112766312c5",
+      "score": 0,
+      "state": "approved",
+      "creationDate": "2023-11-01T22:24:04.639965Z",
+      "direction": 0,
+      "deleted": false
+    }
+  ],
+  "commenters": [
+    {
+      "commenterHex": "018407e4b12b35f43b1d804d82607b341bef80c4325dd047d93f2cbb439cff85",
+      "email": "undefined",
+      "name": "blank",
+      "link": "undefined",
+      "photo": "undefined",
+      "provider": "anon",
+      "joinDate": "2022-06-09T15:54:29.865919Z",
+      "isModerator": false,
+      "deleted": false
+    }
+  ]
+}


### PR DESCRIPTION
Previously, top-level comments were incorrectly assigned parent comment id "root", which made them non-root, so they are not returned when requested in the `/find?format=tree` API call.

To fix the previously imported comments, please export all your comments and replace `"pid":"root"` with `"pid":""` and then re-import them.

Resolves #1696.