### PR TITLE
add RTL support

### DIFF
--- a/frontend/apps/remark42/app/components/auth/auth.tsx
+++ b/frontend/apps/remark42/app/components/auth/auth.tsx
@@ -334,6 +334,7 @@ export function Auth() {
                           const element = evt.target as HTMLInputElement;
                           element.value = element.value.trim();
                         }}
+                        dir="auto"
                       />
                     </div>
                     {view === 'email' && (
@@ -345,6 +346,7 @@ export function Auth() {
                           type="email"
                           placeholder={intl.formatMessage(messages.emailAddress)}
                           disabled={isLoading}
+                          dir="auto"
                         />
                       </div>
                     )}

--- a/frontend/apps/remark42/app/components/comment-form/comment-form.tsx
+++ b/frontend/apps/remark42/app/components/comment-form/comment-form.tsx
@@ -461,6 +461,7 @@ export class CommentForm extends Component<Props, State> {
               disabled={isDisabled}
               autofocus={!!autofocus}
               spellcheck={true}
+              dir="auto"
             />
           </TextExpander>
           {charactersLeft < 100 && <span className="comment-form__counter">{charactersLeft}</span>}
@@ -518,6 +519,7 @@ export class CommentForm extends Component<Props, State> {
                 className="comment-form__preview raw-content"
                 // eslint-disable-next-line react/no-danger
                 dangerouslySetInnerHTML={{ __html: preview }}
+                dir="auto"
               />
             </div>
           )

--- a/frontend/apps/remark42/app/components/comment/comment.tsx
+++ b/frontend/apps/remark42/app/components/comment/comment.tsx
@@ -336,7 +336,7 @@ export class Comment extends Component<CommentProps, State> {
     if (props.view === 'preview') {
       return (
         <article className={b('comment', { mix: props.mix }, defaultMods)}>
-          <div className="comment__body">
+          <div className="comment__body" dir="auto">
             {!!o.title && (
               <div className="comment__title">
                 <a className="comment__title-link" href={`${o.locator.url}#${COMMENT_NODE_CLASSNAME_PREFIX}${o.id}`}>
@@ -477,6 +477,7 @@ export class Comment extends Component<CommentProps, State> {
               ref={this.textNode}
               // eslint-disable-next-line react/no-danger
               dangerouslySetInnerHTML={{ __html: o.text }}
+              dir="auto"
             />
           )}
 

--- a/frontend/apps/remark42/app/components/textarea-autosize.tsx
+++ b/frontend/apps/remark42/app/components/textarea-autosize.tsx
@@ -33,5 +33,5 @@ export const TextareaAutosize = forwardRef<HTMLTextAreaElement, Props>(({ onInpu
     }
   }, [value, ref]);
 
-  return <textarea {...props} data-testid={props.id} onInput={handleInput} value={value} ref={ref} />;
+  return <textarea {...props} data-testid={props.id} onInput={handleInput} value={value} ref={ref} dir="auto" />;
 });


### PR DESCRIPTION
This pull request adds support for RTL (right-to-left) languages. By adding `dir=auto` to the relevant inputs, divs and textareas you get automatic support of RTL languages, with no detriment or loss in functionality to LTR languages.

See this excellent summary [PSA: Add dir="auto" to your inputs and textareas.](https://mough.xyz/312/psa-add-dir-auto-to-your-inputs-and-textareas)

**Before:**

<img width="845" alt="Screenshot 2024-07-25 at 10 12 16 PM" src="https://github.com/user-attachments/assets/bcd3f6cb-48e7-4b17-b3c6-8780039515da">

**After:**

<img width="812" alt="Screenshot 2024-07-25 at 10 01 30 PM" src="https://github.com/user-attachments/assets/84e0acc7-b5bd-46e5-8517-c4a8a29b4391">
