### PR TITLE
Clear user placeholder content when comments iframe loads

### DIFF
--- a/frontend/apps/remark42/app/embed.ts
+++ b/frontend/apps/remark42/app/embed.ts
@@ -79,6 +79,11 @@ function createInstance(config: typeof window.remark_config) {
     }
 
     if (data.inited === true) {
+      // remove placeholder content added by the user before comments loaded
+      Array.from(root!.childNodes)
+        .filter((node) => node !== iframe)
+        .forEach((node) => node.remove());
+
       postHashToIframe();
       postTitleToIframe(document.title);
     }


### PR DESCRIPTION
## Summary

Allow users to add placeholder content (e.g. a loading spinner or "Loading comments..." text) inside the `remark42` root div. When the iframe signals it has initialised, all non-iframe child nodes are removed from the root element.

This lets users show something meaningful while the comment widget loads without any changes to the embed script configuration.

Fixes #1990