### PR TITLE
Automatic fix of errors reported by golangci-lint v2

### DIFF
--- a/backend/app/cmd/cleanup.go
+++ b/backend/app/cmd/cleanup.go
@@ -77,7 +77,7 @@ func (cc *CleanupCommand) procSpam(comments []store.Comment) int {
 					log.Printf("[WARN] can't remove comment, %v", err)
 				}
 			}
-			comment.Text = strings.Replace(comment.Text, "\n", " ", -1)
+			comment.Text = strings.ReplaceAll(comment.Text, "\n", " ")
 			log.Printf("[SPAM] %+v [%.0f%%]", comment, score)
 		}
 	}

--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -1357,7 +1357,7 @@ func newAuthRefreshCache() *authRefreshCache {
 
 // Get implements cache getter with key converted to string
 func (c *authRefreshCache) Get(key string) (token.Claims, bool) {
-	return c.LoadingCache.Peek(key)
+	return c.Peek(key)
 }
 
 // Set implements cache setter with key converted to string

--- a/backend/app/migrator/disqus.go
+++ b/backend/app/migrator/disqus.go
@@ -175,7 +175,7 @@ func (d *Disqus) convert(r io.Reader, siteID string) (ch chan store.Comment) {
 
 func (*Disqus) cleanText(text string) string {
 	text = strings.TrimSpace(text)
-	text = strings.Replace(text, "\n", "", -1)
-	text = strings.Replace(text, "\t", "", -1)
+	text = strings.ReplaceAll(text, "\n", "")
+	text = strings.ReplaceAll(text, "\t", "")
 	return text
 }

--- a/backend/app/notify/email_test.go
+++ b/backend/app/notify/email_test.go
@@ -34,7 +34,7 @@ func TestEmailNew(t *testing.T) {
 	assert.NotNil(t, email, "email returned")
 
 	assert.NotNil(t, email.msgTmpl, "e.template is set")
-	assert.Equal(t, emailParams.From, email.EmailParams.From, "emailParams.From unchanged after creation")
+	assert.Equal(t, emailParams.From, email.From, "emailParams.From unchanged after creation")
 	if smtpParams.TimeOut == 0 {
 		assert.Equal(t, defaultEmailTimeout, email.TimeOut, "empty emailParams.TimeOut changed to default")
 	} else {

--- a/backend/app/rest/api/admin_test.go
+++ b/backend/app/rest/api/admin_test.go
@@ -835,7 +835,7 @@ func TestAdmin_DeleteMeRequestFailed(t *testing.T) {
 
 	// try with wrong audience
 	badClaimsMultipleAudience := claims
-	badClaimsMultipleAudience.RegisteredClaims.Audience = jwt.ClaimStrings{"remark42", "something else"}
+	badClaimsMultipleAudience.Audience = jwt.ClaimStrings{"remark42", "something else"}
 	tkn, err = srv.Authenticator.TokenService().Token(badClaimsMultipleAudience)
 	assert.NoError(t, err)
 	req, err = http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/admin/deleteme?token=%s", ts.URL, tkn), http.NoBody)
@@ -848,7 +848,7 @@ func TestAdmin_DeleteMeRequestFailed(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, resp.Body.Close())
 	assert.Contains(t, string(b), "can't process token, claims.Audience expected to be a single element but it's not")
-	badClaimsMultipleAudience.RegisteredClaims.Audience = jwt.ClaimStrings{"remark42"}
+	badClaimsMultipleAudience.Audience = jwt.ClaimStrings{"remark42"}
 }
 
 func TestAdmin_GetUserInfo(t *testing.T) {

--- a/backend/app/rest/api/migrator.go
+++ b/backend/app/rest/api/migrator.go
@@ -110,10 +110,8 @@ func (m *Migrator) waitCtrl(w http.ResponseWriter, r *http.Request) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeOut)
 	defer cancel()
-	for {
-		if !m.isBusy(siteID) {
-			break
-		}
+	for m.isBusy(siteID) {
+
 		select {
 		case <-ctx.Done():
 			render.Status(r, http.StatusGatewayTimeout)

--- a/backend/app/rest/api/migrator_test.go
+++ b/backend/app/rest/api/migrator_test.go
@@ -123,7 +123,7 @@ func TestMigrator_ImportFromWP(t *testing.T) {
 	ts, _, teardown := startupT(t)
 	defer teardown()
 
-	r := strings.NewReader(strings.Replace(xmlTestWP, "'", "`", -1))
+	r := strings.NewReader(strings.ReplaceAll(xmlTestWP, "'", "`"))
 
 	client := &http.Client{Timeout: 1 * time.Second}
 	defer client.CloseIdleConnections()

--- a/backend/app/rest/api/rest_public.go
+++ b/backend/app/rest/api/rest_public.go
@@ -129,8 +129,8 @@ func (s *public) findCommentsCtrl(w http.ResponseWriter, r *http.Request) {
 		switch format {
 		case "tree":
 			withInfo := treeWithInfo{Tree: service.MakeTree(comments, sort, limit, offsetID), Info: commentsInfo}
-			withInfo.Info.CountLeft = withInfo.Tree.CountLeft()
-			withInfo.Info.LastComment = withInfo.Tree.LastComment()
+			withInfo.Info.CountLeft = withInfo.CountLeft()
+			withInfo.Info.LastComment = withInfo.LastComment()
 			if withInfo.Nodes == nil { // eliminate json nil serialization
 				withInfo.Nodes = []*service.Node{}
 			}

--- a/backend/app/rest/api/rest_public_test.go
+++ b/backend/app/rest/api/rest_public_test.go
@@ -141,9 +141,9 @@ srv, ts := prep(t)
 }
 BKT
 `
-	text = strings.Replace(text, "BKT", "```", -1)
+	text = strings.ReplaceAll(text, "BKT", "```")
 	j := fmt.Sprintf(`{"text": %q, "locator":{"url": "https://radio-t.com/blah1", "site": "radio-t"}}`, text)
-	j = strings.Replace(j, "\n", "\\n", -1)
+	j = strings.ReplaceAll(j, "\n", "\\n")
 
 	resp, err := post(t, ts.URL+"/api/v1/preview", j)
 	assert.NoError(t, err)
@@ -169,9 +169,9 @@ func TestRest_PreviewCode(t *testing.T) {
 func main(aa string) int {return 0}
 BKT
 `
-	text = strings.Replace(text, "BKT", "```", -1)
+	text = strings.ReplaceAll(text, "BKT", "```")
 	j := fmt.Sprintf(`{"text": %q, "locator":{"url": "https://radio-t.com/blah1", "site": "radio-t"}}`, text)
-	j = strings.Replace(j, "\n", "\\n", -1)
+	j = strings.ReplaceAll(j, "\n", "\\n")
 
 	resp, err := post(t, ts.URL+"/api/v1/preview", j)
 	assert.NoError(t, err)

--- a/backend/app/rest/api/rss_test.go
+++ b/backend/app/rest/api/rss_test.go
@@ -271,10 +271,7 @@ func TestServer_RssReplies(t *testing.T) {
 }
 
 func waitOnSecChange() {
-	for {
-		if time.Now().Nanosecond() < 100000000 {
-			break
-		}
+	for time.Now().Nanosecond() >= 100000000 {
 		time.Sleep(10 * time.Nanosecond)
 	}
 }
@@ -283,11 +280,11 @@ func waitOnSecChange() {
 func cleanRssFormatting(expected, actual string) (cleanExp, cleanAct string) {
 	reSpaces := regexp.MustCompile(`[\s\p{Zs}]{2,}`)
 
-	expected = strings.Replace(expected, "\n", " ", -1)
-	expected = strings.Replace(expected, "\t", " ", -1)
+	expected = strings.ReplaceAll(expected, "\n", " ")
+	expected = strings.ReplaceAll(expected, "\t", " ")
 	expected = reSpaces.ReplaceAllString(expected, " ")
 
-	actual = strings.Replace(actual, "\n", " ", -1)
+	actual = strings.ReplaceAll(actual, "\n", " ")
 	actual = reSpaces.ReplaceAllString(actual, " ")
 	return expected, actual
 }

--- a/backend/app/rest/proxy/image.go
+++ b/backend/app/rest/proxy/image.go
@@ -72,7 +72,7 @@ func (p Image) replace(commentHTML string, imgs []string) string {
 	for _, img := range imgs {
 		encodedImgURL := base64.URLEncoding.EncodeToString([]byte(img))
 		resImgURL := p.RemarkURL + p.RoutePath + "?src=" + encodedImgURL
-		commentHTML = strings.Replace(commentHTML, img, resImgURL, -1)
+		commentHTML = strings.ReplaceAll(commentHTML, img, resImgURL)
 	}
 
 	return commentHTML

--- a/backend/app/store/comment.go
+++ b/backend/app/store/comment.go
@@ -144,7 +144,7 @@ func (c *Comment) Snippet(limit int) string {
 	if limit <= 0 {
 		limit = snippetLen
 	}
-	cleanText := strings.Replace(c.Text, "\n", " ", -1)
+	cleanText := strings.ReplaceAll(c.Text, "\n", " ")
 	size := len([]rune(cleanText))
 	if size < limit {
 		return cleanText
@@ -179,9 +179,9 @@ func (c *Comment) SanitizeAsURL(inp string) string {
 
 func (c *Comment) escapeHTMLWithSome(inp string) string {
 	res := template.HTMLEscapeString(inp)
-	res = strings.Replace(res, "&amp;", "&", -1)
-	res = strings.Replace(res, "&#34;", "\"", -1)
-	res = strings.Replace(res, "&#39;", "'", -1)
+	res = strings.ReplaceAll(res, "&amp;", "&")
+	res = strings.ReplaceAll(res, "&#34;", "\"")
+	res = strings.ReplaceAll(res, "&#39;", "'")
 	return res
 }
 

--- a/backend/app/store/formatter.go
+++ b/backend/app/store/formatter.go
@@ -99,7 +99,7 @@ func (f *CommentFormatter) unEscape(txt string) (res string) {
 	}
 	res = txt
 	for _, e := range elems {
-		res = strings.Replace(res, e.from, e.to, -1)
+		res = strings.ReplaceAll(res, e.from, e.to)
 	}
 	return res
 }

--- a/backend/app/store/service/service.go
+++ b/backend/app/store/service/service.go
@@ -659,10 +659,8 @@ func (s *DataStore) ValidateComment(c *store.Comment) error {
 	parser := bf.New(bf.WithRenderer(rend), bf.WithExtensions(bf.CommonExtensions), bf.WithExtensions(mdExt))
 	var wrongLinkError error
 	parser.Parse([]byte(c.Orig)).Walk(func(node *bf.Node, _ bool) bf.WalkStatus {
-		if len(node.LinkData.Destination) != 0 &&
-			!(strings.HasPrefix(string(node.LinkData.Destination), "http://") ||
-				strings.HasPrefix(string(node.LinkData.Destination), "https://") ||
-				strings.HasPrefix(string(node.LinkData.Destination), "mailto:")) {
+		if len(node.Destination) != 0 &&
+			(!strings.HasPrefix(string(node.Destination), "http://") && !strings.HasPrefix(string(node.Destination), "https://") && !strings.HasPrefix(string(node.Destination), "mailto:")) {
 			wrongLinkError = fmt.Errorf("links should start with mailto:, http:// or https://")
 			return bf.Terminate
 		}
@@ -981,7 +979,7 @@ func (s *DataStore) Last(siteID string, limit int, since time.Time, user store.U
 func (s *DataStore) Close() error {
 	errs := new(multierror.Error)
 	if s.repliesCache.LoadingCache != nil {
-		errs = multierror.Append(errs, s.repliesCache.LoadingCache.Close())
+		errs = multierror.Append(errs, s.repliesCache.Close())
 	}
 	if s.TitleExtractor != nil {
 		errs = multierror.Append(errs, s.TitleExtractor.Close())

--- a/backend/app/store/service/title.go
+++ b/backend/app/store/service/title.go
@@ -116,7 +116,7 @@ func (t *TitleExtractor) isTitleElement(n *html.Node) bool {
 func (t *TitleExtractor) traverse(n *html.Node) (string, bool) {
 	if t.isTitleElement(n) {
 		title := n.FirstChild.Data
-		title = strings.Replace(title, "\n", "", -1)
+		title = strings.ReplaceAll(title, "\n", "")
 		title = strings.TrimSpace(title)
 		return title, true
 	}


### PR DESCRIPTION
- Use strings.ReplaceAll
- Remove redundant internal structure names