### PR TITLE
docs: update Telegram configuration with group notification details

### DIFF
--- a/site/src/docs/configuration/telegram/index.md
+++ b/site/src/docs/configuration/telegram/index.md
@@ -48,11 +48,24 @@ To enable Telegram authentication for the users, set the variable `AUTH_TELEGRAM
 To integrate notifications about any comment on your sites with remark42 with [Telegram](https://telegram.org)
 
 1. Set `NOTIFY_ADMINS=telegram`
-2. Make [a channel](https://telegram.org/faq_channels), **add your bot as Administrator** into it and add channel ID to remark42 configuration as `NOTIFY_TELEGRAM_CHAN`
+2. Set up your notification destination and add its ID to remark42 configuration as `NOTIFY_TELEGRAM_CHAN`
 
-   - "Post messages" permission is enough for bot to be able to post messages in your channel, others are unnecessary;
-   - To obtain a public channel ID, forward any message from it to [@JsonDumpBot](https://t.me/JsonDumpBot): look for `id` in `forward_from_chat`;
-   - If you want to use a private channel or chat, use [these instructions](https://github.com/GabrielRF/telegram-id#web-channel-id) to obtain the ID.
+   Notifications can be sent to:
+   - **Channels**: Create [a channel](https://telegram.org/faq_channels) and **add your bot as Administrator**
+   - **Groups**: Create a group and add your bot to it
+   - **Individual users**: Use the user's Telegram ID
+
+   For the ID, you can use:
+   - **Public channels/groups**: Use the username without the @ symbol (e.g., `mygroup` instead of `@mygroup`)
+   - **Private channels/groups**: Use the numeric ID
+   - **Users**: Use the user's numeric Telegram ID
+
+   To obtain IDs:
+   - For public channel/group ID: Forward any message from it to [@JsonDumpBot](https://t.me/JsonDumpBot) and look for `id` in `forward_from_chat`
+   - For private channels/groups: Use [these instructions](https://github.com/GabrielRF/telegram-id#web-channel-id) or [@myidbot](https://t.me/myidbot)
+   - For user ID: Users can get their ID from [@myidbot](https://t.me/myidbot)
+
+   Note: When using channels or groups, ensure the bot has "Post messages" permission.
 
 ### Notifications for users
 


### PR DESCRIPTION
## Summary
- Added information about sending notifications to users, groups, and channels
- Documented that public group usernames can be used without @ symbol as IDs
- Clarified how to obtain IDs for different notification destinations

This addresses the question raised in discussion #1756 about using Telegram groups for notifications.