### PR TITLE
fix(api): reject path traversal in /picture/{user}/{id}

### DIFF
--- a/backend/app/rest/api/rest_public.go
+++ b/backend/app/rest/api/rest_public.go
@@ -373,13 +373,13 @@ func (s *public) listCtrl(w http.ResponseWriter, r *http.Request) {
 // etc.) also closes a log-injection vector since the rejected segment is
 // echoed into the access log.
 func safePictureSegment(seg string) bool {
-	if seg == "" || seg == "." || seg == ".." {
+	if seg == "" || seg == "." {
 		return false
 	}
 	if strings.ContainsAny(seg, "/\\") {
 		return false
 	}
-	if strings.Contains(seg, "..") {
+	if strings.Contains(seg, "..") { // also covers seg == ".."
 		return false
 	}
 	for _, r := range seg {
@@ -464,7 +464,7 @@ func (s *public) telegramQrCtrl(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "image/png")
-	if _, err = w.Write(png); err != nil { //nolint:gosec // png bytes from go-qrcode, not HTML
+	if _, err = w.Write(png); err != nil {
 		log.Printf("[WARN] can't render qr, %v", err)
 	}
 }

--- a/backend/app/rest/api/rest_public.go
+++ b/backend/app/rest/api/rest_public.go
@@ -364,12 +364,36 @@ func (s *public) listCtrl(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// safePictureSegment reports whether seg is acceptable as a path segment in
+// the picture URL (no traversal markers, no path separators, no NULs). Picture
+// IDs are server-generated hashes plus a known extension, so any value carrying
+// these characters is hostile and must be rejected before reaching the store.
+func safePictureSegment(seg string) bool {
+	if seg == "" || seg == "." || seg == ".." {
+		return false
+	}
+	if strings.ContainsAny(seg, "/\\\x00") {
+		return false
+	}
+	if strings.Contains(seg, "..") {
+		return false
+	}
+	return true
+}
+
 // GET /picture/{user}/{id} - get picture
 func (s *public) loadPictureCtrl(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "user") + "/" + chi.URLParam(r, "id")
+	user, imgID := chi.URLParam(r, "user"), chi.URLParam(r, "id")
+	if user == "" || imgID == "" || !safePictureSegment(user) || !safePictureSegment(imgID) {
+		log.Printf("[WARN] rejected picture request with unsafe id segments user=%q id=%q", user, imgID)
+		rest.SendErrorJSON(w, r, http.StatusBadRequest, fmt.Errorf("invalid picture id"), "invalid picture id", rest.ErrAssetNotFound)
+		return
+	}
+	id := user + "/" + imgID
 	img, err := s.imageService.Load(id)
 	if err != nil {
-		rest.SendErrorJSON(w, r, http.StatusBadRequest, err, "can't get image "+id, rest.ErrAssetNotFound)
+		log.Printf("[WARN] can't load image %s: %v", id, err)
+		rest.SendErrorJSON(w, r, http.StatusBadRequest, fmt.Errorf("image not found"), "can't get image", rest.ErrAssetNotFound)
 		return
 	}
 	// enforce client-side caching
@@ -431,7 +455,7 @@ func (s *public) telegramQrCtrl(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "image/png")
-	if _, err = w.Write(png); err != nil {
+	if _, err = w.Write(png); err != nil { //nolint:gosec // png bytes from go-qrcode, not HTML
 		log.Printf("[WARN] can't render qr, %v", err)
 	}
 }

--- a/backend/app/rest/api/rest_public.go
+++ b/backend/app/rest/api/rest_public.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/go-chi/chi/v5"
 	cache "github.com/go-pkgz/lcw/v2"
@@ -365,18 +366,26 @@ func (s *public) listCtrl(w http.ResponseWriter, r *http.Request) {
 }
 
 // safePictureSegment reports whether seg is acceptable as a path segment in
-// the picture URL (no traversal markers, no path separators, no NULs). Picture
-// IDs are server-generated hashes plus a known extension, so any value carrying
-// these characters is hostile and must be rejected before reaching the store.
+// the picture URL (no traversal markers, no path separators, no control
+// characters). Picture IDs are server-generated hashes plus a known
+// extension, so any value carrying these characters is hostile and must be
+// rejected before reaching the store. Rejecting controls (CR, LF, TAB, NUL,
+// etc.) also closes a log-injection vector since the rejected segment is
+// echoed into the access log.
 func safePictureSegment(seg string) bool {
 	if seg == "" || seg == "." || seg == ".." {
 		return false
 	}
-	if strings.ContainsAny(seg, "/\\\x00") {
+	if strings.ContainsAny(seg, "/\\") {
 		return false
 	}
 	if strings.Contains(seg, "..") {
 		return false
+	}
+	for _, r := range seg {
+		if unicode.IsControl(r) {
+			return false
+		}
 	}
 	return true
 }

--- a/backend/app/rest/api/rest_public_test.go
+++ b/backend/app/rest/api/rest_public_test.go
@@ -1028,3 +1028,41 @@ func TestRest_Robots(t *testing.T) {
 		"Allow: /api/v1/list\nAllow: /api/v1/config\nAllow: /api/v1/user\nAllow: /api/v1/img\n"+
 		"Allow: /api/v1/avatar\nAllow: /api/v1/picture\n", body)
 }
+
+// TestRest_LoadPictureRejectsPathTraversal reproduces the unauthenticated path-traversal
+// vulnerability in GET /api/v1/picture/{user}/{id}. Before the fix, the handler concatenated
+// the URL params verbatim into a filesystem path via path.Join, so a request like
+// `/api/v1/picture/../remark.db` would resolve to `<base>/../remark.db`, escaping the image
+// directory. Even when the file did not exist (default Partitions=100 mitigates direct hits),
+// the FS error message leaked the constructed internal path back to the unauthenticated caller.
+func TestRest_LoadPictureRejectsPathTraversal(t *testing.T) {
+	ts, _, teardown := startupT(t)
+	defer teardown()
+
+	cases := []struct {
+		name string
+		path string
+	}{
+		{name: "dotdot in user segment", path: "/api/v1/picture/../remark.db"},
+		{name: "dotdot in id segment", path: "/api/v1/picture/dev_user/..%2Fremark.db"},
+		{name: "encoded dotdot in user segment", path: "/api/v1/picture/%2E%2E/remark.db"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, ts.URL+c.path, http.NoBody)
+			require.NoError(t, err)
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer func() { _ = resp.Body.Close() }()
+
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			s := string(body)
+			assert.NotContains(t, s, "..", "error body must not echo traversal marker")
+			assert.NotContains(t, s, "remark.db", "error body must not echo attacker-supplied filename")
+			assert.NotContains(t, s, "no such file", "error body must not leak filesystem state")
+			assert.NotContains(t, s, "/var/", "error body must not leak internal filesystem path")
+		})
+	}
+}

--- a/backend/app/rest/api/rest_public_test.go
+++ b/backend/app/rest/api/rest_public_test.go
@@ -1066,3 +1066,41 @@ func TestRest_LoadPictureRejectsPathTraversal(t *testing.T) {
 		})
 	}
 }
+
+// TestRest_LoadPictureRejectsControlCharsInSegment makes sure a CRLF / tab / NUL
+// in the URL segment is rejected by safePictureSegment. Without the rejection
+// the [WARN] log line constructed from %q-formatted segments would still be
+// safe (Go's %q escapes control chars), but a future log change to %s would
+// turn this into log forgery — and no legitimate picture id ever needs control
+// characters, so the right place to slam the door is in the validator.
+func TestRest_LoadPictureRejectsControlCharsInSegment(t *testing.T) {
+	ts, _, teardown := startupT(t)
+	defer teardown()
+
+	cases := []struct {
+		name string
+		path string
+	}{
+		{name: "lf in user segment", path: "/api/v1/picture/dev%0Auser/abc.png"},
+		{name: "cr in user segment", path: "/api/v1/picture/dev%0Duser/abc.png"},
+		{name: "tab in user segment", path: "/api/v1/picture/dev%09user/abc.png"},
+		{name: "lf in id segment", path: "/api/v1/picture/dev_user/abc%0A.png"},
+		{name: "nul in id segment", path: "/api/v1/picture/dev_user/abc%00.png"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, ts.URL+c.path, http.NoBody)
+			require.NoError(t, err)
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer func() { _ = resp.Body.Close() }()
+
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			s := string(body)
+			assert.Contains(t, s, "invalid picture id", "must reject as invalid input, not fall through to storage")
+			assert.NotContains(t, s, "no such file", "must not reach the filesystem")
+		})
+	}
+}


### PR DESCRIPTION
Unauthenticated path traversal in `GET /api/v1/picture/{user}/{id}`.

## Reproduction on `demo.remark42.com` (master, before this PR)

```console
$ curl -sS --path-as-is -i "https://demo.remark42.com/api/v1/picture/../remark.db" | tail -2
content-length: 191

{"code":18,"details":"can't get image ../remark.db","error":"can't get image file for ../remark.db: can't get image stats for ../remark.db: stat var/24/remark.db: no such file or directory"}
```

The 400 body leaks `var/24/remark.db` — confirming `..` reaches `path.Join` unsanitised. Default `Partitions=100` makes the file at the resolved path not exist in practice, but with `Partitions=0` (a documented option) the same probe returns the BoltDB. The error response also leaks the internal filesystem path in either configuration.

## After this PR

Same three probes run against a local handler built from this branch:

```console
$ curl -sS --path-as-is -i "http://localhost:xxxx/api/v1/picture/../remark.db"
HTTP 400
{"code":18,"details":"invalid picture id","error":"invalid picture id"}

$ curl -sS --path-as-is -i "http://localhost:xxxx/api/v1/picture/dev_user/..%2Fremark.db"
HTTP 400
{"code":18,"details":"invalid picture id","error":"invalid picture id"}

$ curl -sS --path-as-is -i "http://localhost:xxxx/api/v1/picture/%2E%2E/remark.db"
HTTP 400
{"code":18,"details":"can't get image","error":"image not found"}
```

`..` and `..%2F` are rejected at the handler entry with a generic `invalid picture id` (input-validation trip). `%2E%2E` is preserved by chi as a literal segment, falls through to the regular image load, and returns the sanitised `image not found`. In all cases: no attacker-supplied string is echoed, no internal filesystem path leaks, the original error is logged server-side for operators.

## Fix

`safePictureSegment` validates both URL params (rejects `..`, `/`, `\\`, NUL) at the handler entry. The raw filesystem error is replaced with a generic `image not found` and the original is logged for operators.

Reproduction test in `rest_public_test.go` covers `..`, `..` in id segment, and percent-encoded `..`.

## Verification

`go test ./rest/api/...` — green.