### PR TITLE
Fix fetch module import so that latest release version would be shown on website

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -10,7 +10,7 @@
 		"node": ">=20.11.1",
 		"yarn": ">=1.22"
 	},
-  "packageManager": "yarn@1.22.22",
+	"packageManager": "yarn@1.22.22",
 	"scripts": {
 		"start": "npm-run-all dev",
 		"dev": "npm-run-all -l clean build:css -p dev:css dev:11ty",

--- a/site/src/data/github.js
+++ b/site/src/data/github.js
@@ -6,7 +6,7 @@ module.exports = async function getLatestReleaseVersion() {
 		return currentData
 	}
 	try {
-		const fetch = await import('node-fetch')
+		const fetch = (await import('node-fetch')).default;
 		const res = await fetch(
 			'https://api.github.com/repos/umputun/remark42/releases'
 		)


### PR DESCRIPTION
Now:

<img width="1202" alt="image" src="https://github.com/user-attachments/assets/b7f22f06-cf01-4071-997a-60b036d95cfe">

After this commit:

<img width="1181" alt="image" src="https://github.com/user-attachments/assets/4e0c9f48-72e3-4b13-8865-1726f634f07e">
