### PR TITLE
Fix deleteme feature

### DIFF
--- a/frontend/apps/remark42/templates/deleteme.ejs
+++ b/frontend/apps/remark42/templates/deleteme.ejs
@@ -71,5 +71,6 @@
     <script>
       var remark_config = { host: '<%= htmlWebpackPlugin.options.REMARK_URL %>' };
     </script>
+    <script src="deleteme.js"></script>
   </body>
 </html>


### PR DESCRIPTION
The last step of the data deletion feature–when the admin user visits the link sent by the user requesting to delete their data–was broken due to the deleteme.js script not being loaded.