### PR TITLE
Move gcc installation before backend files addition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,14 +54,14 @@ ARG GIT_BRANCH
 ARG SKIP_BACKEND_TEST
 ARG BACKEND_TEST_TIMEOUT
 
+# install gcc in order to be able to go test package with -race
+RUN apk --no-cache add gcc libc-dev
+
 ADD backend /build/backend
 # to embed the frontend files statically into Remark42 binary
 COPY --from=build-frontend /srv/frontend/apps/remark42/public/ /build/backend/app/cmd/web/
 RUN find /build/backend/app/cmd/web/ -regex '.*\.\(html\|js\|mjs\)$' -print -exec sed -i "s|{% REMARK_URL %}|http://127.0.0.1:8080|g" {} \;
 WORKDIR /build/backend
-
-# install gcc in order to be able to go test package with -race
-RUN apk --no-cache add gcc libc-dev
 
 RUN echo go version: `go version`
 


### PR DESCRIPTION
This allows to not reinstall apk files when backend files change and the new image is built.