### PR TITLE
Fix Commento import URL

### DIFF
--- a/backend/app/migrator/commento.go
+++ b/backend/app/migrator/commento.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/url"
 	"time"
 
 	"github.com/umputun/remark42/backend/app/store"
@@ -116,10 +117,16 @@ func (d *Commento) convert(r io.Reader, siteID string) (ch chan store.Comment) {
 				parentID = ""
 			}
 
+			commentURL, e := url.JoinPath("https://", comment.Domain, comment.Path)
+			if e != nil {
+				log.Printf("[WARN] can't construct comment URL in commento import, %s", err.Error())
+			}
+			log.Printf("[ERROR] commentoURL: %s", commentURL)
+
 			c := store.Comment{
 				ID: comment.CommentHex,
 				Locator: store.Locator{
-					URL:    comment.Path,
+					URL:    commentURL,
 					SiteID: siteID,
 				},
 				User:      u,

--- a/backend/app/migrator/testdata/commento.json
+++ b/backend/app/migrator/testdata/commento.json
@@ -4,7 +4,7 @@
 	{
 	  "commentHex": "e7069a7dfcfaed43caf62300a9b0edb1c124ad79d0f5887c93649c15d7f69945",
 	  "domain": "example.com",
-	  "url": "https://example.com/blog/post/1",
+	  "url": "/blog/post/1",
 	  "commenterHex": "anonymous",
 	  "markdown": "Example comment created by user.",
 	  "html": "",
@@ -18,7 +18,7 @@
 	{
 	  "commentHex": "7d77e39fcd813241d6281478cc8f21ab5f807d043c750bc1a936bc23b34fb854",
 	  "domain": "example.com",
-	  "url": "https://example.com/blog/post/1",
+	  "url": "/blog/post/1",
 	  "commenterHex": "a1ac58ed1146bd7fe3feff6a7276f73955c3bfd23cacee00e2e0a7a89b1a8c10",
 	  "markdown": "Example 2 comment created by user.",
 	  "html": "",
@@ -32,7 +32,7 @@
 	{
 	  "commentHex": "ea5f7bcd6ac9bb7b657f7d0569831104e1bcf9c253d03c1e16bf9654c49a5ce9",
 	  "domain": "example.com",
-	  "url": "https://example.com/blog/post/1",
+	  "url": "/blog/post/1",
 	  "commenterHex": "bd1290ab5c858cf2a05903c2a9a61fd63399c6635db38cc6597002195e22e061",
 	  "markdown": "Great reply!",
 	  "html": "",

--- a/backend/app/rest/api/migrator_test.go
+++ b/backend/app/rest/api/migrator_test.go
@@ -164,7 +164,7 @@ func TestMigrator_ImportFromCommento(t *testing.T) {
 	defer teardown()
 
 	r := strings.NewReader(`{"version":1,"comments":[{"commentHex":"7d77e39fcd813241d6281478cc8f21ab5f807d043c750bc1a936bc23b34fb854",
-"domain":"example.com","url":"https://example.com/blog/post/1","commenterHex":"a1ac58ed1146bd7fe3feff6a7276f73955c3bfd23cacee00e2e0a7a89b1a8c10",
+"domain":"example.com","url":"/blog/post/1","commenterHex":"a1ac58ed1146bd7fe3feff6a7276f73955c3bfd23cacee00e2e0a7a89b1a8c10",
 "markdown":"Example content","html":"","parentHex":"root","score":0,"state":"approved","creationDate":"2021-03-17T12:09:47.722181Z",
 "direction":0,"deleted":false}],"commenters":[{"commenterHex":"a1ac58ed1146bd7fe3feff6a7276f73955c3bfd23cacee00e2e0a7a89b1a8c10",
 "email":"somegreatmail@gmail.com","name":"User5276","link":"https://example.com/profile/257","photo":"https://secure.gravatar.com/avatar/8f279626d26175134b0d5c88648172f7",

--- a/backend/app/rest/api/testdata/commento.json
+++ b/backend/app/rest/api/testdata/commento.json
@@ -4,7 +4,7 @@
     {
       "commentHex": "e7a2ef4b4aa1414a7ee65a989889aaecd9d5e7e3bca598ea7a967b4dbcaa8e11",
       "domain": "example.com",
-      "url": "https://example.com/example",
+      "url": "/example",
       "commenterHex": "018407e4b12b35f43b1d804d82607b341bef80c4325dd047d93f2cbb439cff85",
       "markdown": "",
       "html": "",
@@ -18,7 +18,7 @@
     {
       "commentHex": "a29e741145daceb4ca5b3e5e279e05b56f73c04703d93b944718ef757e15317f",
       "domain": "example.com",
-      "url": "https://example.com/example",
+      "url": "/example",
       "commenterHex": "018407e4b12b35f43b1d804d82607b341bef80c4325dd047d93f2cbb439cff85",
       "markdown": "",
       "html": "",
@@ -32,7 +32,7 @@
     {
       "commentHex": "46baf36433830a4e8bda1de56290cf5fd74c08bfa844fee4ec1744985dc77010",
       "domain": "example.com",
-      "url": "https://example.com/example",
+      "url": "/example",
       "commenterHex": "018407e4b12b35f43b1d804d82607b341bef80c4325dd047d93f2cbb439cff85",
       "markdown": "",
       "html": "",
@@ -46,7 +46,7 @@
     {
       "commentHex": "6d3bb64ff73b5f9d6a959212ffde472a51abf8bdefaa5ed843659796bceef9de",
       "domain": "example.com",
-      "url": "https://example.com/example",
+      "url": "/example",
       "commenterHex": "018407e4b12b35f43b1d804d82607b341bef80c4325dd047d93f2cbb439cff85",
       "markdown": "",
       "html": "",
@@ -60,7 +60,7 @@
     {
       "commentHex": "23fcfcd03745ed71a9d23a9b59387a313df57e5c0faad8ba5dc96112766312c5",
       "domain": "example.com",
-      "url": "https://example.com/example",
+      "url": "/example",
       "commenterHex": "018407e4b12b35f43b1d804d82607b341bef80c4325dd047d93f2cbb439cff85",
       "markdown": "",
       "html": "",
@@ -74,7 +74,7 @@
     {
       "commentHex": "d0ad6f11cf0c5f8e17457a378a6bb789f412c6b7ef7ada4ae06ec8451f7a18aa",
       "domain": "example.com",
-      "url": "https://example.com/example",
+      "url": "/example",
       "commenterHex": "018407e4b12b35f43b1d804d82607b341bef80c4325dd047d93f2cbb439cff85",
       "markdown": "",
       "html": "",
@@ -88,7 +88,7 @@
     {
       "commentHex": "098960fd01c1fc7c0d3ea428f52fab97ea5c18aa52f3565bba679224daddc687",
       "domain": "example.com",
-      "url": "https://example.com/example",
+      "url": "/example",
       "commenterHex": "018407e4b12b35f43b1d804d82607b341bef80c4325dd047d93f2cbb439cff85",
       "markdown": "",
       "html": "",

--- a/site/src/docs/backup/migration/index.md
+++ b/site/src/docs/backup/migration/index.md
@@ -20,3 +20,5 @@ Remark42 supports importing comments from Disqus, WordPress, Commento, or native
 
 1. Move exported json file to your Remark42 host within `./var`
 2. Run import command (`ADMIN_PASSWD` must to be enabled on server for it to work) - `docker exec -it remark42 import -p commento -f /srv/var/{commento-export-name}.json -s {your site ID}`
+
+Comments are imported for the domain specified in the provided file, with `https://` prefix. If you want to import comments for a different domain or for `http://` domain, you'll need to export them after importing, alter the export file `url` property and re-import them.


### PR DESCRIPTION
Previously, it was not using the domain and relying on another export format.

Resolves #1697.