### PR TITLE
Add Content-Security-Policy and Permissions-Policy headers

### DIFF
--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -608,6 +608,7 @@ func (s *ServerCommand) newServerApp(ctx context.Context) (*serverApp, error) {
 		SubscribersOnly:            s.SubscribersOnly,
 		DisableSignature:           s.DisableSignature,
 		DisableFancyTextFormatting: s.DisableFancyTextFormatting,
+		ExternalImageProxy:         s.ImageProxy.CacheExternal,
 	}
 
 	srv.ScoreThresholds.Low, srv.ScoreThresholds.Critical = s.LowScore, s.CriticalScore


### PR DESCRIPTION
This is a security change. The policies I've added are not ideal but an improvement over lack of policies, and were tested by me for a few months to verify their work.

`Content-Security-Policy` now restricts resource loading and execution to enhance security:
  - `default-src 'none'`: Disallow all resource loading by default.
  - `base-uri 'none'`: Prevents the use of `<base>` tag to change the base URL for relative URLs.
  - `form-action 'none'`: Disallows form submissions.
  - `connect-src 'self'`: Restricts the origins that can be connected to (via XHR, WebSockets, etc.) to the same origin.
  - `frame-src *`: Allow to be embedded on any domain.
  - `img-src 'self'`: Allows images to be loaded only from the same origin. If `imageProxyEnabled` is true, allows images from any origin (`*`).
  - `script-src 'self' 'unsafe-inline'`: Allows scripts to be loaded and executed only from the same origin and allows inline scripts.
  - `style-src 'self' 'unsafe-inline'`: Allows styles to be loaded and applied only from the same origin and allows inline styles.
  - `font-src data:`: Allows fonts to be loaded from data URIs.
  - `object-src 'none'`: Disallows the use of `<object>`, `<embed>`, and `<applet>` tags.

`Permissions-Policy` now restricts the use of certain browser features which we don't use to enhance user privacy and security:
  - `accelerometer=()`: Disables the use of the accelerometer sensor.
  - `autoplay=()`: Disables automatic playback of media.
  - `camera=()`: Disables the use of the camera.
  - `cross-origin-isolated=()`: Disallows the page from being treated as cross-origin isolated.
  - `display-capture=()`: Disables the ability to capture the display.
  - `encrypted-media=()`: Disables the use of Encrypted Media Extensions .
  - `fullscreen=()`: Disables the ability to use fullscreen mode.
  - `geolocation=()`: Disables the use of geolocation.
  - `gyroscope=()`: Disables the use of the gyroscope sensor.
  - `keyboard-map=()`: Disables the use of the keyboard map.
  - `magnetometer=()`: Disables the use of the magnetometer sensor.
  - `microphone=()`: Disables the use of the microphone.
  - `midi=()`: Disables the use of the MIDI API.
  - `payment=()`: Disables the Payment Request API.
  - `picture-in-picture=()`: Disables the use of Picture-in-Picture mode .
  - `publickey-credentials-get=()`: Disables the use of the Web Authentication API.
  - `screen-wake-lock=()`: Disables the ability to prevent the screen from dimming.
  - `sync-xhr=()`: Disables synchronous XMLHttpRequest.
  - `usb=()`: Disables the use of the USB API.
  - `xr-spatial-tracking=()`: Disables the use of spatial tracking in WebXR.
  - `clipboard-read=()`: Disables the ability to read from the clipboard .
  - `clipboard-write=()`: Disables the ability to write to the clipboard .
  - `gamepad=()`: Disables the use of the Gamepad API.
  - `hid=()`: Disables the use of the Human Interface Device API.
  - `idle-detection=()`: Disables the ability to detect idle state.
  - `interest-cohort=()`: Disables the use of interest cohort tracking.
  - `serial=()`: Disables the use of the Serial API.
  - `unload=()`: Disables the ability to use the `beforeunload` and `unload` events.
  - `window-management=()`: Disables the ability to use window management APIs.