### PR TITLE
Add X-Content-Type-Options and Referrer-Policy security headers

### DIFF
--- a/backend/app/rest/api/rest_test.go
+++ b/backend/app/rest/api/rest_test.go
@@ -352,6 +352,8 @@ func TestRest_securityHeaders(t *testing.T) {
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Contains(t, resp.Header.Get("Content-Security-Policy"), "img-src *;")
+	assert.Equal(t, "nosniff", resp.Header.Get("X-Content-Type-Options"))
+	assert.Equal(t, "strict-origin-when-cross-origin", resp.Header.Get("Referrer-Policy"))
 	teardown()
 
 	// check CSP with proxy enabled
@@ -364,6 +366,8 @@ func TestRest_securityHeaders(t *testing.T) {
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Contains(t, resp.Header.Get("Content-Security-Policy"), "img-src 'self';")
+	assert.Equal(t, "nosniff", resp.Header.Get("X-Content-Type-Options"))
+	assert.Equal(t, "strict-origin-when-cross-origin", resp.Header.Get("Referrer-Policy"))
 }
 
 func TestRest_subscribersOnly(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `X-Content-Type-Options: nosniff` header to prevent browsers from MIME-sniffing responses away from the declared Content-Type (e.g. a user-uploaded image being reinterpreted as executable HTML/JS)
- Add `Referrer-Policy: strict-origin-when-cross-origin` header to limit URL information leaked in the Referer header — sends only the origin (no path) to other domains, and nothing at all on HTTPS→HTTP downgrades