### PR TITLE
Improve GitHub Actions workflows security and performance

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -16,13 +16,18 @@ on:
       - "backend/**"
       - "!backend/scripts/**"
       - "!**.md"
+
 jobs:
   test:
     name: Test & Coverage
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: debug if needed
         run: if [[ "$DEBUG" == "true" ]]; then env; fi
@@ -53,13 +58,13 @@ jobs:
           TZ: "America/Chicago"
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: "v2.6.0"
           working-directory: backend/app
 
       - name: golangci-lint on example directory
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: "v2.6.0"
           args: --config ../../.golangci.yml

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,18 +1,6 @@
 name: build
 
 on:
-  push:
-    branches:
-    tags:
-    paths:
-      - ".github/workflows/ci-build.yml"
-      - "backend/**"
-      - "frontend/apps/**"
-      - ".dockerignore"
-      - "docker-init.sh"
-      - "Dockerfile"
-      - "!**.md"
-      - "!frontend/packages/**"
   pull_request:
     paths:
       - ".github/workflows/ci-build.yml"
@@ -23,17 +11,32 @@ on:
       - "Dockerfile"
       - "!**.md"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  # Build without pushing for PRs and non-master branches
-  build-test:
-    name: Build test (non-master)
-    if: ${{ github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/tags/') }}
-    runs-on: ubuntu-24.04-arm
+  build-images:
+    name: Validate Docker build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: expose GitHub Actions cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
 
       - name: free disk space
         run: |
@@ -44,203 +47,20 @@ jobs:
 
       - name: build docker image without pushing
         run: |
-          docker buildx build \
+          docker buildx build --load \
+              --cache-from type=local,src=/tmp/.buildx-cache \
+              --cache-to type=local,dest=/tmp/.buildx-cache-new,mode=max \
               --build-arg SKIP_BACKEND_TEST=true --build-arg SKIP_FRONTEND_TEST=true \
-              --platform linux/arm64 .
+              --platform linux/amd64 .
 
       - name: build example docker image without pushing
         run: |
-          docker buildx build \
+          docker buildx build --load \
+              --cache-from type=local,src=/tmp/.buildx-cache \
               --build-arg SKIP_BACKEND_TEST=true --build-arg SKIP_FRONTEND_TEST=true \
-              --platform linux/arm64 -f backend/_example/memory_store/Dockerfile .
+              --platform linux/amd64 -f backend/_example/memory_store/Dockerfile .
 
-  # Build and push for master and tags using native runners
-  build-push:
-    name: Build ${{ matrix.platform }}
-    if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-latest
-            artifact-name: linux-amd64
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-            artifact-name: linux-arm64
-    runs-on: ${{ matrix.runner }}
-
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: free disk space
+      - name: rotate cache
         run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /usr/local/share/boost
-          docker system prune -af
-
-      - name: login to ghcr.io
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.PKG_TOKEN }}
-
-      - name: login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: umputun
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
-
-      - name: prepare build args
-        id: prep
-        run: |
-          ref="$(echo ${GITHUB_REF} | cut -d'/' -f3)"
-          echo "ref=${ref}" >> $GITHUB_OUTPUT
-          echo "GITHUB_REF=${GITHUB_REF}, GITHUB_SHA=${GITHUB_SHA}, GIT_BRANCH=${ref}"
-
-      - name: build and push to ghcr.io
-        id: build-ghcr
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: ${{ matrix.platform }}
-          build-args: |
-            SKIP_BACKEND_TEST=true
-            SKIP_FRONTEND_TEST=true
-            CI=github
-            GITHUB_SHA=${{ github.sha }}
-            GIT_BRANCH=${{ steps.prep.outputs.ref }}
-            GITHUB_REF=${{ github.ref }}
-          outputs: type=image,name=ghcr.io/umputun/remark42,push-by-digest=true,name-canonical=true,push=true
-
-      - name: build and push to Docker Hub
-        id: build-dockerhub
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: ${{ matrix.platform }}
-          build-args: |
-            SKIP_BACKEND_TEST=true
-            SKIP_FRONTEND_TEST=true
-            CI=github
-            GITHUB_SHA=${{ github.sha }}
-            GIT_BRANCH=${{ steps.prep.outputs.ref }}
-            GITHUB_REF=${{ github.ref }}
-          outputs: type=image,name=umputun/remark42,push-by-digest=true,name-canonical=true,push=true
-
-      - name: export digests
-        run: |
-          mkdir -p /tmp/digests/ghcr /tmp/digests/dockerhub
-          digest_ghcr="${{ steps.build-ghcr.outputs.digest }}"
-          digest_dockerhub="${{ steps.build-dockerhub.outputs.digest }}"
-          touch "/tmp/digests/ghcr/${digest_ghcr#sha256:}"
-          touch "/tmp/digests/dockerhub/${digest_dockerhub#sha256:}"
-
-      - name: upload ghcr digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-ghcr-${{ matrix.artifact-name }}
-          path: /tmp/digests/ghcr/*
-          if-no-files-found: error
-          retention-days: 1
-
-      - name: upload dockerhub digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-dockerhub-${{ matrix.artifact-name }}
-          path: /tmp/digests/dockerhub/*
-          if-no-files-found: error
-          retention-days: 1
-
-  # Merge digests and create multi-arch manifest
-  merge-push:
-    name: Create multi-arch manifest
-    runs-on: ubuntu-latest
-    needs: build-push
-
-    steps:
-      - name: download ghcr digests
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests/ghcr
-          pattern: digests-ghcr-*
-          merge-multiple: true
-
-      - name: download dockerhub digests
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests/dockerhub
-          pattern: digests-dockerhub-*
-          merge-multiple: true
-
-      - name: verify all digests present
-        run: |
-          for registry in ghcr dockerhub; do
-            expected=2
-            actual=$(ls /tmp/digests/${registry} | wc -l)
-            if [ "$actual" -ne "$expected" ]; then
-              echo "Expected $expected digests for ${registry}, found $actual"
-              ls -la /tmp/digests/${registry}
-              exit 1
-            fi
-            echo "All $expected digests present for ${registry}"
-          done
-
-      - name: set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: login to ghcr.io
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.PKG_TOKEN }}
-
-      - name: login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: umputun
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
-
-      - name: prepare tags
-        id: prep
-        run: |
-          ref="$(echo ${GITHUB_REF} | cut -d'/' -f3)"
-          echo "ref=${ref}" >> $GITHUB_OUTPUT
-
-          # for master branch, tag with branch name only
-          if [[ "${GITHUB_REF}" == "refs/heads/master" ]]; then
-            echo "ghcr_tags=-t ghcr.io/umputun/remark42:${ref}" >> $GITHUB_OUTPUT
-            echo "dockerhub_tags=-t umputun/remark42:${ref}" >> $GITHUB_OUTPUT
-          fi
-
-          # for tags, include both version and latest
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            echo "ghcr_tags=-t ghcr.io/umputun/remark42:${ref} -t ghcr.io/umputun/remark42:latest" >> $GITHUB_OUTPUT
-            echo "dockerhub_tags=-t umputun/remark42:${ref} -t umputun/remark42:latest" >> $GITHUB_OUTPUT
-          fi
-
-      - name: create ghcr manifest and push
-        working-directory: /tmp/digests/ghcr
-        run: |
-          docker buildx imagetools create \
-            ${{ steps.prep.outputs.ghcr_tags }} \
-            $(printf 'ghcr.io/umputun/remark42@sha256:%s ' *)
-
-      - name: create dockerhub manifest and push
-        working-directory: /tmp/digests/dockerhub
-        run: |
-          docker buildx imagetools create \
-            ${{ steps.prep.outputs.dockerhub_tags }} \
-            $(printf 'umputun/remark42@sha256:%s ' *)
-
-      - name: remote deployment to remark42.com from master
-        if: ${{ github.ref == 'refs/heads/master' }}
-        env:
-          UPDATER_KEY: ${{ secrets.UPDATER_KEY }}
-        run: curl -s https://jess.umputun.com/update/remark42-core/${UPDATER_KEY}
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache || true

--- a/.github/workflows/ci-frontend-api.yml
+++ b/.github/workflows/ci-frontend-api.yml
@@ -18,13 +18,17 @@ jobs:
   type-check:
     name: Type check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         node: [ 16 ]
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install node
         uses: actions/setup-node@v6
@@ -61,13 +65,17 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         node: [ 16 ]
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install node
         uses: actions/setup-node@v6
@@ -104,13 +112,17 @@ jobs:
   test:
     name: Tests & Coverage
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         node: [ 16 ]
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install node
         uses: actions/setup-node@v6

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -18,13 +18,17 @@ jobs:
   translations-check:
     name: Translations check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         node: [16]
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install node
         uses: actions/setup-node@v6
@@ -61,13 +65,17 @@ jobs:
   type-check:
     name: Type check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         node: [16]
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install node
         uses: actions/setup-node@v6
@@ -104,13 +112,17 @@ jobs:
   lint:
     name: Eslint & Stylelint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         node: [16]
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install node
         uses: actions/setup-node@v6
@@ -148,11 +160,16 @@ jobs:
     name: Size limit
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
     env:
       CI_JOB_NUMBER: 1
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4.2.0
@@ -171,13 +188,17 @@ jobs:
   test:
     name: Tests & Coverage
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         node: [16]
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install node
         uses: actions/setup-node@v6

--- a/.github/workflows/ci-site.yml
+++ b/.github/workflows/ci-site.yml
@@ -13,57 +13,130 @@ on:
       - ".github/workflows/ci-site.yml"
       - "site/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
-    name: Build
-    runs-on: ubuntu-latest
+    name: Build site image (${{ matrix.platform }})
+    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            artifact: linux-amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            artifact: linux-arm64
 
     steps:
       - name: checkout
-        uses: actions/checkout@v5
-
-      - name: set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: set up Docker Buildx
-        id: buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: available platforms
-        run: echo ${{ steps.buildx.outputs.platforms }}
+      - name: login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.PKG_TOKEN }}
 
-      - name: build and deploy master image to ghcr.io
-        if: ${{ github.ref == 'refs/heads/master' }}
+      - name: build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ./site
+          platforms: ${{ matrix.platform }}
+          cache-from: type=gha,scope=site-${{ matrix.platform }}
+          cache-to: type=gha,scope=site-${{ matrix.platform }},mode=max
+          outputs: type=image,name=ghcr.io/umputun/remark42-site,push-by-digest=true,name-canonical=true,push=true
+
+      - name: export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: upload digest
+        uses: actions/upload-artifact@v5
+        with:
+          name: site-digests-${{ matrix.artifact }}
+          path: /tmp/digests/*
+          retention-days: 1
+
+  merge:
+    name: Create site multi-arch manifest
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: download digests
+        uses: actions/download-artifact@v6
+        with:
+          path: /tmp/digests
+          pattern: site-digests-*
+          merge-multiple: true
+
+      - name: verify all digests present
+        run: |
+          expected=2
+          actual=$(find /tmp/digests -maxdepth 1 -type f | wc -l)
+          if [ "$actual" -ne "$expected" ]; then
+            echo "Expected $expected digests, found $actual"
+            ls -la /tmp/digests
+            exit 1
+          fi
+          echo "All $expected digests present"
+
+      - name: set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.PKG_TOKEN }}
+
+      - name: create manifest and push
+        working-directory: /tmp/digests
         env:
-          GITHUB_PACKAGE_TOKEN: ${{ secrets.PKG_TOKEN }}
-          USERNAME: ${{ github.actor }}
-          GITHUB_SHA: ${{ github.sha}}
-          GITHUB_REF: ${{ github.ref}}
-        working-directory: ./site
+          GITHUB_REF: ${{ github.ref }}
         run: |
           ref="$(echo ${GITHUB_REF} | cut -d'/' -f3)"
-          echo GITHUB_REF - $ref
-          echo ${GITHUB_PACKAGE_TOKEN} | docker login ghcr.io -u ${USERNAME} --password-stdin
-          docker buildx build --push --no-cache --platform linux/amd64,linux/arm64 \
-            -t ghcr.io/umputun/remark42-site:${ref} .
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            docker buildx imagetools create \
+              -t ghcr.io/umputun/remark42-site:${ref} \
+              -t ghcr.io/umputun/remark42-site:latest \
+              $(printf 'ghcr.io/umputun/remark42-site@sha256:%s ' *)
+          else
+            docker buildx imagetools create \
+              -t ghcr.io/umputun/remark42-site:${ref} \
+              $(printf 'ghcr.io/umputun/remark42-site@sha256:%s ' *)
+          fi
 
-      - name: deploy tagged (latest) to ghcr.io
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
-        env:
-          GITHUB_PACKAGE_TOKEN: ${{ secrets.PKG_TOKEN }}
-          USERNAME: ${{ github.actor }}
-          GITHUB_SHA: ${{ github.sha}}
-          GITHUB_REF: ${{ github.ref}}
-        working-directory: ./site
-        run: |
-          ref="$(echo ${GITHUB_REF} | cut -d'/' -f3)"
-          echo "GITHUB_REF=$ref, GITHUB_SHA=${GITHUB_SHA}"
-          echo ${GITHUB_PACKAGE_TOKEN} | docker login ghcr.io -u ${USERNAME} --password-stdin
-          docker buildx build --push --no-cache --platform linux/amd64,linux/arm64 \
-            -t ghcr.io/umputun/remark42-site:${ref} -t ghcr.io/umputun/remark42-site:latest .
+  deploy:
+    name: Deploy site
+    runs-on: ubuntu-latest
+    needs: merge
+    if: github.ref == 'refs/heads/master'
 
-      - name: remote site deployment from master
-        if: ${{ github.ref == 'refs/heads/master' }}
+    steps:
+      - name: trigger deployment
         env:
           UPDATER_KEY: ${{ secrets.UPDATER_KEY }}
-        run: curl https://jess.umputun.com/update/remark42-site/${UPDATER_KEY}
+        run: curl -sf https://jess.umputun.com/update/remark42-site/${UPDATER_KEY}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,214 @@
+name: docker
+
+on:
+  workflow_run:
+    workflows: [backend]
+    types: [completed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build Docker image (${{ matrix.platform }})
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event != 'pull_request' &&
+      (github.event.workflow_run.head_branch == 'master' ||
+       startsWith(github.event.workflow_run.head_branch, 'v'))
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            artifact: linux-amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            artifact: linux-arm64
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
+
+      - name: set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.PKG_TOKEN }}
+
+      - name: login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: umputun
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/boost
+          docker system prune -af
+
+      - name: build and push to ghcr.io by digest
+        id: build-ghcr
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,scope=${{ matrix.platform }},mode=max
+          build-args: |
+            SKIP_BACKEND_TEST=true
+            SKIP_FRONTEND_TEST=true
+            CI=github
+            GITHUB_SHA=${{ github.event.workflow_run.head_sha }}
+            GIT_BRANCH=${{ github.event.workflow_run.head_branch }}
+            GITHUB_REF=refs/heads/${{ github.event.workflow_run.head_branch }}
+          outputs: type=image,name=ghcr.io/umputun/remark42,push-by-digest=true,name-canonical=true,push=true
+
+      - name: build and push to DockerHub by digest
+        id: build-dockerhub
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          build-args: |
+            SKIP_BACKEND_TEST=true
+            SKIP_FRONTEND_TEST=true
+            CI=github
+            GITHUB_SHA=${{ github.event.workflow_run.head_sha }}
+            GIT_BRANCH=${{ github.event.workflow_run.head_branch }}
+            GITHUB_REF=refs/heads/${{ github.event.workflow_run.head_branch }}
+          outputs: type=image,name=umputun/remark42,push-by-digest=true,name-canonical=true,push=true
+
+      - name: export digests
+        run: |
+          mkdir -p /tmp/digests/ghcr /tmp/digests/dockerhub
+          digest_ghcr="${{ steps.build-ghcr.outputs.digest }}"
+          digest_dockerhub="${{ steps.build-dockerhub.outputs.digest }}"
+          touch "/tmp/digests/ghcr/${digest_ghcr#sha256:}"
+          touch "/tmp/digests/dockerhub/${digest_dockerhub#sha256:}"
+
+      - name: upload ghcr digest
+        uses: actions/upload-artifact@v5
+        with:
+          name: digests-ghcr-${{ matrix.artifact }}
+          path: /tmp/digests/ghcr/*
+          retention-days: 1
+
+      - name: upload dockerhub digest
+        uses: actions/upload-artifact@v5
+        with:
+          name: digests-dockerhub-${{ matrix.artifact }}
+          path: /tmp/digests/dockerhub/*
+          retention-days: 1
+
+  merge:
+    name: Create multi-arch manifest
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: download ghcr digests
+        uses: actions/download-artifact@v6
+        with:
+          path: /tmp/digests/ghcr
+          pattern: digests-ghcr-*
+          merge-multiple: true
+
+      - name: download dockerhub digests
+        uses: actions/download-artifact@v6
+        with:
+          path: /tmp/digests/dockerhub
+          pattern: digests-dockerhub-*
+          merge-multiple: true
+
+      - name: verify all digests present
+        run: |
+          expected=2
+          for registry in ghcr dockerhub; do
+            actual=$(find /tmp/digests/$registry -maxdepth 1 -type f | wc -l)
+            if [ "$actual" -ne "$expected" ]; then
+              echo "Expected $expected digests for $registry, found $actual"
+              ls -la /tmp/digests/$registry
+              exit 1
+            fi
+          done
+          echo "All digests present for both registries"
+
+      - name: set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.PKG_TOKEN }}
+
+      - name: login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: umputun
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: create ghcr.io manifest and push
+        working-directory: /tmp/digests/ghcr
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          if [[ "$HEAD_BRANCH" == v* ]]; then
+            docker buildx imagetools create \
+              -t ghcr.io/umputun/remark42:${HEAD_BRANCH} \
+              -t ghcr.io/umputun/remark42:latest \
+              $(printf 'ghcr.io/umputun/remark42@sha256:%s ' *)
+          else
+            docker buildx imagetools create \
+              -t ghcr.io/umputun/remark42:${HEAD_BRANCH} \
+              $(printf 'ghcr.io/umputun/remark42@sha256:%s ' *)
+          fi
+
+      - name: create DockerHub manifest and push
+        working-directory: /tmp/digests/dockerhub
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          if [[ "$HEAD_BRANCH" == v* ]]; then
+            docker buildx imagetools create \
+              -t umputun/remark42:${HEAD_BRANCH} \
+              -t umputun/remark42:latest \
+              $(printf 'umputun/remark42@sha256:%s ' *)
+          else
+            docker buildx imagetools create \
+              -t umputun/remark42:${HEAD_BRANCH} \
+              $(printf 'umputun/remark42@sha256:%s ' *)
+          fi
+
+  deploy:
+    name: Deploy to remark42.com
+    runs-on: ubuntu-latest
+    needs: merge
+    if: github.event.workflow_run.head_branch == 'master'
+
+    steps:
+      - name: trigger deployment
+        env:
+          UPDATER_KEY: ${{ secrets.UPDATER_KEY }}
+        run: curl -sf https://jess.umputun.com/update/remark42-core/${UPDATER_KEY}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -22,9 +22,13 @@ jobs:
     name: Tests
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Build & run containers
         id: tests


### PR DESCRIPTION
## Summary

- Separate Docker build/push into dedicated `docker.yml` triggered after backend tests pass via `workflow_run`
- Simplify `ci-build.yml` to PR-only validation (removes push triggers, production builds moved to docker.yml)
- Migrate `ci-site.yml` to native ARM64 runners with build matrix → manifest merge → deploy pattern
- Upgrade `actions/checkout` to v6 with `persist-credentials: false` across all workflows for improved security
- Add explicit `permissions: contents: read` to all jobs (principle of least privilege)
- Upgrade `golangci-lint-action` to v9
- Use GHA cache instead of local cache for Docker builds
- Add concurrency groups to prevent redundant workflow runs