### PR TITLE
Drop GitHub token permissions on deploy jobs

### DIFF
--- a/.github/workflows/ci-site.yml
+++ b/.github/workflows/ci-site.yml
@@ -135,6 +135,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: merge
     if: github.ref == 'refs/heads/master' || github.event_name == 'release'
+    permissions: {} # only calls an external URL via curl, no GitHub API access needed
 
     steps:
       - name: trigger deployment

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -206,6 +206,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: merge
     if: github.event.workflow_run.head_branch == 'master'
+    permissions: {} # only calls an external URL via curl, no GitHub API access needed
 
     steps:
       - name: trigger deployment


### PR DESCRIPTION
## Summary
- Add explicit `permissions: {}` to deploy jobs in `docker.yml` and `ci-site.yml`
- These jobs only `curl` an external updater URL and need no GitHub API access
- Without an explicit block they inherit the workflow default, which may include `contents:write`, `packages:write`, etc. — far more than needed
- Limits the blast radius if a deploy job is ever compromised

Inspired by https://adnanthekhan.com/posts/clinejection/