### PR TITLE
Stop updating examples via dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,13 +20,6 @@ updates:
     groups:
       "Go modules updates":
         dependency-type: "production"
-  - package-ecosystem: "gomod"
-    directory: "/backend/_example/memory_store"
-    schedule:
-      interval: "monthly"
-    groups:
-      "Go modules updates":
-        dependency-type: "production"
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:


### PR DESCRIPTION
Examples should be updated alongside the backend directory and it makes no sense to have separate update PRs for it.