### PR TITLE
Migrate Docker images from Docker Hub to GitHub Container Registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ bin:
 	docker rm -f remark42.bin
 
 docker:
-	DOCKER_BUILDKIT=1 docker build -t umputun/remark42 --build-arg GITHUB_REF=$(GITHUB_REF) --build-arg GITHUB_SHA=$(GITHUB_SHA) \
+	DOCKER_BUILDKIT=1 docker build -t umputun/remark42 -t ghcr.io/umputun/remark42 --build-arg GITHUB_REF=$(GITHUB_REF) --build-arg GITHUB_SHA=$(GITHUB_SHA) \
 		--build-arg CI=true --build-arg SKIP_FRONTEND_TEST=true --build-arg SKIP_BACKEND_TEST=true .
 
 dockerx:

--- a/backend/_example/memory_store/compose-dev-memstore.yml
+++ b/backend/_example/memory_store/compose-dev-memstore.yml
@@ -11,7 +11,7 @@ services:
       args:
         - SKIP_BACKEND_TEST=true
         - SKIP_FRONTEND_TEST=true
-    image: umputun/remark42:dev
+    image: ghcr.io/umputun/remark42:dev
     container_name: "remark42-dev"
     hostname: "remark42-dev"
     restart: always

--- a/compose-dev-backend.yml
+++ b/compose-dev-backend.yml
@@ -18,7 +18,7 @@ services:
         - CI
         - GITHUB_REF
         - GITHUB_SHA
-    image: umputun/remark42:dev
+    image: ghcr.io/umputun/remark42:dev
     container_name: "remark42-dev"
     hostname: "remark42-dev"
 

--- a/compose-dev-frontend.yml
+++ b/compose-dev-frontend.yml
@@ -16,7 +16,7 @@ services:
         - SKIP_FRONTEND_BUILD=true
         # - NODE_ENV=development
 
-    image: umputun/remark42:dev
+    image: ghcr.io/umputun/remark42:dev
     container_name: "remark42-dev"
     hostname: "remark42-dev"
 

--- a/compose-e2e-test.yml
+++ b/compose-e2e-test.yml
@@ -10,7 +10,7 @@ services:
         - SKIP_BACKEND_TEST=true
         - SKIP_FRONTEND_TEST=true
 
-    image: umputun/remark42:dev
+    image: ghcr.io/umputun/remark42:dev
     container_name: "remark42"
 
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     # remove the next line in case you want to use this Docker Compose file separately
     # as otherwise it would complain for absence of Dockerfile
     build: .
-    image: umputun/remark42:latest
+    image: ghcr.io/umputun/remark42:latest
     container_name: "remark42"
     hostname: "remark42"
     restart: always

--- a/site/src/docs/configuration/parameters/index.md
+++ b/site/src/docs/configuration/parameters/index.md
@@ -17,7 +17,7 @@ version: "2"
 
 services:
   remark42:
-    image: umputun/remark42:latest
+    image: ghcr.io/umputun/remark42:latest
     restart: always
     container_name: "remark42"
     environment:

--- a/site/src/docs/contributing/backend/index.md
+++ b/site/src/docs/contributing/backend/index.md
@@ -36,8 +36,8 @@ In order to have working Remark42 installation you need once to copy frontend st
 
 ```shell
 # frontend files
-docker pull umputun/remark42:master
-docker create -ti --name remark42files umputun/remark42:master sh
+docker pull ghcr.io/umputun/remark42:master
+docker create -ti --name remark42files ghcr.io/umputun/remark42:master sh
 docker cp remark42files:/srv/web/ ./backend/app/cmd/
 docker rm -f remark42files
 # fix frontend files to point to the right URL

--- a/site/src/docs/getting-started/installation/index.md
+++ b/site/src/docs/getting-started/installation/index.md
@@ -76,5 +76,5 @@ To verify if Remark42 has been properly installed, check a demo page at `${REMAR
 
 ### Build from the source
 
-- to build Docker container - `make docker`. This command will produce container `umputun/remark42`
+- to build Docker container - `make docker`. This command will produce container `ghcr.io/umputun/remark42`
 - to build a single binary for direct execution - `make OS=<linux|windows|darwin> ARCH=<amd64|386>`. This step will produce an executable `remark42` file with everything embedded

--- a/site/src/docs/manuals/kubernetes/index.md
+++ b/site/src/docs/manuals/kubernetes/index.md
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
         - name: remark42
-          image: umputun/remark42:v1.8.1
+          image: ghcr.io/umputun/remark42:v1.14.0
           ports:
             # http:
             - containerPort: 8080

--- a/site/src/docs/manuals/reproxy/index.md
+++ b/site/src/docs/manuals/reproxy/index.md
@@ -43,7 +43,7 @@ services:
       - ./var/logs:/srv/var/logs
 
   remark42:
-    image: umputun/remark42:master
+    image: ghcr.io/umputun/remark42:master
     container_name: "remark42"
     hostname: "remark42"
     restart: always

--- a/site/src/docs/manuals/subdomain/index.md
+++ b/site/src/docs/manuals/subdomain/index.md
@@ -25,7 +25,7 @@ Example `docker-compose.yml`:
 version: "2"
 services:
   remark42:
-    image: umputun/remark42:latest
+    image: ghcr.io/umputun/remark42:latest
     container_name: remark42
     restart: always
     environment:


### PR DESCRIPTION
This commit replaces all references to `umputun/remark42` Docker images on Docker Hub with `ghcr.io/umputun/remark42` from the GitHub Container Registry. It updates various Docker Compose files, documentation, and the Makefile to use the new image location. It also updates the kubernetes example to use the latest version.

Docker Hub is going to kill free pulls for too long by now.