### PR TITLE
Switch playwright (e2e) to latest stable version

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -6,12 +6,14 @@ on:
     paths:
       - "frontend/apps/remark42/**"
       - "frontend/e2e/**"
+      - "frontend/Dockerfile.e2e"
 
   pull_request:
     branches: [master]
     paths:
       - "frontend/apps/remark42/**"
       - "frontend/e2e/**"
+      - "frontend/Dockerfile.e2e"
 
 jobs:
   tests:

--- a/frontend/Dockerfile.e2e
+++ b/frontend/Dockerfile.e2e
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.44-jammy
+FROM mcr.microsoft.com/playwright:jammy
 
 ENV CI true
 WORKDIR /frontend


### PR DESCRIPTION
I accidentally broke the image and it was not tested. Now it would be latest stable and dockerfile change will trigger e2e tests to catch breaking like that.