### PR TITLE
Remove -f flag from curl in deployment triggers

### DIFF
--- a/.github/workflows/ci-site.yml
+++ b/.github/workflows/ci-site.yml
@@ -139,4 +139,4 @@ jobs:
       - name: trigger deployment
         env:
           UPDATER_KEY: ${{ secrets.UPDATER_KEY }}
-        run: curl -sf https://jess.umputun.com/update/remark42-site/${UPDATER_KEY}
+        run: curl -s https://jess.umputun.com/update/remark42-site/${UPDATER_KEY}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -211,4 +211,4 @@ jobs:
       - name: trigger deployment
         env:
           UPDATER_KEY: ${{ secrets.UPDATER_KEY }}
-        run: curl -sf https://jess.umputun.com/update/remark42-core/${UPDATER_KEY}
+        run: curl -s https://jess.umputun.com/update/remark42-core/${UPDATER_KEY}


### PR DESCRIPTION
## Summary
- Remove `-f` flag from curl commands in deployment trigger steps
- The `-f` flag causes curl to fail on HTTP errors, which breaks CI when the deployment endpoint returns non-2xx responses
- Keep `-s` (silent) flag to suppress progress output