### PR TITLE
Disallow image proxy for private IPs, add blacklist support

### DIFF
--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -133,8 +133,10 @@ type ServerCommand struct {
 
 // ImageProxyGroup defines options group for image proxy
 type ImageProxyGroup struct {
-	HTTP2HTTPS    bool `long:"http2https" env:"HTTP2HTTPS" description:"enable HTTP->HTTPS proxy"`
-	CacheExternal bool `long:"cache-external" env:"CACHE_EXTERNAL" description:"enable caching for external images"`
+	HTTP2HTTPS           bool     `long:"http2https" env:"HTTP2HTTPS" description:"enable HTTP->HTTPS proxy"`
+	CacheExternal        bool     `long:"cache-external" env:"CACHE_EXTERNAL" description:"enable caching for external images"`
+	Blacklist            []string `long:"blacklist" env:"BLACKLIST" description:"list of IPs, subnets and domains to exclude from proxy"  env-delim:","`
+	AllowPrivateNetworks bool     `long:"allow-private-networks" env:"ALLOW_PRIVATE_NETWORKS" description:"allow proxying private networks"`
 }
 
 // AppleGroup defines options for Apple auth params
@@ -560,11 +562,13 @@ func (s *ServerCommand) newServerApp(ctx context.Context) (*serverApp, error) {
 	notifyService := s.makeNotifyService(dataService, notifyDestinations, telegramService)
 
 	imgProxy := &proxy.Image{
-		HTTP2HTTPS:    s.ImageProxy.HTTP2HTTPS,
-		CacheExternal: s.ImageProxy.CacheExternal,
-		RoutePath:     "/api/v1/img",
-		RemarkURL:     s.RemarkURL,
-		ImageService:  imageService,
+		HTTP2HTTPS:           s.ImageProxy.HTTP2HTTPS,
+		CacheExternal:        s.ImageProxy.CacheExternal,
+		Blacklist:            s.ImageProxy.Blacklist,
+		RoutePath:            "/api/v1/img",
+		RemarkURL:            s.RemarkURL,
+		ImageService:         imageService,
+		AllowPrivateNetworks: s.ImageProxy.AllowPrivateNetworks,
 	}
 	emojiFmt := store.CommentConverterFunc(func(text string) string { return text })
 	if s.EnableEmoji {

--- a/backend/app/rest/proxy/private_ips.go
+++ b/backend/app/rest/proxy/private_ips.go
@@ -1,0 +1,76 @@
+package proxy
+
+import (
+	"bytes"
+	"net"
+	"net/url"
+)
+
+// ipRange represents a range of IP addresses.
+type ipRange struct {
+	start net.IP
+	end   net.IP
+}
+
+// privateRanges contains the list of private and special-use IP ranges.
+// https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
+// https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml
+var privateRanges = []ipRange{
+	// IPv4 Private Ranges
+	{start: net.ParseIP("10.0.0.0"), end: net.ParseIP("10.255.255.255")},
+	{start: net.ParseIP("172.16.0.0"), end: net.ParseIP("172.31.255.255")},
+	{start: net.ParseIP("192.168.0.0"), end: net.ParseIP("192.168.255.255")},
+	// IPv4 Link-Local
+	{start: net.ParseIP("169.254.0.0"), end: net.ParseIP("169.254.255.255")},
+	// IPv4 Shared Address Space (RFC 6598)
+	{start: net.ParseIP("100.64.0.0"), end: net.ParseIP("100.127.255.255")},
+	// IPv4 Benchmarking (RFC 2544)
+	{start: net.ParseIP("198.18.0.0"), end: net.ParseIP("198.19.255.255")},
+	// IPv6 Unique Local Addresses (ULA)
+	{start: net.ParseIP("fc00::"), end: net.ParseIP("fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")},
+	// IPv6 Link-local Addresses
+	{start: net.ParseIP("fe80::"), end: net.ParseIP("febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff")},
+	// IPv6 Documentation
+	{start: net.ParseIP("2001:db8::"), end: net.ParseIP("2001:db8:ffff:ffff:ffff:ffff:ffff:ffff")},
+}
+
+// isPrivateURL checks if the given URL points to a private network
+func isPrivateURL(urlStr string) bool {
+	parsedURL, err := url.Parse(urlStr)
+	if err != nil {
+		return false
+	}
+
+	host := parsedURL.Hostname()
+	ip := net.ParseIP(host)
+
+	if ip == nil {
+		// Resolve hostname to IP
+		ips, err := net.LookupIP(host)
+		if err != nil || len(ips) == 0 {
+			return false
+		}
+		ip = ips[0]
+	}
+
+	return isPrivateSubnet(ip)
+}
+
+// isPrivateSubnet - check to see if this ip is in a private subnet
+func isPrivateSubnet(ipAddress net.IP) bool {
+	// inRange - check to see if a given ip address is within a range given
+	inRange := func(r ipRange, ipAddress net.IP) bool {
+		// ensure the IPs are in the same format for comparison
+		ipAddress = ipAddress.To16()
+		r.start = r.start.To16()
+		r.end = r.end.To16()
+		return bytes.Compare(ipAddress, r.start) >= 0 && bytes.Compare(ipAddress, r.end) <= 0
+	}
+
+	for _, r := range privateRanges {
+		if inRange(r, ipAddress) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/app/store/engine/bolt_test.go
+++ b/backend/app/store/engine/bolt_test.go
@@ -324,7 +324,7 @@ func TestBoltDB_InfoPost(t *testing.T) {
 	b, teardown := prep(t) // two comments for https://radio-t.com
 	defer teardown()
 
-	ts := func(min int) time.Time { return time.Date(2017, 12, 20, 15, 18, min, 0, time.Local) }
+	ts := func(seconds int) time.Time { return time.Date(2017, 12, 20, 15, 18, seconds, 0, time.Local) }
 
 	// add one more for https://radio-t.com/2
 	comment := store.Comment{

--- a/backend/app/store/service/service_test.go
+++ b/backend/app/store/service/service_test.go
@@ -213,7 +213,6 @@ func TestService_Put(t *testing.T) {
 	assert.Equal(t, "https://radio-t.com", got.Locator.URL, "should be unaltered")
 	assert.Equal(t, "radio-t", got.Locator.SiteID, "should be unaltered")
 	assert.Equal(t, time.Date(2017, 12, 20, 15, 18, 22, 0, time.Local), got.Timestamp, "should be unaltered")
-
 }
 
 func TestService_SetTitle(t *testing.T) {

--- a/site/src/docs/configuration/parameters/index.md
+++ b/site/src/docs/configuration/parameters/index.md
@@ -151,6 +151,8 @@ services:
 | read-age                       | READONLY_AGE                   |                         | read-only age of comments, days                          |
 | image-proxy.http2https         | IMAGE_PROXY_HTTP2HTTPS         | `false`                 | enable HTTP->HTTPS proxy for images                      |
 | image-proxy.cache-external     | IMAGE_PROXY_CACHE_EXTERNAL     | `false`                 | enable caching external images to current image storage  |
+| image-proxy.blacklist          | IMAGE_PROXY_BLACKLIST          |                         | list of IPs, subnets and domains to exclude from proxy, _multi_ |
+| image-proxy.allow-private-networks | IMAGE_PROXY_ALLOW_PRIVATE_NETWORKS | `false`         | allow proxying private networks                          |
 | emoji                          | EMOJI                          | `false`                 | enable emoji support                                     |
 | simple-view                    | SIMPLE_VIEW                    | `false`                 | minimized UI with basic info only                        |
 | proxy-cors                     | PROXY_CORS                     | `false`                 | disable internal CORS and delegate it to proxy           |


### PR DESCRIPTION
This mitigates the problem where a user might probe machines that are unavailable to the user directly but accessible to the server hosting Remark42.

Scenarios addressed:

1. A malicious user could learn about the presence of specific software or hardware running on an internal address. For example, the presence of an image at `http://192.168.0.1/img/container_bottom_shade_login.png` can expose the type of router you have.

2. A malicious user might receive non-timeout `invalid content type` responses from internal addresses, enabling them to scan and identify HTTP servers running in the internal IP range without revealing their content but indicating their presence.

The new functionality is breaking, but I assume no one intends to expose only private network images to the outside world. The old behavior can be restored by setting the `--image-proxy.allow-private-networks` flag.

Additionally, this change adds the `--image-proxy.blacklist` flag to allow blacklisting private parts of the infrastructure from being accessed by the image proxy. You can blacklist IPs (e.g., `8.8.8.8`), CIDR subnets (e.g., `8.8.8.8/31`), and domains (e.g., `private.example .com`). Note that all subdomains of a given domain will also be blacklisted.

`127.0.0.0/8` and `::1/128` ranges are not included as they are most commonly used for local testing, and it would be cumbersome to prohibit them. Localhost is considered less of a security threat than probing other hosts in the network. If desired, localhost can be restricted using the blacklist functionality.