### PR TITLE
Fix Firefox dark mode white background on comment iframe

### DIFF
--- a/frontend/apps/remark42/app/embed.ts
+++ b/frontend/apps/remark42/app/embed.ts
@@ -116,6 +116,7 @@ function createInstance(config: typeof window.remark_config) {
 
   function changeTheme(theme: Theme) {
     window.remark_config.theme = theme;
+    iframe.style.colorScheme = theme;
     postMessageToIframe(iframe, { theme });
   }
 

--- a/frontend/apps/remark42/app/remark.tsx
+++ b/frontend/apps/remark42/app/remark.tsx
@@ -40,15 +40,20 @@ async function init(): Promise<void> {
 
     if (data.theme === 'light') {
       document.body.classList.remove('dark');
+      document.documentElement.style.colorScheme = 'light';
     }
 
     if (data.theme === 'dark') {
       document.body.classList.add('dark');
+      document.documentElement.style.colorScheme = 'dark';
     }
   });
 
   if (theme === 'dark') {
     document.body.classList.add('dark');
+    document.documentElement.style.colorScheme = 'dark';
+  } else {
+    document.documentElement.style.colorScheme = 'light';
   }
 
   boundActions.fetchHiddenUsers();

--- a/frontend/apps/remark42/app/utils/create-iframe.ts
+++ b/frontend/apps/remark42/app/utils/create-iframe.ts
@@ -20,7 +20,7 @@ export function createIframe({ __colors__, styles, ...params }: Params) {
     padding: 0,
     margin: 0,
     overflow: 'hidden',
-    colorScheme: 'none',
+    colorScheme: params.theme === 'dark' ? 'dark' : params.theme === 'light' ? 'light' : 'light dark',
     ...styles,
   });
 

--- a/frontend/apps/remark42/app/utils/create-iframe.ts
+++ b/frontend/apps/remark42/app/utils/create-iframe.ts
@@ -20,7 +20,7 @@ export function createIframe({ __colors__, styles, ...params }: Params) {
     padding: 0,
     margin: 0,
     overflow: 'hidden',
-    colorScheme: params.theme === 'dark' ? 'dark' : params.theme === 'light' ? 'light' : 'light dark',
+    colorScheme: params.theme === 'dark' ? 'dark' : 'light',
     ...styles,
   });
 


### PR DESCRIPTION
## Summary

- Firefox renders a white background on the comment iframe in dark mode because `color-scheme: none` is not a valid CSS value. Chrome silently ignores it, but Firefox treats it literally and uses the default light canvas.
- Sets `color-scheme` on the iframe's inner `<html>` element to match the active theme (`dark` or `light`), which tells Firefox to use the correct canvas color.
- Also updates the outer `<iframe>` element's `color-scheme` on creation and on runtime theme changes via `changeTheme()`.
- Resolves #1430, #2011, and builds on the groundwork from #1427 and #1429.

## Changes

- **`remark.tsx`**: Sets `document.documentElement.style.colorScheme` inside the iframe on init and when receiving theme change messages
- **`embed.ts`**: Updates `iframe.style.colorScheme` when `changeTheme()` is called at runtime
- **`create-iframe.ts`**: Replaces invalid `colorScheme: 'none'` with a theme-aware value (`'dark'`, `'light'`, or `'light dark'`)

## Test plan

- Open `http://127.0.0.1:8080/web/` in Firefox and Chrome
- Toggle dark mode and verify no white background appears on the iframe in either browser
- Switch back to light mode and verify it renders correctly
- Verify `changeTheme('dark')` and `changeTheme('light')` in the console both update the iframe canvas color
## Before
### Firefox
#### Dark
<img width="768" height="328" alt="image" src="https://github.com/user-attachments/assets/01fdfea2-ae92-4dd9-a121-26dd327399db" />


### Chromium
#### Dark
<img width="743" height="289" alt="image" src="https://github.com/user-attachments/assets/f945a3ab-66a0-4ce4-a89f-41de5dd6fcd9" />

## After
### Firefox

#### Light
<img width="848" height="859" alt="image" src="https://github.com/user-attachments/assets/e54a2c03-e091-4eda-80d2-534e92123725" />

#### Dark
<img width="855" height="866" alt="image" src="https://github.com/user-attachments/assets/8b66d1ab-fcc0-43e6-8b58-087f41a3b96b" />

### Chromium
#### Light
<img width="852" height="844" alt="image" src="https://github.com/user-attachments/assets/1a4ff78a-770d-41d8-8533-8283ae82a3e1" />

#### Dark
<img width="852" height="839" alt="image" src="https://github.com/user-attachments/assets/f561acb9-4295-4e28-94a6-80bffb96a52a" />
