### PR TITLE
Do not fail if frontend pre-commit hook fails

### DIFF
--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -1,6 +1,4 @@
 # .husky/pre-commit
 
 cd frontend
-nvm use || true
-npm i || true
 pnpm lint-staged || true


### PR DESCRIPTION
Without this, installing and then deleting frontend dependencies leaves the developer unable to commit anything.