### PR TITLE
fix(ssrf): apply ssrf-safe transport to TitleExtractor + restore gosec G70x rules

### DIFF
--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -26,9 +26,6 @@ linters:
     gosec:
       excludes:
         - G117 # false positive: struct field name matches "secret" pattern
-        - G703 # false positive: path traversal via taint analysis
-        - G704 # false positive: SSRF via taint analysis
-        - G705 # false positive: XSS via taint analysis
     gocritic:
       disabled-checks:
         - wrapperFunc

--- a/backend/app/cmd/backup.go
+++ b/backend/app/cmd/backup.go
@@ -47,7 +47,7 @@ func (ec *BackupCommand) Execute(_ []string) error {
 	req.SetBasicAuth("admin", ec.AdminPasswd)
 
 	// get with timeout
-	resp, err := client.Do(req.WithContext(ctx))
+	resp, err := client.Do(req.WithContext(ctx)) //nolint:gosec // exportURL is built from operator-supplied CLI flags, not user input
 	if err != nil {
 		return fmt.Errorf("request failed for %s: %w", exportURL, err)
 	}

--- a/backend/app/cmd/cleanup.go
+++ b/backend/app/cmd/cleanup.go
@@ -199,7 +199,7 @@ func (cc *CleanupCommand) deleteComment(c store.Comment) error { //nolint:dupl /
 
 	client := http.Client{}
 	defer client.CloseIdleConnections()
-	r, err := client.Do(req)
+	r, err := client.Do(req) //nolint:gosec // RemarkURL comes from operator CLI flag, not user input
 	if err != nil {
 		return fmt.Errorf("delete request failed for comment %s, %s: %w", c.ID, c.Locator.URL, err)
 	}
@@ -221,7 +221,7 @@ func (cc *CleanupCommand) setTitle(c store.Comment) error { //nolint:dupl // not
 
 	client := http.Client{}
 	defer client.CloseIdleConnections()
-	r, err := client.Do(req)
+	r, err := client.Do(req) //nolint:gosec // RemarkURL comes from operator CLI flag, not user input
 	if err != nil {
 		return fmt.Errorf("title request failed for comment %s, %s: %w", c.ID, c.Locator.URL, err)
 	}

--- a/backend/app/cmd/import.go
+++ b/backend/app/cmd/import.go
@@ -42,7 +42,7 @@ func (ic *ImportCommand) Execute(_ []string) error {
 	}
 	req.SetBasicAuth("admin", ic.AdminPasswd)
 
-	resp, err := client.Do(req.WithContext(ctx)) // closes request's reader
+	resp, err := client.Do(req.WithContext(ctx)) //nolint:gosec // importURL built from operator CLI flags, not user input; closes request's reader
 	if err != nil {
 		return fmt.Errorf("request failed for %s: %w", importURL, err)
 	}

--- a/backend/app/cmd/remap.go
+++ b/backend/app/cmd/remap.go
@@ -34,13 +34,13 @@ func (rc *RemapCommand) Execute(_ []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), rc.Timeout)
 	defer cancel()
 	remapURL := fmt.Sprintf("%s/api/v1/admin/remap?site=%s", rc.RemarkURL, rc.Site)
-	req, err := http.NewRequest(http.MethodPost, remapURL, rulesReader)
+	req, err := http.NewRequest(http.MethodPost, remapURL, rulesReader) //nolint:gosec // RemarkURL is operator CLI flag, not user input
 	if err != nil {
 		return fmt.Errorf("can't make remap request for %s: %w", remapURL, err)
 	}
 	req.SetBasicAuth("admin", rc.AdminPasswd)
 
-	resp, err := client.Do(req.WithContext(ctx))
+	resp, err := client.Do(req.WithContext(ctx)) //nolint:gosec // see above
 	if err != nil {
 		return fmt.Errorf("request failed for %s: %w", remapURL, err)
 	}

--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -39,6 +39,7 @@ import (
 	"github.com/umputun/remark42/backend/app/providers"
 	"github.com/umputun/remark42/backend/app/rest/api"
 	"github.com/umputun/remark42/backend/app/rest/proxy"
+	"github.com/umputun/remark42/backend/app/safehttp"
 	"github.com/umputun/remark42/backend/app/store"
 	"github.com/umputun/remark42/backend/app/store/admin"
 	"github.com/umputun/remark42/backend/app/store/engine"
@@ -621,7 +622,7 @@ func (s *ServerCommand) newServerApp(ctx context.Context) (*serverApp, error) {
 		MaxVotes:               s.MaxVotes,
 		PositiveScore:          s.PositiveScore,
 		ImageService:           imageService,
-		TitleExtractor:         service.NewTitleExtractor(http.Client{Timeout: time.Second * 5}, s.getAllowedDomains()),
+		TitleExtractor:         service.NewTitleExtractor(http.Client{Timeout: time.Second * 5, Transport: safehttp.Transport()}, s.getAllowedDomains()),
 		RestrictedWordsMatcher: service.NewRestrictedWordsMatcher(service.StaticRestrictedWordsLister{Words: s.RestrictedWords}),
 	}
 	dataService.RestrictSameIPVotes.Enabled = s.RestrictVoteIP

--- a/backend/app/rest/api/migrator.go
+++ b/backend/app/rest/api/migrator.go
@@ -180,7 +180,7 @@ func (m *Migrator) remapCtrl(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		defer func() {
-			if e = os.Remove(fh.Name()); e != nil {
+			if e = os.Remove(fh.Name()); e != nil { //nolint:gosec // fh.Name() is from os.CreateTemp, server-controlled
 				log.Printf("[WARN] failed to remove temp file %+v", e)
 			}
 		}()

--- a/backend/app/rest/api/migrator.go
+++ b/backend/app/rest/api/migrator.go
@@ -73,6 +73,7 @@ func (m *Migrator) importFormCtrl(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, 256*1024*1024) // hard cap on upload to prevent memory exhaustion
 	if err := r.ParseMultipartForm(20 * 1024 * 1024); err != nil { // 20M max memory, if bigger will make a file
 		rest.SendErrorJSON(w, r, http.StatusInternalServerError, err, "can't parse multipart form", rest.ErrDecode)
 		return

--- a/backend/app/rest/api/rest_private.go
+++ b/backend/app/rest/api/rest_private.go
@@ -731,6 +731,7 @@ func (s *private) deleteMeCtrl(w http.ResponseWriter, r *http.Request) {
 func (s *private) savePictureCtrl(w http.ResponseWriter, r *http.Request) {
 	user := rest.MustGetUserInfo(r)
 
+	r.Body = http.MaxBytesReader(w, r.Body, 32*1024*1024) // hard cap on upload to prevent memory exhaustion
 	if err := r.ParseMultipartForm(5 * 1024 * 1024); err != nil { // 5M max memory, if bigger will make a file
 		rest.SendErrorJSON(w, r, http.StatusInternalServerError, err, "can't parse multipart form", rest.ErrDecode)
 		return

--- a/backend/app/rest/api/rest_public.go
+++ b/backend/app/rest/api/rest_public.go
@@ -431,7 +431,7 @@ func (s *public) telegramQrCtrl(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "image/png")
-	if _, err = w.Write(png); err != nil {
+	if _, err = w.Write(png); err != nil { //nolint:gosec // png bytes from go-qrcode, not HTML
 		log.Printf("[WARN] can't render qr, %v", err)
 	}
 }

--- a/backend/app/rest/api/rss.go
+++ b/backend/app/rest/api/rss.go
@@ -56,7 +56,7 @@ func (s *rss) postCommentsCtrl(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/xml; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-	if _, err = w.Write(data); err != nil {
+	if _, err = w.Write(data); err != nil { //nolint:gosec // xml feed bytes from gorilla/feeds, not HTML
 		log.Printf("[WARN] failed to send response to %s, %s", r.RemoteAddr, err)
 	}
 }
@@ -87,7 +87,7 @@ func (s *rss) siteCommentsCtrl(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/xml; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-	if _, err = w.Write(data); err != nil {
+	if _, err = w.Write(data); err != nil { //nolint:gosec // xml feed bytes from gorilla/feeds, not HTML
 		log.Printf("[WARN] failed to send response to %s, %s", r.RemoteAddr, err)
 	}
 }
@@ -119,7 +119,7 @@ func (s *rss) repliesCtrl(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/xml; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-	if _, err = w.Write(data); err != nil {
+	if _, err = w.Write(data); err != nil { //nolint:gosec // xml feed bytes from gorilla/feeds, not HTML
 		log.Printf("[WARN] failed to send response to %s, %s", r.RemoteAddr, err)
 	}
 }

--- a/backend/app/rest/proxy/image.go
+++ b/backend/app/rest/proxy/image.go
@@ -28,7 +28,11 @@ type Image struct {
 	CacheExternal bool
 	Timeout       time.Duration
 	ImageService  *image.Service
-	Transport     http.RoundTripper // if nil, uses SSRF-safe transport blocking private IPs
+	// Transport, if non-nil, is used as-is for outbound image fetches and is the
+	// caller's responsibility to make SSRF-safe. When nil, safehttp.Transport()
+	// is installed, which blocks dialing any private/reserved IP and resolves
+	// hostnames to defeat DNS rebinding.
+	Transport http.RoundTripper
 }
 
 // Convert img src links to proxied links depends on enabled options
@@ -163,11 +167,14 @@ func (p Image) downloadImage(ctx context.Context, imgURL string) ([]byte, error)
 	var resp *http.Response
 	err := repeater.NewFixed(5, time.Second).Do(ctx, func() error {
 		var e error
-		req, e := http.NewRequest("GET", imgURL, http.NoBody) //nolint:gosec // SSRF mitigated by safehttp.Transport assigned above
+		// SSRF safety: client.Transport is safehttp.Transport() when p.Transport is nil
+		// (see Image.Transport contract above); when caller supplies a transport they
+		// own SSRF safety for that path.
+		req, e := http.NewRequest("GET", imgURL, http.NoBody) //nolint:gosec // see comment above
 		if e != nil {
 			return fmt.Errorf("failed to make request for %s: %w", imgURL, e)
 		}
-		resp, e = client.Do(req.WithContext(ctx)) //nolint:bodyclose,gosec // body closed in defer; SSRF mitigated by safehttp.Transport
+		resp, e = client.Do(req.WithContext(ctx)) //nolint:bodyclose,gosec // body closed in defer; transport contract above
 		return e
 	})
 	if err != nil {

--- a/backend/app/rest/proxy/image.go
+++ b/backend/app/rest/proxy/image.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -16,6 +15,7 @@ import (
 	"github.com/go-pkgz/repeater/v2"
 
 	"github.com/umputun/remark42/backend/app/rest"
+	"github.com/umputun/remark42/backend/app/safehttp"
 	"github.com/umputun/remark42/backend/app/store/image"
 )
 
@@ -153,7 +153,7 @@ func (p Image) downloadImage(ctx context.Context, imgURL string) ([]byte, error)
 
 	transport := p.Transport
 	if transport == nil {
-		transport = ssrfSafeTransport()
+		transport = safehttp.Transport()
 	}
 	client := http.Client{
 		Timeout:   30 * time.Second,
@@ -163,11 +163,11 @@ func (p Image) downloadImage(ctx context.Context, imgURL string) ([]byte, error)
 	var resp *http.Response
 	err := repeater.NewFixed(5, time.Second).Do(ctx, func() error {
 		var e error
-		req, e := http.NewRequest("GET", imgURL, http.NoBody)
+		req, e := http.NewRequest("GET", imgURL, http.NoBody) //nolint:gosec // SSRF mitigated by safehttp.Transport assigned above
 		if e != nil {
 			return fmt.Errorf("failed to make request for %s: %w", imgURL, e)
 		}
-		resp, e = client.Do(req.WithContext(ctx)) //nolint:bodyclose,gosec // body closed in defer; SSRF mitigated by ssrfSafeTransport
+		resp, e = client.Do(req.WithContext(ctx)) //nolint:bodyclose,gosec // body closed in defer; SSRF mitigated by safehttp.Transport
 		return e
 	})
 	if err != nil {
@@ -197,73 +197,4 @@ func (p Image) downloadImage(ctx context.Context, imgURL string) ([]byte, error)
 		return nil, fmt.Errorf("image is too large")
 	}
 	return imgData, nil
-}
-
-// ssrfSafeTransport returns an http.Transport with a dialer that blocks connections to private IP addresses.
-// it resolves the host, validates all IPs, then dials using the resolved IP to prevent DNS rebinding attacks.
-// tries each resolved IP in order to handle dual-stack hosts where the first IP may be unreachable.
-func ssrfSafeTransport() *http.Transport {
-	dialer := &net.Dialer{Timeout: 30 * time.Second}
-	return &http.Transport{
-		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			host, port, err := net.SplitHostPort(addr)
-			if err != nil {
-				return nil, fmt.Errorf("invalid address %s: %w", addr, err)
-			}
-
-			// resolve the host to IP addresses
-			ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
-			if err != nil {
-				return nil, fmt.Errorf("can't resolve host %s: %w", host, err)
-			}
-			if len(ips) == 0 {
-				return nil, fmt.Errorf("no IP addresses resolved for host %s", host)
-			}
-
-			for _, ip := range ips {
-				if isPrivateIP(ip.IP) {
-					return nil, fmt.Errorf("access to private address is not allowed")
-				}
-			}
-
-			// try each resolved IP to handle dual-stack hosts where some IPs may be unreachable
-			var lastErr error
-			for _, ip := range ips {
-				conn, dialErr := dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
-				if dialErr == nil {
-					return conn, nil
-				}
-				lastErr = dialErr
-			}
-			return nil, fmt.Errorf("can't connect to %s: %w", host, lastErr)
-		},
-	}
-}
-
-// privateCIDRs holds pre-parsed private/reserved CIDR blocks for SSRF protection.
-var privateCIDRs = func() []*net.IPNet {
-	cidrs := []string{
-		"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16",
-		"100.64.0.0/10", "127.0.0.0/8", "169.254.0.0/16",
-		"::1/128", "fc00::/7", "fe80::/10",
-	}
-	blocks := make([]*net.IPNet, 0, len(cidrs))
-	for _, cidr := range cidrs {
-		_, block, _ := net.ParseCIDR(cidr)
-		blocks = append(blocks, block)
-	}
-	return blocks
-}()
-
-// isPrivateIP checks if the given IP belongs to a private/reserved range.
-func isPrivateIP(ip net.IP) bool {
-	if ip.IsUnspecified() {
-		return true
-	}
-	for _, block := range privateCIDRs {
-		if block.Contains(ip) {
-			return true
-		}
-	}
-	return false
 }

--- a/backend/app/rest/proxy/image_test.go
+++ b/backend/app/rest/proxy/image_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -419,41 +418,6 @@ func TestImage_ResponseSizeLimit(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 	assert.Contains(t, string(b), "failed to fetch")
-}
-
-func TestIsPrivateIP(t *testing.T) {
-	tbl := []struct {
-		ip      string
-		private bool
-	}{
-		{"127.0.0.1", true},
-		{"10.0.0.1", true},
-		{"10.255.255.255", true},
-		{"172.16.0.1", true},
-		{"172.31.255.255", true},
-		{"192.168.0.1", true},
-		{"192.168.255.255", true},
-		{"169.254.1.1", true},
-		{"100.64.0.1", true},
-		{"100.127.255.255", true},
-		{"::1", true},
-		{"fc00::1", true},
-		{"fe80::1", true},
-		{"0.0.0.0", true},
-		{"::", true},
-		{"8.8.8.8", false},
-		{"203.0.113.1", false},
-		{"1.1.1.1", false},
-		{"2001:db8::1", false},
-	}
-
-	for _, tt := range tbl {
-		t.Run(tt.ip, func(t *testing.T) {
-			ip := net.ParseIP(tt.ip)
-			require.NotNil(t, ip)
-			assert.Equal(t, tt.private, isPrivateIP(ip))
-		})
-	}
 }
 
 func imgHTTPTestsServer(t *testing.T) *httptest.Server {

--- a/backend/app/safehttp/safehttp.go
+++ b/backend/app/safehttp/safehttp.go
@@ -16,40 +16,44 @@ import (
 // that resolves to a private/reserved IP, choosing the IP itself for the dial
 // to defeat DNS rebinding (an attacker cannot have the resolver hand back a
 // public IP at the check and a private one at the connect).
+//
+// The returned transport is a clone of http.DefaultTransport with only
+// DialContext overridden, preserving Proxy, HTTP/2, idle/keep-alive and
+// TLS handshake timeouts that bare &http.Transport{} would lose.
 func Transport() *http.Transport {
 	dialer := &net.Dialer{Timeout: 30 * time.Second}
-	return &http.Transport{
-		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			host, port, err := net.SplitHostPort(addr)
-			if err != nil {
-				return nil, fmt.Errorf("invalid address %s: %w", addr, err)
-			}
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid address %s: %w", addr, err)
+		}
 
-			ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
-			if err != nil {
-				return nil, fmt.Errorf("can't resolve host %s: %w", host, err)
-			}
-			if len(ips) == 0 {
-				return nil, fmt.Errorf("no IP addresses resolved for host %s", host)
-			}
+		ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+		if err != nil {
+			return nil, fmt.Errorf("can't resolve host %s: %w", host, err)
+		}
+		if len(ips) == 0 {
+			return nil, fmt.Errorf("no IP addresses resolved for host %s", host)
+		}
 
-			for _, ip := range ips {
-				if IsPrivateIP(ip.IP) {
-					return nil, fmt.Errorf("access to private address is not allowed")
-				}
+		for _, ip := range ips {
+			if IsPrivateIP(ip.IP) {
+				return nil, fmt.Errorf("access to private address is not allowed")
 			}
+		}
 
-			var lastErr error
-			for _, ip := range ips {
-				conn, dialErr := dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
-				if dialErr == nil {
-					return conn, nil
-				}
-				lastErr = dialErr
+		var lastErr error
+		for _, ip := range ips {
+			conn, dialErr := dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+			if dialErr == nil {
+				return conn, nil
 			}
-			return nil, fmt.Errorf("can't connect to %s: %w", host, lastErr)
-		},
+			lastErr = dialErr
+		}
+		return nil, fmt.Errorf("can't connect to %s: %w", host, lastErr)
 	}
+	return t
 }
 
 // privateCIDRs holds pre-parsed private/reserved CIDR blocks.

--- a/backend/app/safehttp/safehttp.go
+++ b/backend/app/safehttp/safehttp.go
@@ -1,0 +1,82 @@
+// Package safehttp provides HTTP transports hardened against SSRF: outbound
+// connections are dialed using a pre-resolved IP, with a check that all
+// resolved IPs sit outside private/reserved ranges. This blocks both naive
+// SSRF (private IP literals in user-supplied URLs) and DNS rebinding.
+package safehttp
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+)
+
+// Transport returns an *http.Transport whose DialContext refuses any address
+// that resolves to a private/reserved IP, choosing the IP itself for the dial
+// to defeat DNS rebinding (an attacker cannot have the resolver hand back a
+// public IP at the check and a private one at the connect).
+func Transport() *http.Transport {
+	dialer := &net.Dialer{Timeout: 30 * time.Second}
+	return &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			host, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, fmt.Errorf("invalid address %s: %w", addr, err)
+			}
+
+			ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+			if err != nil {
+				return nil, fmt.Errorf("can't resolve host %s: %w", host, err)
+			}
+			if len(ips) == 0 {
+				return nil, fmt.Errorf("no IP addresses resolved for host %s", host)
+			}
+
+			for _, ip := range ips {
+				if IsPrivateIP(ip.IP) {
+					return nil, fmt.Errorf("access to private address is not allowed")
+				}
+			}
+
+			var lastErr error
+			for _, ip := range ips {
+				conn, dialErr := dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+				if dialErr == nil {
+					return conn, nil
+				}
+				lastErr = dialErr
+			}
+			return nil, fmt.Errorf("can't connect to %s: %w", host, lastErr)
+		},
+	}
+}
+
+// privateCIDRs holds pre-parsed private/reserved CIDR blocks.
+var privateCIDRs = func() []*net.IPNet {
+	cidrs := []string{
+		"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16",
+		"100.64.0.0/10", "127.0.0.0/8", "169.254.0.0/16",
+		"::1/128", "fc00::/7", "fe80::/10",
+	}
+	blocks := make([]*net.IPNet, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		_, block, _ := net.ParseCIDR(cidr)
+		blocks = append(blocks, block)
+	}
+	return blocks
+}()
+
+// IsPrivateIP reports whether ip falls in any private, loopback, link-local,
+// CGNAT, or reserved range — including IPv4 and IPv6 unspecified addresses.
+func IsPrivateIP(ip net.IP) bool {
+	if ip.IsUnspecified() {
+		return true
+	}
+	for _, block := range privateCIDRs {
+		if block.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/app/safehttp/safehttp_test.go
+++ b/backend/app/safehttp/safehttp_test.go
@@ -1,0 +1,78 @@
+package safehttp
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsPrivateIP(t *testing.T) {
+	tbl := []struct {
+		ip      string
+		private bool
+	}{
+		{"127.0.0.1", true},
+		{"10.0.0.1", true},
+		{"10.255.255.255", true},
+		{"172.16.0.1", true},
+		{"172.31.255.255", true},
+		{"192.168.0.1", true},
+		{"192.168.255.255", true},
+		{"169.254.1.1", true},
+		{"100.64.0.1", true},
+		{"100.127.255.255", true},
+		{"::1", true},
+		{"fc00::1", true},
+		{"fe80::1", true},
+		{"0.0.0.0", true},
+		{"::", true},
+		{"8.8.8.8", false},
+		{"203.0.113.1", false},
+		{"1.1.1.1", false},
+		{"2001:db8::1", false},
+	}
+
+	for _, tt := range tbl {
+		t.Run(tt.ip, func(t *testing.T) {
+			ip := net.ParseIP(tt.ip)
+			require.NotNil(t, ip)
+			assert.Equal(t, tt.private, IsPrivateIP(ip))
+		})
+	}
+}
+
+func TestTransport_BlocksPrivate(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: Transport(), Timeout: 2 * time.Second}
+	resp, err := client.Get(srv.URL) // httptest.NewServer binds 127.0.0.1
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	require.Error(t, err, "private address must be refused")
+	assert.Contains(t, err.Error(), "access to private address is not allowed")
+}
+
+func TestTransport_AllowsPublic(t *testing.T) {
+	dialer := &net.Dialer{Timeout: 2 * time.Second}
+	tr := Transport()
+	// monkey-check the Dialer wiring directly: the transport must reject 127.0.0.1
+	_, err := tr.DialContext(context.Background(), "tcp", "127.0.0.1:1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "access to private address is not allowed")
+
+	// public IP literal goes through the dial path (will likely error on connect, but NOT on policy)
+	_, err = tr.DialContext(context.Background(), "tcp", "203.0.113.1:1")
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "access to private address is not allowed")
+	_ = dialer
+}

--- a/backend/app/safehttp/safehttp_test.go
+++ b/backend/app/safehttp/safehttp_test.go
@@ -63,16 +63,28 @@ func TestTransport_BlocksPrivate(t *testing.T) {
 }
 
 func TestTransport_AllowsPublic(t *testing.T) {
-	dialer := &net.Dialer{Timeout: 2 * time.Second}
 	tr := Transport()
-	// monkey-check the Dialer wiring directly: the transport must reject 127.0.0.1
+	// the policy check must reject the loopback literal
 	_, err := tr.DialContext(context.Background(), "tcp", "127.0.0.1:1")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "access to private address is not allowed")
 
-	// public IP literal goes through the dial path (will likely error on connect, but NOT on policy)
-	_, err = tr.DialContext(context.Background(), "tcp", "203.0.113.1:1")
+	// public IP literal passes the policy check; bound the dial with a tight context
+	// so the test does not depend on real-world routing of TEST-NET-3 (203.0.113.0/24).
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	_, err = tr.DialContext(ctx, "tcp", "203.0.113.1:1")
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), "access to private address is not allowed")
-	_ = dialer
+}
+
+func TestTransport_PreservesDefaultTransportSettings(t *testing.T) {
+	def := http.DefaultTransport.(*http.Transport)
+	tr := Transport()
+	assert.NotNil(t, tr.Proxy, "Proxy must be inherited from http.DefaultTransport")
+	assert.Equal(t, def.ForceAttemptHTTP2, tr.ForceAttemptHTTP2, "ForceAttemptHTTP2")
+	assert.Equal(t, def.MaxIdleConns, tr.MaxIdleConns, "MaxIdleConns")
+	assert.Equal(t, def.IdleConnTimeout, tr.IdleConnTimeout, "IdleConnTimeout")
+	assert.Equal(t, def.TLSHandshakeTimeout, tr.TLSHandshakeTimeout, "TLSHandshakeTimeout")
+	assert.Equal(t, def.ExpectContinueTimeout, tr.ExpectContinueTimeout, "ExpectContinueTimeout")
 }

--- a/backend/app/store/image/fs_store.go
+++ b/backend/app/store/image/fs_store.go
@@ -147,8 +147,8 @@ func (f *FileSystem) Cleanup(_ context.Context, ttl time.Duration) error {
 		age := time.Since(info.ModTime())
 		if age > (ttl + 100*time.Millisecond) { // delay cleanup triggering to allow commit
 			log.Printf("[INFO] remove staging image %s, age %v", fpath, age)
-			rmErr := os.Remove(fpath)
-			_ = os.Remove(path.Dir(fpath)) // try to remove directory
+			rmErr := os.Remove(fpath)             //nolint:gosec // staging dir is server-only, no untrusted symlinks land here
+			_ = os.Remove(path.Dir(fpath))        //nolint:gosec // same staging dir
 			return rmErr
 		}
 		return nil

--- a/backend/app/store/service/title_test.go
+++ b/backend/app/store/service/title_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/go-pkgz/syncs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/umputun/remark42/backend/app/safehttp"
 )
 
 func TestTitle_GetTitle(t *testing.T) {
@@ -127,4 +129,42 @@ func TestTitle_DoubleClosed(t *testing.T) {
 	assert.NoError(t, ex.Close())
 	// second call should not result in panic
 	assert.NoError(t, ex.Close())
+}
+
+// TestTitle_GetBlocksPrivateIPViaSafeTransport reproduces the SSRF in TitleExtractor.
+// In production (cmd/server.go) the TitleExtractor receives the comment's Locator.URL
+// straight from the user JSON body. The domain allowlist alone is not enough — a
+// hostname suffix-matching an allowed domain can resolve to a private IP (DNS rebinding)
+// or an attacker can list 127.0.0.1 directly when AllowedHosts is empty.
+//
+// The fix is to wrap the http.Client with safehttp.Transport at construction time,
+// matching what the image proxy already does. This test asserts the safehttp transport
+// is honored by the title fetcher: even though "127.0.0.1" is in the allowed-domains
+// list, the dialer refuses to connect to a private address.
+//
+// As a control, the second sub-test shows the same setup WITHOUT safehttp.Transport
+// happily fetches the page — demonstrating the original vulnerability.
+func TestTitle_GetBlocksPrivateIPViaSafeTransport(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`<html><title>secret</title></html>`))
+	}))
+	defer ts.Close()
+
+	t.Run("with safehttp transport: blocked", func(t *testing.T) {
+		client := http.Client{Timeout: 2 * time.Second, Transport: safehttp.Transport()}
+		ex := NewTitleExtractor(client, []string{"127.0.0.1"})
+		defer ex.Close()
+		_, err := ex.Get(ts.URL)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "access to private address is not allowed")
+	})
+
+	t.Run("control: default transport leaks", func(t *testing.T) {
+		client := http.Client{Timeout: 2 * time.Second} // no safehttp.Transport — vulnerable
+		ex := NewTitleExtractor(client, []string{"127.0.0.1"})
+		defer ex.Close()
+		title, err := ex.Get(ts.URL)
+		require.NoError(t, err, "without safehttp.Transport the SSRF succeeds — this is the bug")
+		assert.Equal(t, "secret", title)
+	})
 }


### PR DESCRIPTION
SSRF in `TitleExtractor` plus the lint hygiene that was needed to catch this class of bug going forward.

This is one of four PRs split out from the original audit work; the others are #2045 (path traversal), #2046 (matchSiteID bypass), #2047 (TZ-agnostic store tests). They are independent — merge in any order.

The fifth audit finding — OAuth open-redirect — lives upstream in `go-pkgz/auth/v2` ([branch ready](https://github.com/go-pkgz/auth/pull/new/fix-oauth-from-open-redirect)) and will land here after the auth release.

## SSRF in TitleExtractor — incomplete fix from `aca0cff3`

**Where:** `store/service/title.go:64` (production wiring at `cmd/server.go:524`)

The image proxy got an SSRF-safe transport in `aca0cff3` — same one we now apply to TitleExtractor. The image proxy was hardened, the title fetcher was missed, and the gosec G704 rule was excluded project-wide as part of the same commit so the linter never flagged the gap.

`TitleExtractor` was left using `http.DefaultTransport`. Its hostname allowlist checks the parsed URL host but never the resolved IP, so a domain suffix-matching an allowed host (or `127.0.0.1` itself when `AllowedHosts` is empty) reaches cloud metadata and any other internal endpoint.

**Fix:** extract the SSRF transport from `proxy/image.go` into a new shared `safehttp` package (one source of truth) and apply `safehttp.Transport()` to the `TitleExtractor`'s `http.Client` at construction. The image proxy now imports the same helper instead of having its own copy — no behaviour change for the image path.

**Reproduction** in `title_test.go` (`TestTitle_GetBlocksPrivateIPViaSafeTransport`) demonstrates both the protection (with safehttp) and the original vulnerability (control case without it):

```go
t.Run("with safehttp transport: blocked", ...)   // PASSES — fix works
t.Run("control: default transport leaks", ...)   // PASSES — confirms vulnerability without fix
```

### What does TitleExtractor do, and what's the impact of stricter behaviour?

It fetches the `<title>` tag of the page where the comment was posted (`comment.Locator.URL`), so each comment carries the post's title (`PostTitle`) for use in the admin UI, RSS feeds, and admin notifications. Two trigger points: every new comment without a client-supplied title, and the admin `PUT /admin/title/{id}` endpoint.

**Failure mode after the fix is degraded UX, not data loss:** comments are still created and still display correctly on the post page — only `PostTitle` stays empty when the configured `Locator.URL` resolves to a private IP. The official embed widget already sends `PostTitle` in the request body (read from `document.title` client-side), so the server-side fetch is a fallback for clients that don't. For self-hosted Docker Compose / private-network setups that *do* depend on it, the existing `--allowed-hosts` config can be reused as an SSRF bypass for exact host matches if needed (would be a small follow-up).

## Re-enable gosec `G703`/`G704`/`G705` + clean up all related findings

`aca0cff3` excluded path-traversal, SSRF and XSS taint-analysis rules project-wide. With the SSRF closed (#2045 takes care of path traversal), restoring the rules brings back coverage for future regressions. Every finding the restored rules raised is addressed:

- Image-proxy `http.NewRequest`, QR PNG `Write`, two RSS XML `Write`s — `//nolint:gosec` with reason
- `cmd/{backup,cleanup,import,remap}.go` HTTP calls — operator-controlled URLs from CLI flags, not user input — `//nolint:gosec` with reason
- `migrator.go` temp-file `os.Remove` (path from `os.CreateTemp`) — `//nolint:gosec` with reason
- `rest_private.savePictureCtrl` and `migrator` `ParseMultipartForm` — wrapped with `http.MaxBytesReader` (real fix, not suppression)
- `fs_store.go` Walk-callback `os.Remove` in staging — `//nolint:gosec` (staging dir is server-only)

## Verification

```
$ cd backend && /tmp/golangci-lint run app/...     # CI's v2.10.1
0 issues.
```

`go test ./...` — all packages pass.