### PR TITLE
fix: Apple login integration

### DIFF
--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -139,7 +139,7 @@ type ImageProxyGroup struct {
 
 // AppleGroup defines options for Apple auth params
 type AppleGroup struct {
-	CID                string `long:"cid" env:"CID" description:"Apple client ID"`
+	CID                string `long:"cid" env:"CID" description:"Apple client ID (App ID or Services ID)"`
 	TID                string `long:"tid" env:"TID" description:"Apple service ID"`
 	KID                string `long:"kid" env:"KID" description:"Private key ID"`
 	PrivateKeyFilePath string `long:"private-key-filepath" env:"PRIVATE_KEY_FILEPATH" description:"Private key file location" default:"/srv/var/apple.p8"`

--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -905,9 +905,9 @@ func (s *ServerCommand) addAuthProviders(authenticator *auth.Service) error {
 	if s.Auth.Apple.CID != "" && s.Auth.Apple.TID != "" && s.Auth.Apple.KID != "" {
 		err := authenticator.AddAppleProvider(
 			provider.AppleConfig{
-				ClientID:     s.Auth.Apple.CID,
-				TeamID:       s.Auth.Apple.TID,
-				KeyID:        s.Auth.Apple.KID,
+				ClientID: s.Auth.Apple.CID,
+				TeamID:   s.Auth.Apple.TID,
+				KeyID:    s.Auth.Apple.KID,
 			},
 			provider.LoadApplePrivateKeyFromFile(s.Auth.Apple.PrivateKeyFilePath),
 		)

--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -908,7 +908,6 @@ func (s *ServerCommand) addAuthProviders(authenticator *auth.Service) error {
 				ClientID:     s.Auth.Apple.CID,
 				TeamID:       s.Auth.Apple.TID,
 				KeyID:        s.Auth.Apple.KID,
-				ResponseMode: "query", // default is form_post which wouldn't work here
 			},
 			provider.LoadApplePrivateKeyFromFile(s.Auth.Apple.PrivateKeyFilePath),
 		)

--- a/site/src/docs/configuration/authorization/index.md
+++ b/site/src/docs/configuration/authorization/index.md
@@ -9,16 +9,16 @@ Authentication is handled by external providers. You should set up OAuth2 for at
 ### Apple
 
 1. Log in [to the developer account](https://developer.apple.com/account).
-1. If you don't have an App ID yet, [create one](https://developer.apple.com/account/resources/identifiers/add/bundleId). Later on, you'll need **TeamID**, which is an "App ID Prefix" value.
-1. Enable the "Sign in with Apple" capability for your App ID in [the Certificates, Identifiers & Profiles](https://developer.apple.com/account/resources/identifiers/list) section.
-1. Create [Service ID](https://developer.apple.com/account/resources/identifiers/list/serviceId) and bind with App ID from the previous step. Apple will display the description field value to end-users on sign-in. You'll need that service **Identifier as a ClientID** later on.
-1. Configure "Sign in with Apple" for created Service ID. Add the domain where you will use that auth to "Domains and subdomains" and its main page URL (like `https://example.com/` to "Return URLs".
-1. Register a [New Key](https://developer.apple.com/account/resources/authkeys/list) (**private key**) for the "Sign in with Apple" feature and download it, you'll need to put it to `/srv/var/apple.p8` path inside the container. Also, write down the private **Key ID**.
-1. Add your Remark42 domain name and sender email in the Certificates, Identifiers & Profiles >> [More](https://developer.apple.com/account/resources/services/configure) section as a new Email Source.
+2. If you don't have an App ID yet, [create one](https://developer.apple.com/account/resources/identifiers/add/bundleId). Later on, you'll need **TeamID**, which is an "App ID Prefix" value.
+3. Enable the "Sign in with Apple" capability for your App ID in [the Certificates, Identifiers & Profiles](https://developer.apple.com/account/resources/identifiers/list) section.
+4. Create [Service ID](https://developer.apple.com/account/resources/identifiers/list/serviceId) and bind with App ID from the previous step. Apple will display the description field value to end-users on sign-in. You'll need that service **Identifier as a ClientID** later on.
+5. Configure "Sign in with Apple" for created Service ID. Add the domain where you will use that auth to "Domains and subdomains" and its Return URLs (like `https://example.com/auth/apple/callback` to "Return URLs".
+6. Register a [New Key](https://developer.apple.com/account/resources/authkeys/list) (**private key**) for the "Sign in with Apple" feature and download it, you'll need to put it to `/srv/var/apple.p8` path inside the container. Also, write down the private **Key ID**.
+7. Add your Remark42 domain name and sender email in the Certificates, Identifiers & Profiles >> [More](https://developer.apple.com/account/resources/services/configure) section as a new Email Source.
 
 After completing the previous steps, you can configure the Apple auth provider. You'll need to set the following environment variables:
 
-- `AUTH_APPLE_CID` (**required**) - Client ID
+- `AUTH_APPLE_CID` (**required**) - Client ID (App ID or Services ID)
 - `AUTH_APPLE_TID` (**required**) - Team ID
 - `AUTH_APPLE_KID` (**required**) - Private Key ID
 - `AUTH_APPLE_PRIVATE_KEY_FILEPATH` (default `/srv/var/apple.p8`) - Private key file location

--- a/site/src/docs/configuration/authorization/index.md
+++ b/site/src/docs/configuration/authorization/index.md
@@ -9,12 +9,12 @@ Authentication is handled by external providers. You should set up OAuth2 for at
 ### Apple
 
 1. Log in [to the developer account](https://developer.apple.com/account).
-2. If you don't have an App ID yet, [create one](https://developer.apple.com/account/resources/identifiers/add/bundleId). Later on, you'll need **TeamID**, which is an "App ID Prefix" value.
-3. Enable the "Sign in with Apple" capability for your App ID in [the Certificates, Identifiers & Profiles](https://developer.apple.com/account/resources/identifiers/list) section.
-4. Create [Service ID](https://developer.apple.com/account/resources/identifiers/list/serviceId) and bind with App ID from the previous step. Apple will display the description field value to end-users on sign-in. You'll need that service **Identifier as a ClientID** later on.
-5. Configure "Sign in with Apple" for created Service ID. Add the domain where you will use that auth to "Domains and subdomains" and its Return URLs (like `https://example.com/auth/apple/callback` to "Return URLs".
-6. Register a [New Key](https://developer.apple.com/account/resources/authkeys/list) (**private key**) for the "Sign in with Apple" feature and download it, you'll need to put it to `/srv/var/apple.p8` path inside the container. Also, write down the private **Key ID**.
-7. Add your Remark42 domain name and sender email in the Certificates, Identifiers & Profiles >> [More](https://developer.apple.com/account/resources/services/configure) section as a new Email Source.
+1. If you don't have an App ID yet, [create one](https://developer.apple.com/account/resources/identifiers/add/bundleId). Later on, you'll need **TeamID**, which is an "App ID Prefix" value.
+1. Enable the "Sign in with Apple" capability for your App ID in [the Certificates, Identifiers & Profiles](https://developer.apple.com/account/resources/identifiers/list) section.
+1. Create [Service ID](https://developer.apple.com/account/resources/identifiers/list/serviceId) and bind with App ID from the previous step. Apple will display the description field value to end-users on sign-in. You'll need that service **Identifier as a ClientID** later on.
+1. Configure "Sign in with Apple" for created Service ID. Add the domain where you will use that auth to "Domains and subdomains" and its Return URLs (like `https://example.com/auth/apple/callback` to "Return URLs".
+1. Register a [New Key](https://developer.apple.com/account/resources/authkeys/list) (**private key**) for the "Sign in with Apple" feature and download it, you'll need to put it to `/srv/var/apple.p8` path inside the container. Also, write down the private **Key ID**.
+1. Add your Remark42 domain name and sender email in the Certificates, Identifiers & Profiles >> [More](https://developer.apple.com/account/resources/services/configure) section as a new Email Source.
 
 After completing the previous steps, you can configure the Apple auth provider. You'll need to set the following environment variables:
 

--- a/site/src/docs/configuration/parameters/index.md
+++ b/site/src/docs/configuration/parameters/index.md
@@ -81,10 +81,10 @@ services:
 | auth.ttl.cookie                | AUTH_TTL_COOKIE                | `200h`                  | cookie TTL                                               |
 | auth.send-jwt-header           | AUTH_SEND_JWT_HEADER           | `false`                 | send JWT as a header instead of a cookie                 |
 | auth.same-site                 | AUTH_SAME_SITE                 | `default`               | set same site policy for cookies (`default`, `none`, `lax` or `strict`) |
-| auth.apple.cid                 | AUTH_APPLE_CID                 |                         | Apple client ID                                          |
+| auth.apple.cid                 | AUTH_APPLE_CID                 |                         | Apple client ID (App ID or Services ID)                  |
 | auth.apple.tid                 | AUTH_APPLE_TID                 |                         | Apple service ID                                         |
-| auth.apple.kid                 | AUTH_APPLE_KID                 |                         | Private key ID                                           |
-| auth.apple.private-key-filepath | AUTH_APPLE_PRIVATE_KEY_FILEPATH | `/srv/var/apple.p8`       | Private key file location                                |
+| auth.apple.kid                 | AUTH_APPLE_KID                 |                         | Apple Private key ID                                     |
+| auth.apple.private-key-filepath | AUTH_APPLE_PRIVATE_KEY_FILEPATH | `/srv/var/apple.p8`       | Apple Private key file location                          |
 | auth.google.cid                | AUTH_GOOGLE_CID                |                         | Google OAuth client ID                                   |
 | auth.google.csec               | AUTH_GOOGLE_CSEC               |                         | Google OAuth client secret                               |
 | auth.facebook.cid              | AUTH_FACEBOOK_CID              |                         | Facebook OAuth client ID                                 |


### PR DESCRIPTION
As mentioned in #1789, Apple login was broken in #1617.

I removed the problematic lines, recompiled a docker image, and confirmed the bug was indeed caused by the wrong `ResponseMode` params.

In addition, I've also improved some sections of docs about how to configure credentials used by Apple integration. One thing worth mentioning is that the term "Client ID" used by remark42 does not appear in Apple's developer dashboard but is used in [some documentation](https://developer.apple.com/documentation/sign_in_with_apple/request_an_authorization_to_the_sign_in_with_apple_server), which can cause some confusion. Therefore, I added an annotation indicating that the "Client ID" can be either "App ID" or "Service ID".

resolves #1789