### PR TITLE
Hide delete button for non-admin users after edit period expires

### DIFF
--- a/frontend/apps/remark42/app/components/comment/comment-actions.spec.tsx
+++ b/frontend/apps/remark42/app/components/comment/comment-actions.spec.tsx
@@ -89,10 +89,18 @@ describe('<CommentActions/>', () => {
     expect(screen.getByText('Hide')).toBeInTheDocument();
   });
 
-  it('should render "Delete" for current user comments', () => {
+  it('should render "Delete" for current user comments when editing is available', () => {
     props.currentUser = true;
+    props.editDeadline = Date.now() + 300 * 1000; // set editDeadline to a future timestamp
     render(<CommentActions {...props} />);
     expect(screen.getByText('Delete')).toBeInTheDocument();
+  });
+
+  it('should not render "Delete" for current user comments when editDeadline is undefined', () => {
+    props.currentUser = true;
+    props.editDeadline = undefined; // set editDeadline to undefined
+    render(<CommentActions {...props} />);
+    expect(screen.queryByText('Delete')).not.toBeInTheDocument();
   });
 
   it('should not render "Delete" for other users comments', () => {

--- a/frontend/apps/remark42/app/components/comment/comment-actions.tsx
+++ b/frontend/apps/remark42/app/components/comment/comment-actions.tsx
@@ -113,7 +113,7 @@ export function CommentActions({
             )}
           </>
         )}
-        {(currentUser || admin) && deleteJSX}
+        {((currentUser && editDeadline !== undefined) || admin) && deleteJSX}
       </div>
     </div>
   );


### PR DESCRIPTION
Resolves #1737. The user couldn't delete their comment once EditDuration passes.