### PR TITLE
Fix #2040: preserve orig verbatim in edit textarea

### DIFF
--- a/frontend/apps/remark42/app/components/comment/comment.test.tsx
+++ b/frontend/apps/remark42/app/components/comment/comment.test.tsx
@@ -7,6 +7,7 @@ import { render } from 'tests/utils';
 import { StaticStore } from 'common/static-store';
 
 import { Comment, CommentProps } from './comment';
+import { CommentForm } from 'components/comment-form';
 import { CommentMode } from 'common/types';
 
 function CommentWithIntl(props: CommentProps) {
@@ -253,6 +254,101 @@ describe('<Comment />', () => {
     rerender(<CommentWithIntl {...props} />);
     await waitFor(() => {
       expect(screen.getByText('Edit')).toBeVisible();
+    });
+  });
+
+  // Regression tests for issue #2040.
+  // The edit textarea must reflect `data.orig` byte-for-byte; any transformation
+  // (HTML-entity decoding in particular) corrupts user input on save because
+  // bluemonday then strips now-real tags that the user typed as entities.
+  describe('edit textarea preserves data.orig verbatim', () => {
+    afterEach(() => {
+      CommentForm.textareaCounter = 0;
+      localStorage.clear();
+    });
+
+    const cases: Array<[string, string]> = [
+      ['issue 2040 canonical', '&lt;script&gt;Hacked you!&lt;/script&gt;'],
+      ['doubly-escaped entity', '&amp;lt;script&amp;gt;'],
+      ['mixed named entities', 'I love &copy; 2026 &amp; &quot;quotes&quot; &apos;too&apos;'],
+      ['nbsp entity whitespace', '&nbsp;&nbsp;&nbsp;indented'],
+      ['decimal numeric entities', '&#60;div&#62;hello&#60;/div&#62;'],
+      ['hex numeric entities with xss-like content', '&#x3C;img src=x onerror=alert(1)&#x3E;'],
+      ['hex numeric emoji entities', '&#x1F600; &#x1F4A9; emoji via numeric'],
+      ['obscure named entities', '&AElig;sop &eacute;tait &zwj;ici'],
+      ['malformed entity without semicolon', '&lt without semicolon and &amp; with'],
+      ['entity-shaped junk', '&;&lt;;&#;&#x;&#xZZZ;'],
+      ['recursive-looking numeric entity', '&#38;#60;'],
+      ['programmer content with real < and entities', '5 &lt; 10 &amp;&amp; 10 &gt; 5'],
+      ['real < mixed with &lt;', 'a < b and &lt;tag&gt; literal'],
+      ['sixteen back-to-back &lt;', '&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;'],
+      ['fenced code block with entities', '```\n&lt;pre&gt;code&lt;/pre&gt;\n```'],
+      ['link with entity-encoded query ampersands', '[link](https://example.com/?a=1&amp;b=2&amp;c=3)'],
+      ['null/replacement/surrogate hex entities', '&#x0;&#xFFFD;&#xD800;'],
+
+      ['zero-width characters interleaved', 'Hello\u200Bworld\u200Cfoo\u200Dbar'],
+      ['bidi Hebrew + Arabic + ASCII', '\u05E9\u05DC\u05D5\u05DD hello \u0645\u0631\u062D\u0628\u0627'],
+      ['RLO override embedded', 'safe\u202Eevil\u202Cend'],
+      ['decomposed vs precomposed é', 'cafe\u0301 vs caf\u00E9'],
+      ['ZWJ family emoji', 'family: \uD83D\uDC68\u200D\uD83D\uDC69\u200D\uD83D\uDC66'],
+      ['supplementary plane surrogate pairs', 'poop: \uD83D\uDCA9 and math: \uD835\uDC00'],
+      ['line and paragraph separators', 'line1\u2028line2\u2029para2'],
+      ['BOM at start middle end', '\uFEFFstart mid\uFEFFdle end\uFEFF'],
+      ['varied unicode whitespace', 'a\u00A0b\u3000c\u2003d\u202Fe'],
+      ['tab LF CR CRLF LFCR', 'tab\there\nnl\rcr\r\ncrlf\n\rlfcr'],
+      ['cyrillic homoglyph a', 'Cyrillic \u0430pple vs Latin apple'],
+      ['full-width angle brackets', 'fullwidth \uFF1Cscript\uFF1E not a tag'],
+      ['bidi mark soup', 'mix: \u202Dltr\u202C \u202Ertl\u202C \u200E\u200F'],
+
+      ['inline code with real script tag', '`<script>alert(1)</script>`'],
+      ['inline code with entity script tag', '`&lt;script&gt;`'],
+      [
+        'fenced html with iframe and double-escaped',
+        '```html\n<iframe src="javascript:alert(1)"></iframe>\n&amp;lt;b&amp;gt;\n```',
+      ],
+      ['javascript link', '[click](javascript:alert(1))'],
+      ['image with entity alt and title', '![&lt;alt&gt;](x.png "&amp;title&amp;")'],
+      ['markdown backslash escapes', '\\*not em\\* \\_not em\\_ \\\\ \\< \\& \\`not code\\`'],
+      ['entities inside emphasis markers', '*&lt;em&gt;* _&gt;underscore&lt;_ **&amp;bold&amp;**'],
+      ['headers with entities', '# &lt;h1&gt;\n## &amp;header&amp;'],
+      ['blockquote with entities multiline', '> &lt;foo&gt;\n> &amp;quoted&amp;\n>\n> nested &lt;bar/&gt;'],
+      ['raw autolinks', '<https://example.com/?a=1&b=2> see also <user@example.com>'],
+      ['raw script tag no markdown', '<script>alert(1)</script>'],
+      ['iframe object embed chain', '<iframe src=x></iframe><object data=x></object><embed src=x>'],
+      ['kitchen sink', 'mix: `a` \\* *b* &lt;c&gt; &amp;d&amp; \\\\ \\`e\\` [f](javascript:0) ![g](h "&quot;")'],
+
+      ['empty string', ''],
+      ['only whitespace', '   \t\n   '],
+    ];
+
+    // HTML5 textarea.value always normalises \r\n and lone \r to \n.
+    // This happens inside the browser regardless of any remark42 code,
+    // so the edit round-trip guarantee is "byte-equal after newline normalisation".
+    const expectedTextareaValue = (raw: string) => raw.replace(/\r\n|\r/g, '\n');
+
+    it.each(cases)('renders unchanged: %s', (_label, payload) => {
+      CommentForm.textareaCounter = 0;
+      StaticStore.config.edit_duration = 300;
+
+      const p = getProps();
+      p.repliesCount = 0;
+      p.user!.id = '100';
+      p.data.user.id = '100';
+      p.editMode = CommentMode.Edit;
+      // @ts-ignore - CommentForm prop is optional on CommentProps
+      p.CommentForm = CommentForm;
+      Object.assign(p.data, {
+        id: '101',
+        vote: 1,
+        time: Date.now(),
+        delete: false,
+        orig: payload,
+      });
+
+      render(<CommentWithIntl {...p} />);
+
+      const textarea = screen.getByTestId('textarea_1') as HTMLTextAreaElement;
+      expect(textarea.value).toBe(expectedTextareaValue(payload));
     });
   });
 });

--- a/frontend/apps/remark42/app/components/comment/comment.tsx
+++ b/frontend/apps/remark42/app/components/comment/comment.tsx
@@ -303,14 +303,7 @@ export class Comment extends Component<CommentProps, State> {
           ? intl.formatMessage(messages.deletedComment)
           : props.data.text,
       time: new Date(props.data.time),
-      orig: isEditing
-        ? props.data.orig &&
-          props.data.orig.replace(/&[#A-Za-z0-9]+;/gi, (entity) => {
-            const span = document.createElement('span');
-            span.innerHTML = entity;
-            return span.innerText;
-          })
-        : props.data.orig,
+      orig: props.data.orig,
       user: props.data.user,
     };
 


### PR DESCRIPTION
## Summary

Fixes #2040. Removes a stale HTML-entity decode from the edit textarea flow. When a user posted a comment containing literal HTML entities (e.g. `&lt;script&gt;Hacked you!&lt;/script&gt;`), the edit textarea would show the decoded `<script>...</script>`. Saving that decoded text made bluemonday strip the now-real `<script>` tag on the way back to storage, collapsing the comment body to an empty string.

## Root cause

`frontend/apps/remark42/app/components/comment/comment.tsx:306-313` was running `props.data.orig` through the browser's HTML parser via a detached `<span>.innerHTML` to "decode entities":

```tsx
orig: isEditing
  ? props.data.orig &&
    props.data.orig.replace(/&[#A-Za-z0-9]+;/gi, (entity) => {
      const span = document.createElement('span');
      span.innerHTML = entity;
      return span.innerText;
    })
  : props.data.orig,
```

That block was added in commit `78b9a10` (2018) because the backend `Comment.Sanitize()` at the time ran bluemonday on **both** `Text` and `Orig`. bluemonday HTML-escapes raw `<`/`>`/`&` in text content, so a user typing `1 < 2` got `orig = "1 &lt; 2"` back from the API, and the frontend compensated.

Commit `243c835` (2022, _"do not sanitise the original comment markdown"_) removed bluemonday from `Orig` in the backend. After that, `Orig` is stored and returned byte-for-byte. The frontend decode was never removed alongside — it has been a silent corruption path for ~3.5 years, only surfacing when a user actually types entities they want preserved.

See issue #2040 for the full investigation trail.

## Fix

Delete the decode block. The edit textarea now receives `props.data.orig` unchanged, matching the backend contract documented at `backend/app/store/comment.go:118-120`: _"Comment.Orig … is not sanitized as we expect to never render it as HTML"_.

## Test coverage

Added a 45-case table-driven regression test in `comment.test.tsx` — `<Comment /> › edit textarea preserves data.orig verbatim`. Payloads come from three independent brainstorming passes covering:

- **HTML entities**: canonical issue repro, doubly-escaped (`&amp;lt;`), decimal/hex numeric, named entity mix, malformed entities, real `<` adjacent to `&lt;`, recursive-looking sequences
- **Unicode**: zero-width characters, bidi mix, RTL overrides, decomposed vs precomposed, ZWJ emoji, supplementary-plane surrogate pairs, LS/PS separators, BOM, homoglyphs, full-width characters, whitespace variety
- **Markdown interactions**: code spans with raw/entity script tags, fenced code blocks, javascript: links, images with entity alt/title, backslash escapes, entities inside emphasis/headers/blockquotes, raw autolinks, iframe/object/embed chains, kitchen sink

Verified the test fails as intended by reverting the fix and re-running — 24 of 45 cases (every entity-containing payload) fail against the buggy code, all 45 pass against the fixed code.

Also verified end-to-end in a real browser against `make rundev`: typed the issue's canonical payload, saw it display as literal text, clicked Edit, confirmed the textarea shows `&lt;script&gt;...` (previously `<script>...`), saved, confirmed the body survives (previously empty).

## Behavioural note

The test found one incidental DOM-level normalisation: HTML5 mandates that `<textarea>.value` normalises `\r\n` and lone `\r` to `\n`. This happens in the browser regardless of any remark42 code, so the guarantee is _"byte-equal after newline normalisation"_ — documented inline in the test.

## Screenshots

<img width="836" height="113" alt="image" src="https://github.com/user-attachments/assets/58a0e9bd-a1c9-426d-b7ed-1b0ce159ea1c" />

Edit without this change on https://remark42.com/demo/:

<img width="661" height="299" alt="image" src="https://github.com/user-attachments/assets/b6f5661c-abea-42b4-a5c9-12017631ac4b" />


Edit with this change:
<img width="819" height="295" alt="image" src="https://github.com/user-attachments/assets/c339c5d9-b719-4c2a-9bd3-abf0bb6c0ceb" />
