### PR TITLE
Fix login persistence with AUTH_SEND_JWT_HEADER enabled

### DIFF
--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -96,7 +96,7 @@ type ServerCommand struct {
 			Cookie time.Duration `long:"cookie" env:"COOKIE" default:"200h" description:"auth cookie TTL"`
 		} `group:"ttl" namespace:"ttl" env-namespace:"TTL"`
 
-		SendJWTHeader bool   `long:"send-jwt-header" env:"SEND_JWT_HEADER" description:"send JWT as a header instead of cookie"`
+		SendJWTHeader bool   `long:"send-jwt-header" env:"SEND_JWT_HEADER" description:"send JWT as a header instead of server-set cookie; with this enabled, frontend stores the JWT in a client-side cookie (note: increases vulnerability to XSS attacks)"`
 		SameSite      string `long:"same-site" env:"SAME_SITE" description:"set same site policy for cookies" choice:"default" choice:"none" choice:"lax" choice:"strict" default:"default"` // nolint
 
 		Apple     AppleGroup `group:"apple" namespace:"apple" env-namespace:"APPLE" description:"Apple OAuth"`

--- a/frontend/apps/remark42/app/common/cookies.ts
+++ b/frontend/apps/remark42/app/common/cookies.ts
@@ -8,15 +8,14 @@ interface CookieOptions {
   path?: string;
   domain?: string;
   secure?: boolean;
+  sameSite?: 'Strict' | 'Lax' | 'None';
 }
 
 export function setCookie(name: string, value: string, options: CookieOptions = {}) {
   if (options.expires) {
+    // Convert number (seconds) or Date to UTC string
     if (typeof options.expires === 'number') {
-      const d = new Date();
-      d.setTime(d.getTime() + options.expires * 1000);
-      options.expires = d;
-      options.expires = options.expires.toUTCString();
+      options.expires = new Date(Date.now() + options.expires * 1000).toUTCString();
     } else if (options.expires instanceof Date) {
       options.expires = options.expires.toUTCString();
     }
@@ -27,13 +26,61 @@ export function setCookie(name: string, value: string, options: CookieOptions = 
   let updatedCookie = `${name}=${value}`;
 
   for (const [key, value] of Object.entries(options)) {
-    updatedCookie += `; ${key}`;
-    if (value !== true) {
-      updatedCookie += `=${value}`;
+    // For boolean attributes like 'secure', only add them if true, otherwise skip
+    if (value === true) {
+      updatedCookie += `; ${key}`;
+    }
+    if (typeof value !== 'boolean') {
+      updatedCookie += `; ${key}=${value}`;
     }
   }
 
   document.cookie = updatedCookie;
+}
+
+/**
+ * Sets a cookie with enhanced security options for authentication
+ * @param name The name of the cookie
+ * @param value The value to set
+ * @param options Additional cookie options
+ */
+export function setAuthCookie(name: string, value: string, options: CookieOptions = {}) {
+  const isSecure = window.location.protocol === 'https:';
+  const cookiePrefix = isSecure ? '__Host-' : '';
+
+  // Default options for auth cookies with strong security
+  const authOptions: CookieOptions = {
+    path: '/',
+    sameSite: 'Strict',
+    secure: isSecure,
+    ...options,
+  };
+
+  setCookie(`${cookiePrefix}${name}`, value, authOptions);
+}
+
+/**
+ * Clears an authentication cookie by setting its expiration to the past
+ * @param name The name of the cookie to clear
+ */
+export function clearAuthCookie(name: string) {
+  const isSecure = window.location.protocol === 'https:';
+  const cookiePrefix = isSecure ? '__Host-' : '';
+
+  setCookie(`${cookiePrefix}${name}`, '', {
+    path: '/',
+    secure: isSecure,
+    expires: new Date(0), // Set to epoch time to expire immediately
+  });
+
+  // Also try to clear the non-prefixed version to be thorough
+  if (cookiePrefix) {
+    setCookie(name, '', {
+      path: '/',
+      secure: isSecure,
+      expires: new Date(0),
+    });
+  }
 }
 
 export function getCookie(name: string) {

--- a/frontend/apps/remark42/app/common/fetcher.ts
+++ b/frontend/apps/remark42/app/common/fetcher.ts
@@ -1,16 +1,43 @@
 import { errorMessages, RequestError } from 'utils/errorUtils';
 
 import { siteId } from './settings';
-import { getCookie } from './cookies';
+import { getCookie, setAuthCookie, clearAuthCookie } from './cookies';
 import { StaticStore } from './static-store';
 import { BASE_URL, API_BASE } from './constants';
 
 /** Header name for JWT token */
 export const JWT_HEADER = 'X-JWT';
+/** Cookie name for JWT token when using AUTH_SEND_JWT_HEADER */
+export const JWT_COOKIE_NAME = 'JWT';
 /** Header name for XSRF token */
 export const XSRF_HEADER = 'X-XSRF-TOKEN';
 /** Cookie field with XSRF token */
 export const XSRF_COOKIE = 'XSRF-TOKEN';
+/**
+ * Cookie TTL in seconds - matches backend's auth.ttl.cookie default of 200 hours
+ * The JWT token itself expires in 5 minutes, but the cookie persists longer
+ * to match server-side behavior when not using AUTH_SEND_JWT_HEADER
+ */
+export const AUTH_COOKIE_TTL_SECONDS = 200 * 60 * 60;
+
+/**
+ * Safely parses JWT payload with proper base64url handling
+ * @param token - JWT token string
+ * @returns parsed payload or null if parsing fails
+ */
+function parseJwtPayload(token: string): Record<string, unknown> | null {
+  try {
+    const base64Url = token.split('.')[1];
+    if (!base64Url) return null;
+
+    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+    const rawPayload = window.atob(base64);
+    return JSON.parse(rawPayload);
+  } catch (e) {
+    console.error('Failed to parse JWT payload', e);
+    return null;
+  }
+}
 
 type QueryParams = Record<string, string | number | undefined>;
 type Payload = BodyInit | Record<string, unknown> | null;
@@ -74,10 +101,30 @@ const createFetcher = (baseUrl: string = ''): Methods => {
       // backend could update jwt in any time. so, we should handle it
       if (res.headers.has(JWT_HEADER)) {
         activeJwtToken = res.headers.get(JWT_HEADER) as string;
+
+        // Store the JWT token in cookies for persistence across page reloads
+        try {
+          const payload = parseJwtPayload(activeJwtToken);
+          if (payload && payload.jti) {
+            // Set XSRF cookie with the JWT ID using enhanced security
+            setAuthCookie(XSRF_COOKIE, payload.jti as string, {
+              expires: AUTH_COOKIE_TTL_SECONDS,
+            });
+
+            // Store the JWT in cookie for persistence with enhanced security
+            setAuthCookie(JWT_COOKIE_NAME, activeJwtToken, {
+              expires: AUTH_COOKIE_TTL_SECONDS,
+            });
+          }
+        } catch (e) {
+          console.error('Failed to process JWT token', e);
+        }
       }
 
       if ([401, 403].includes(res.status)) {
         activeJwtToken = undefined;
+        clearAuthCookie(JWT_COOKIE_NAME);
+        clearAuthCookie(XSRF_COOKIE);
       }
 
       if (res.status >= 400) {

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -4994,7 +4994,7 @@ packages:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /chrome-trace-event@1.0.3:
@@ -6986,14 +6986,6 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
 
-  /fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -8225,7 +8217,7 @@ packages:
       micromatch: 4.0.5
       walker: 1.0.8
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /jest-haste-map@28.1.3:
@@ -8244,7 +8236,7 @@ packages:
       micromatch: 4.0.5
       walker: 1.0.8
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /jest-leak-detector@28.1.3:

--- a/site/src/docs/configuration/parameters/index.md
+++ b/site/src/docs/configuration/parameters/index.md
@@ -79,7 +79,7 @@ services:
 | image.resize-height            | IMAGE_RESIZE_HEIGHT            | `900`                   | height of a resized image                                |
 | auth.ttl.jwt                   | AUTH_TTL_JWT                   | `5m`                    | JWT TTL                                                  |
 | auth.ttl.cookie                | AUTH_TTL_COOKIE                | `200h`                  | cookie TTL                                               |
-| auth.send-jwt-header           | AUTH_SEND_JWT_HEADER           | `false`                 | send JWT as a header instead of a cookie                 |
+| auth.send-jwt-header           | AUTH_SEND_JWT_HEADER           | `false`                 | send JWT as a header instead of a server-set cookie; with this enabled, frontend stores the JWT in a client-side cookie. [See security considerations](#security-considerations-for-auth.send-jwt-header). |
 | auth.same-site                 | AUTH_SAME_SITE                 | `default`               | set same site policy for cookies (`default`, `none`, `lax` or `strict`) |
 | auth.apple.cid                 | AUTH_APPLE_CID                 |                         | Apple client ID (App ID or Services ID)                  |
 | auth.apple.tid                 | AUTH_APPLE_TID                 |                         | Apple service ID                                         |
@@ -168,6 +168,23 @@ services:
 - command-line parameters are long-form `--<key>=value`, i.e., `--site=https://demo.remark42.com`
 - _multi_ parameters separated by `,` in the environment or repeated with command-line keys, like `--site=s1 --site=s2 ...`
 - _required_ parameters have to be presented in the environment or provided in the command-line
+
+### Security Considerations for auth.send-jwt-header
+
+When `auth.send-jwt-header=true` is enabled:
+
+- **Security Impact**: JWT tokens are stored in client-accessible cookies that can be accessed by JavaScript
+- **Vulnerability**: This increases vulnerability to XSS attacks compared to server-set HttpOnly cookies
+- **Implementation Mitigations**:
+  - SameSite=Strict cookies to prevent CSRF attacks
+  - Secure flag automatically added on HTTPS connections
+  - __Host- prefix added on HTTPS to prevent subdomain attacks
+  - Double Submit Cookie pattern with XSRF token matching the JWT ID
+
+This configuration should only be used when:
+1. You need cross-domain authentication support
+2. You understand and accept the increased XSS risk
+3. You have implemented strong XSS protections on your site
 
 ### Deprecated parameters
 


### PR DESCRIPTION
## Summary
- When using AUTH_SEND_JWT_HEADER=true, the JWT token in header needed to be persisted to maintain login after page reload
- The frontend now properly handles JWT tokens received in headers by:
  - Storing them in client-side cookies with the name 'JWT' to match what backend expects
  - Extracting and storing the JWT ID as XSRF token in 'XSRF-TOKEN' cookie
  - Setting cookies with Secure flag when on HTTPS connections
- Documentation has been updated to clarify that with this flag enabled, the frontend stores the JWT in a client-side cookie

First part of the fix for #1877, pre-requirement for fixing OAUTH login in #241

## Technical Details
The issue was occurring because the JWT token was received in X-JWT header with AUTH_SEND_JWT_HEADER=true, but the token was only stored in memory. When the page reloaded, the token would be lost, causing users to be logged out.

This implementation allows the frontend to handle authentication consistently regardless of whether AUTH_SEND_JWT_HEADER is enabled or not, making it transparent to users.

## Demo

Before:

https://github.com/user-attachments/assets/7990ca72-5e7c-4dcf-aacc-ad9b6b9d3aa7

After:

https://github.com/user-attachments/assets/c9d7bbf0-a83c-4881-be36-a114a27a39d7

## Concerns

Stored cookie is not [HTTPOnly](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#httponly) as it's written from JS, so could be read from JS on the page as well. I thought it would be better than storing it in local storage, at least we know that the only sensitive stuff is still in the cookie.