### PR TITLE
Fix CSP img-src directive to allow everything without proxy

### DIFF
--- a/backend/app/rest/api/rest.go
+++ b/backend/app/rest/api/rest.go
@@ -624,9 +624,9 @@ func cacheControl(expiration time.Duration, version string) func(http.Handler) h
 func securityHeadersMiddleware(imageProxyEnabled bool, allowedAncestors []string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			imgSrc := "'self'"
+			imgSrc := "*"
 			if imageProxyEnabled {
-				imgSrc = "*"
+				imgSrc = "'self'"
 			}
 			frameAncestors := "*"
 			if len(allowedAncestors) > 0 {


### PR DESCRIPTION
Change the default img-src value to "*" and sets it to "'self'" when image proxy is enabled. The previous state was inversion of this logic which was wrong.