### PR TITLE
Update docker-compose.yml with example for local reverse proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,10 @@ services:
     #  - "80:8080"
     #  - "443:8443"
 
+    # uncomment to expose to reverse proxy running on the same host but not in docker
+    #ports:
+    #  - "127.0.0.1:8080:8080"
+
     environment:
       - REMARK_URL
       - SECRET


### PR DESCRIPTION
In discussion #1852 I realised that we don't have example with reverse proxy running outside of docker, this commit fixes that.