### PR TITLE
Fix site rebuild on release

### DIFF
--- a/.github/workflows/ci-site.yml
+++ b/.github/workflows/ci-site.yml
@@ -1,10 +1,11 @@
 name: site
 
 on:
+  release:
+    types: [published]
   push:
     branches:
       - master
-    tags:
     paths:
       - ".github/workflows/ci-site.yml"
       - "site/**"
@@ -133,7 +134,7 @@ jobs:
     name: Deploy site
     runs-on: ubuntu-latest
     needs: merge
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' || github.event_name == 'release'
 
     steps:
       - name: trigger deployment


### PR DESCRIPTION
## Summary
- Replace `tags` trigger with `release` event in site CI workflow
- The `paths` filter was incorrectly applying to tag pushes, preventing site rebuilds when releases don't include `site/**` changes
- Add deploy condition for release events so the site gets deployed after release builds

Closes #1992