### PR TITLE
feat: make Microsoft Entra ID tenant configurable

### DIFF
--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -103,7 +103,7 @@ type ServerCommand struct {
 		Google    AuthGroup  `group:"google" namespace:"google" env-namespace:"GOOGLE" description:"Google OAuth"`
 		Github    AuthGroup  `group:"github" namespace:"github" env-namespace:"GITHUB" description:"Github OAuth"`
 		Facebook  AuthGroup  `group:"facebook" namespace:"facebook" env-namespace:"FACEBOOK" description:"Facebook OAuth"`
-		Microsoft AuthGroup  `group:"microsoft" namespace:"microsoft" env-namespace:"MICROSOFT" description:"Microsoft OAuth"`
+		Microsoft MicrosoftAuthGroup `group:"microsoft" namespace:"microsoft" env-namespace:"MICROSOFT" description:"Microsoft OAuth"`
 		Yandex    AuthGroup  `group:"yandex" namespace:"yandex" env-namespace:"YANDEX" description:"Yandex OAuth"`
 		Twitter   AuthGroup  `group:"twitter" namespace:"twitter" env-namespace:"TWITTER" description:"[deprecated, doesn't work] Twitter OAuth"`
 		Patreon   AuthGroup  `group:"patreon" namespace:"patreon" env-namespace:"PATREON" description:"Patreon OAuth"`
@@ -150,6 +150,13 @@ type AppleGroup struct {
 type AuthGroup struct {
 	CID  string `long:"cid" env:"CID" description:"OAuth client ID"`
 	CSEC string `long:"csec" env:"CSEC" description:"OAuth client secret"`
+}
+
+// MicrosoftAuthGroup defines options group for Microsoft auth params
+type MicrosoftAuthGroup struct {
+	CID    string `long:"cid" env:"CID" description:"OAuth client ID"`
+	CSEC   string `long:"csec" env:"CSEC" description:"OAuth client secret"`
+	Tenant string `long:"tenant" env:"TENANT" description:"Azure AD tenant ID, domain, or 'common' (default)" default:"common"`
 }
 
 // StoreGroup defines options group for store params
@@ -939,7 +946,7 @@ func (s *ServerCommand) addAuthProviders(authenticator *auth.Service) error {
 		providersCount++
 	}
 	if s.Auth.Microsoft.CID != "" && s.Auth.Microsoft.CSEC != "" {
-		authenticator.AddProvider("microsoft", s.Auth.Microsoft.CID, s.Auth.Microsoft.CSEC)
+		authenticator.AddMicrosoftProvider(s.Auth.Microsoft.CID, s.Auth.Microsoft.CSEC, s.Auth.Microsoft.Tenant)
 		providersCount++
 	}
 	if s.Auth.Yandex.CID != "" && s.Auth.Yandex.CSEC != "" {

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/didip/tollbooth/v8 v8.0.1
 	github.com/go-chi/chi/v5 v5.2.3
 	github.com/go-chi/cors v1.2.2
-	github.com/go-pkgz/auth/v2 v2.1.1
+	github.com/go-pkgz/auth/v2 v2.1.2-0.20260211003156-fbba7f2baa6b
 	github.com/go-pkgz/jrpc v0.4.0
 	github.com/go-pkgz/lcw/v2 v2.0.0
 	github.com/go-pkgz/lgr v0.12.1

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -50,6 +50,12 @@ github.com/go-oauth2/oauth2/v4 v4.5.4 h1:YjI0tmGW8oxVhn9QSBIxlr641QugWrJY5UWa6Xm
 github.com/go-oauth2/oauth2/v4 v4.5.4/go.mod h1:BXiOY+QZtZy2ewbsGk2B5P8TWmtz/Rf7ES5ZttQFxfQ=
 github.com/go-pkgz/auth/v2 v2.1.1 h1:CBH3Z6ovLT51Nx9TkBcu2L8Dd/xwL6CgJcgqUnC2isQ=
 github.com/go-pkgz/auth/v2 v2.1.1/go.mod h1:9LwzESczjMavmXNZo1XhYpfYdKWtoCbXt/ZIi0GTvF0=
+github.com/go-pkgz/auth/v2 v2.1.2-0.20260119213210-5ff800f4c064 h1:+7XirxGV7RV0VzStWbyP6c0edbfaCXB69JeZh6uVpE0=
+github.com/go-pkgz/auth/v2 v2.1.2-0.20260119213210-5ff800f4c064/go.mod h1:9LwzESczjMavmXNZo1XhYpfYdKWtoCbXt/ZIi0GTvF0=
+github.com/go-pkgz/auth/v2 v2.1.2-0.20260210234152-7e1ed2cedf71 h1:FxzoRgUemfWKBt0iw9J9Qck5nHB6bNlhmUJneMNL/C8=
+github.com/go-pkgz/auth/v2 v2.1.2-0.20260210234152-7e1ed2cedf71/go.mod h1:9LwzESczjMavmXNZo1XhYpfYdKWtoCbXt/ZIi0GTvF0=
+github.com/go-pkgz/auth/v2 v2.1.2-0.20260211003156-fbba7f2baa6b h1:N8iS/o/LgbSL4NLabOuLgfmROjtMLW2Qc3EsMmdYNGs=
+github.com/go-pkgz/auth/v2 v2.1.2-0.20260211003156-fbba7f2baa6b/go.mod h1:9LwzESczjMavmXNZo1XhYpfYdKWtoCbXt/ZIi0GTvF0=
 github.com/go-pkgz/email v0.6.0 h1:snZnXldjeF4PgKSjnx9Fa25mtOgFpAOEeWvnQvrxjLE=
 github.com/go-pkgz/email v0.6.0/go.mod h1:+wgi4x7S33IuCzfcCM5euN0GwQG6XvO/PBLxrNffYLI=
 github.com/go-pkgz/expirable-cache/v3 v3.1.0 h1:s05P851/O6QJ6Mc+7o2bh9aGtD3romB1SxDTXifdoqc=

--- a/backend/vendor/github.com/go-pkgz/auth/v2/provider/oauth2.go
+++ b/backend/vendor/github.com/go-pkgz/auth/v2/provider/oauth2.go
@@ -44,6 +44,8 @@ type Params struct {
 
 	Port int    // relevant for providers supporting port customization, for example dev oauth2
 	Host string // relevant for providers supporting host customization, for example dev oauth2
+
+	MicrosoftTenant string // tenant for microsoft provider, default "common"
 }
 
 // UserData is type for user information returned from oauth2 providers /info API method

--- a/backend/vendor/github.com/go-pkgz/auth/v2/provider/providers.go
+++ b/backend/vendor/github.com/go-pkgz/auth/v2/provider/providers.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha1" //nolint
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/dghubble/oauth1"
 	"github.com/dghubble/oauth1/twitter"
@@ -192,9 +193,13 @@ func NewBattlenet(p Params) Oauth2Handler {
 
 // NewMicrosoft makes microsoft azure oauth2 provider
 func NewMicrosoft(p Params) Oauth2Handler {
+	tenant := p.MicrosoftTenant
+	if tenant == "" || strings.ContainsAny(tenant, "/?# \t\n\r") || strings.Contains(tenant, "..") {
+		tenant = "common"
+	}
 	return initOauth2Handler(p, Oauth2Handler{
 		name:     "microsoft",
-		endpoint: microsoft.AzureADEndpoint("common"),
+		endpoint: microsoft.AzureADEndpoint(tenant),
 		scopes:   []string{"User.Read"},
 		infoURL:  "https://graph.microsoft.com/v1.0/me",
 		// non-beta doesn't provide photo for consumers yet

--- a/backend/vendor/modules.txt
+++ b/backend/vendor/modules.txt
@@ -56,7 +56,7 @@ github.com/go-chi/cors
 github.com/go-oauth2/oauth2/v4
 github.com/go-oauth2/oauth2/v4/errors
 github.com/go-oauth2/oauth2/v4/server
-# github.com/go-pkgz/auth/v2 v2.1.1
+# github.com/go-pkgz/auth/v2 v2.1.2-0.20260211003156-fbba7f2baa6b
 ## explicit; go 1.24.0
 github.com/go-pkgz/auth/v2
 github.com/go-pkgz/auth/v2/avatar

--- a/site/src/docs/configuration/authorization/index.md
+++ b/site/src/docs/configuration/authorization/index.md
@@ -82,6 +82,7 @@ _instructions for Google OAuth2 setup borrowed from [oauth2_proxy](https://githu
 3. In **"Overview"** take note of the **Application (client) ID** (`AUTH_MICROSOFT_CID`)
 4. Choose the new project from the top right project dropdown (only if another project is selected)
 5. Select **"Certificates & secrets"** and click on **"+ New Client Secret"** (`AUTH_MICROSOFT_CSEC`)
+6. For single-tenant Entra ID applications, set `AUTH_MICROSOFT_TENANT` to your tenant ID or domain name. The default value is `common`, which works for multi-tenant applications.
 
 ### Yandex
 

--- a/site/src/docs/configuration/parameters/index.md
+++ b/site/src/docs/configuration/parameters/index.md
@@ -91,6 +91,7 @@ services:
 | auth.facebook.csec             | AUTH_FACEBOOK_CSEC             |                         | Facebook OAuth client secret                             |
 | auth.microsoft.cid             | AUTH_MICROSOFT_CID             |                         | Microsoft OAuth client ID                                |
 | auth.microsoft.csec            | AUTH_MICROSOFT_CSEC            |                         | Microsoft OAuth client secret                            |
+| auth.microsoft.tenant          | AUTH_MICROSOFT_TENANT          | `common`                | Azure AD tenant ID, domain, or "common"                  |
 | auth.github.cid                | AUTH_GITHUB_CID                |                         | GitHub OAuth client ID                                   |
 | auth.github.csec               | AUTH_GITHUB_CSEC               |                         | GitHub OAuth client secret                               |
 | auth.patreon.cid               | AUTH_PATREON_CID               |                         | Patreon OAuth Client ID                                  |


### PR DESCRIPTION
## Summary

- Add `AUTH_MICROSOFT_TENANT` env var to configure the Azure AD tenant for Microsoft OAuth
- Defaults to `common` (multi-tenant), allowing single-tenant Entra ID apps to specify their tenant ID or domain
- Update site documentation with the new parameter

Depends on go-pkgz/auth#266

Closes #1998