### PR TITLE
test(store): use time.UTC in test fixtures to be timezone-agnostic

### DIFF
--- a/backend/app/store/comment_test.go
+++ b/backend/app/store/comment_test.go
@@ -120,7 +120,7 @@ func TestComment_PrepareUntrusted(t *testing.T) {
 		Score:       10,
 		Pin:         true,
 		Deleted:     true,
-		Timestamp:   time.Date(2018, 1, 1, 9, 30, 0, 0, time.Local),
+		Timestamp:   time.Date(2018, 1, 1, 9, 30, 0, 0, time.UTC),
 		Votes:       map[string]bool{"uu": true},
 		Controversy: 123,
 		Imported:    true,
@@ -150,7 +150,7 @@ func TestComment_SetDeleted(t *testing.T) {
 		Locator:   Locator{SiteID: "site", URL: "url"},
 		Score:     10,
 		Deleted:   false,
-		Timestamp: time.Date(2018, 1, 1, 9, 30, 0, 0, time.Local),
+		Timestamp: time.Date(2018, 1, 1, 9, 30, 0, 0, time.UTC),
 		Votes:     map[string]bool{"uu": true},
 		Pin:       true,
 	}
@@ -177,7 +177,7 @@ func TestComment_SetDeletedHard(t *testing.T) {
 		Locator:   Locator{SiteID: "site", URL: "url"},
 		Score:     10,
 		Deleted:   false,
-		Timestamp: time.Date(2018, 1, 1, 9, 30, 0, 0, time.Local),
+		Timestamp: time.Date(2018, 1, 1, 9, 30, 0, 0, time.UTC),
 		Votes:     map[string]bool{"uu": true},
 		Pin:       true,
 	}

--- a/backend/app/store/engine/bolt_test.go
+++ b/backend/app/store/engine/bolt_test.go
@@ -48,7 +48,7 @@ func TestBoltDB_CreateFailedReadOnly(t *testing.T) {
 	comment := store.Comment{
 		ID:        "id-ro",
 		Text:      `some text, <a href="http://radio-t.com">link</a>`,
-		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.Local),
+		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.UTC),
 		Locator:   store.Locator{URL: "https://radio-t.com/ro", SiteID: "radio-t"},
 		User:      store.User{ID: "user1", Name: "user name"},
 	}
@@ -147,20 +147,20 @@ func TestBoltDB_FindLastSince(t *testing.T) {
 	var b, teardown = prep(t)
 	defer teardown()
 
-	ts := time.Date(2017, 12, 20, 15, 18, 21, 0, time.Local)
+	ts := time.Date(2017, 12, 20, 15, 18, 21, 0, time.UTC)
 	req := FindRequest{Locator: store.Locator{SiteID: "radio-t"}, Sort: "-time", Since: ts}
 	res, err := b.Find(req)
 	assert.NoError(t, err)
 	require.Equal(t, 2, len(res))
 	assert.Equal(t, "some text2", res[0].Text)
 
-	req.Since = time.Date(2017, 12, 20, 15, 18, 22, 0, time.Local)
+	req.Since = time.Date(2017, 12, 20, 15, 18, 22, 0, time.UTC)
 	res, err = b.Find(req)
 	assert.NoError(t, err)
 	require.Equal(t, 1, len(res))
 	assert.Equal(t, "some text2", res[0].Text)
 
-	req.Since = time.Date(2017, 12, 20, 16, 18, 22, 0, time.Local)
+	req.Since = time.Date(2017, 12, 20, 16, 18, 22, 0, time.UTC)
 	res, err = b.Find(req)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(res))
@@ -170,20 +170,20 @@ func TestBoltDB_FindInPostSince(t *testing.T) {
 	var b, teardown = prep(t)
 	defer teardown()
 
-	ts := time.Date(2017, 12, 20, 15, 18, 21, 0, time.Local)
+	ts := time.Date(2017, 12, 20, 15, 18, 21, 0, time.UTC)
 	req := FindRequest{Locator: store.Locator{URL: "https://radio-t.com", SiteID: "radio-t"}, Sort: "-time", Since: ts}
 	res, err := b.Find(req)
 	assert.NoError(t, err)
 	require.Equal(t, 2, len(res))
 	assert.Equal(t, "some text2", res[0].Text)
 
-	req.Since = time.Date(2017, 12, 20, 15, 18, 22, 0, time.Local)
+	req.Since = time.Date(2017, 12, 20, 15, 18, 22, 0, time.UTC)
 	res, err = b.Find(req)
 	assert.NoError(t, err)
 	require.Equal(t, 1, len(res))
 	assert.Equal(t, "some text2", res[0].Text)
 
-	req.Since = time.Date(2017, 12, 20, 16, 18, 22, 0, time.Local)
+	req.Since = time.Date(2017, 12, 20, 16, 18, 22, 0, time.UTC)
 	res, err = b.Find(req)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(res))
@@ -239,7 +239,7 @@ func TestBoltDB_FindForUserPagination(t *testing.T) {
 	for i := range 200 {
 		c.ID = fmt.Sprintf("id-%d", i)
 		c.Text = fmt.Sprintf("text #%d", i)
-		c.Timestamp = time.Date(2017, 12, 20, 15, 18, i, 0, time.Local)
+		c.Timestamp = time.Date(2017, 12, 20, 15, 18, i, 0, time.UTC)
 		_, err = b.Create(c)
 		require.NoError(t, err)
 	}
@@ -324,13 +324,13 @@ func TestBoltDB_InfoPost(t *testing.T) {
 	b, teardown := prep(t) // two comments for https://radio-t.com
 	defer teardown()
 
-	ts := func(minute int) time.Time { return time.Date(2017, 12, 20, 15, 18, minute, 0, time.Local) }
+	ts := func(minute int) time.Time { return time.Date(2017, 12, 20, 15, 18, minute, 0, time.UTC) }
 
 	// add one more for https://radio-t.com/2
 	comment := store.Comment{
 		ID:        "12345",
 		Text:      `some text, <a href="http://radio-t.com">link</a>`,
-		Timestamp: time.Date(2017, 12, 20, 15, 18, 24, 0, time.Local),
+		Timestamp: time.Date(2017, 12, 20, 15, 18, 24, 0, time.UTC),
 		Locator:   store.Locator{URL: "https://radio-t.com/2", SiteID: "radio-t"},
 		User:      store.User{ID: "user1", Name: "user name"},
 	}
@@ -379,14 +379,14 @@ func TestBoltDB_InfoList(t *testing.T) {
 	comment := store.Comment{
 		ID:        "12345",
 		Text:      `some text, <a href="http://radio-t.com">link</a>`,
-		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.Local),
+		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.UTC),
 		Locator:   store.Locator{URL: "https://radio-t.com/2", SiteID: "radio-t"},
 		User:      store.User{ID: "user1", Name: "user name"},
 	}
 	_, err := b.Create(comment)
 	assert.NoError(t, err)
 
-	ts := func(sec int) time.Time { return time.Date(2017, 12, 20, 15, 18, sec, 0, time.Local) }
+	ts := func(sec int) time.Time { return time.Date(2017, 12, 20, 15, 18, sec, 0, time.UTC) }
 
 	req := InfoRequest{Locator: store.Locator{SiteID: "radio-t"}}
 	res, err := b.Info(req)
@@ -890,7 +890,7 @@ func TestBoltDB_ref(t *testing.T) {
 	comment := store.Comment{
 		ID:        "12345",
 		Text:      `some text, <a href="http://radio-t.com">link</a>`,
-		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.Local),
+		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.UTC),
 		Locator:   store.Locator{URL: "https://radio-t.com/2", SiteID: "radio-t"},
 		User:      store.User{ID: "user1", Name: "user name"},
 	}
@@ -929,7 +929,7 @@ func prep(t *testing.T) (b *BoltDB, teardown func()) {
 	comment := store.Comment{
 		ID:        "id-1",
 		Text:      `some text, <a href="http://radio-t.com">link</a>`,
-		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.Local),
+		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.UTC),
 		Locator:   store.Locator{URL: "https://radio-t.com", SiteID: "radio-t"},
 		User:      store.User{ID: "user1", Name: "user name"},
 	}
@@ -939,7 +939,7 @@ func prep(t *testing.T) (b *BoltDB, teardown func()) {
 	comment = store.Comment{
 		ID:        "id-2",
 		Text:      "some text2",
-		Timestamp: time.Date(2017, 12, 20, 15, 18, 23, 0, time.Local),
+		Timestamp: time.Date(2017, 12, 20, 15, 18, 23, 0, time.UTC),
 		Locator:   store.Locator{URL: "https://radio-t.com", SiteID: "radio-t"},
 		User:      store.User{ID: "user1", Name: "user name"},
 	}

--- a/backend/app/store/engine/engine_test.go
+++ b/backend/app/store/engine/engine_test.go
@@ -11,10 +11,10 @@ import (
 
 func TestEngine_sortComments(t *testing.T) {
 	cc := []store.Comment{
-		{ID: "1", Score: 5, Controversy: 1, Timestamp: time.Date(2018, 2, 5, 10, 1, 0, 0, time.Local)},
-		{ID: "2", Score: 4, Controversy: 2, Timestamp: time.Date(2018, 2, 5, 10, 2, 0, 0, time.Local)},
-		{ID: "3", Score: 6, Controversy: 3, Timestamp: time.Date(2018, 2, 5, 10, 3, 0, 0, time.Local)},
-		{ID: "4", Score: 6, Controversy: 1, Timestamp: time.Date(2018, 2, 5, 10, 4, 0, 0, time.Local)},
+		{ID: "1", Score: 5, Controversy: 1, Timestamp: time.Date(2018, 2, 5, 10, 1, 0, 0, time.UTC)},
+		{ID: "2", Score: 4, Controversy: 2, Timestamp: time.Date(2018, 2, 5, 10, 2, 0, 0, time.UTC)},
+		{ID: "3", Score: 6, Controversy: 3, Timestamp: time.Date(2018, 2, 5, 10, 3, 0, 0, time.UTC)},
+		{ID: "4", Score: 6, Controversy: 1, Timestamp: time.Date(2018, 2, 5, 10, 4, 0, 0, time.UTC)},
 	}
 
 	SortComments(cc, "+time")

--- a/backend/app/store/formatter_test.go
+++ b/backend/app/store/formatter_test.go
@@ -79,7 +79,7 @@ func TestFormatter_FormatComment(t *testing.T) {
 		Score:     10,
 		Pin:       true,
 		Deleted:   true,
-		Timestamp: time.Date(2018, 1, 1, 9, 30, 0, 0, time.Local),
+		Timestamp: time.Date(2018, 1, 1, 9, 30, 0, 0, time.UTC),
 		Votes:     map[string]bool{"uu": true},
 	}
 

--- a/backend/app/store/service/service_test.go
+++ b/backend/app/store/service/service_test.go
@@ -184,7 +184,7 @@ func TestService_Put(t *testing.T) {
 		Text:      "test text",
 		User:      store.User{ID: "user2", Name: "user name 2"},
 		Locator:   store.Locator{URL: "https://radio-t.com", SiteID: "radio-t"},
-		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.Local),
+		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.UTC),
 	}
 	_, err := b.Create(comment)
 	require.NoError(t, err)
@@ -196,7 +196,7 @@ func TestService_Put(t *testing.T) {
 		Text:      "new text",
 		User:      store.User{ID: "user3", Name: "user name 3"},
 		Locator:   store.Locator{URL: "https://example.com", SiteID: "example"},
-		Timestamp: time.Date(2018, 12, 20, 15, 18, 22, 0, time.Local),
+		Timestamp: time.Date(2018, 12, 20, 15, 18, 22, 0, time.UTC),
 	}
 
 	err = b.Put(store.Locator{URL: "https://radio-t.com", SiteID: "radio-t"}, updatedComment)
@@ -212,7 +212,7 @@ func TestService_Put(t *testing.T) {
 	assert.Equal(t, "user name 2", got.User.Name, "should be unaltered")
 	assert.Equal(t, "https://radio-t.com", got.Locator.URL, "should be unaltered")
 	assert.Equal(t, "radio-t", got.Locator.SiteID, "should be unaltered")
-	assert.Equal(t, time.Date(2017, 12, 20, 15, 18, 22, 0, time.Local), got.Timestamp, "should be unaltered")
+	assert.Equal(t, time.Date(2017, 12, 20, 15, 18, 22, 0, time.UTC), got.Timestamp, "should be unaltered")
 
 }
 
@@ -595,7 +595,7 @@ func TestService_RestrictedWords(t *testing.T) {
 		ID:        "c-1",
 		ParentID:  "id-1",
 		Text:      "restricted word",
-		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.Local),
+		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.UTC),
 		Locator:   store.Locator{URL: "https://radio-t.com", SiteID: "radio-t"},
 		User:      store.User{ID: "user2", Name: "user name 2"},
 	}
@@ -630,7 +630,7 @@ func TestDataStore_AdminStoreErrors(t *testing.T) {
 		ID:        "c-1",
 		ParentID:  "id-1",
 		Text:      "restricted word",
-		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.Local),
+		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.UTC),
 		Locator:   store.Locator{URL: "https://radio-t.com", SiteID: "radio-t"},
 		User:      store.User{ID: "user2", Name: "user name 2"},
 	}
@@ -880,7 +880,7 @@ func TestService_EditCommentReplyFailed(t *testing.T) {
 		ID:        "123456",
 		ParentID:  "id-1",
 		Text:      "some text",
-		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.Local),
+		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.UTC),
 		Locator:   store.Locator{URL: "https://radio-t.com", SiteID: "radio-t"},
 		User:      store.User{ID: "user2", Name: "user name 2"},
 	}
@@ -952,7 +952,7 @@ func TestService_Counts(t *testing.T) {
 	comment := store.Comment{
 		ID:        "123456",
 		Text:      `some text, <a href="http://radio-t.com">link</a>`,
-		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.Local),
+		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.UTC),
 		Locator:   store.Locator{URL: "https://radio-t.com/2", SiteID: "radio-t"},
 		User:      store.User{ID: "user1", Name: "user name"},
 	}
@@ -1123,7 +1123,7 @@ func TestService_HasReplies(t *testing.T) {
 	comment := store.Comment{
 		ID:        "id-1",
 		Text:      `some text, <a href="http://radio-t.com">link</a>`,
-		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.Local),
+		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.UTC),
 		Locator:   store.Locator{URL: "https://radio-t.com", SiteID: "radio-t"},
 		User:      store.User{ID: "user1", Name: "user name"},
 	}
@@ -1133,7 +1133,7 @@ func TestService_HasReplies(t *testing.T) {
 		ID:        "c-1",
 		ParentID:  "id-1",
 		Text:      "some text",
-		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.Local),
+		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.UTC),
 		Locator:   store.Locator{URL: "https://radio-t.com", SiteID: "radio-t"},
 		User:      store.User{ID: "user2", Name: "user name 2"},
 	}
@@ -1279,7 +1279,7 @@ func TestService_Find(t *testing.T) {
 	comment := store.Comment{
 		ID:        "123456",
 		Text:      `some text, <a href="http://radio-t.com">link</a>`,
-		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.Local),
+		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.UTC),
 		Locator:   store.Locator{URL: "https://radio-t.com", SiteID: "radio-t"},
 		User:      store.User{ID: "user1", Name: "user name"},
 		Score:     1,
@@ -1315,7 +1315,7 @@ func TestService_FindSince(t *testing.T) {
 	assert.Equal(t, "id-1", res[0].ID)
 
 	res, err = b.FindSince(store.Locator{URL: "https://radio-t.com", SiteID: "radio-t"}, "time", store.User{},
-		time.Date(2017, 12, 20, 15, 18, 22, 0, time.Local))
+		time.Date(2017, 12, 20, 15, 18, 22, 0, time.UTC))
 	require.NoError(t, err)
 	require.Equal(t, 1, len(res))
 	assert.Equal(t, "id-2", res[0].ID)
@@ -1332,7 +1332,7 @@ func TestService_Info(t *testing.T) {
 	comment := store.Comment{
 		ID:        "123456xyz",
 		Text:      `some text, <a href="http://radio-t.com">link</a>`,
-		Timestamp: time.Date(2018, 12, 20, 15, 18, 22, 0, time.Local),
+		Timestamp: time.Date(2018, 12, 20, 15, 18, 22, 0, time.UTC),
 		Locator:   store.Locator{URL: "https://radio-t.com/another", SiteID: "radio-t"},
 		User:      store.User{ID: "user2", Name: "user name"},
 	}
@@ -1423,7 +1423,7 @@ func TestService_deleteImagesOnCommentDelete(t *testing.T) {
 	c := store.Comment{
 		ID:        "id-22",
 		Text:      `some text <img src="/images/dev/pic1.png"/> xx <img src="/images/dev/pic2.png"/>`,
-		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.Local),
+		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.UTC),
 		Locator:   store.Locator{URL: "https://radio-t.com", SiteID: "radio-t"},
 		User:      store.User{ID: "user1", Name: "user name"},
 	}
@@ -1484,7 +1484,7 @@ func TestService_DeleteUser(t *testing.T) {
 	comment := store.Comment{
 		ID:        "123456xyz",
 		Text:      `some text, <a href="http://radio-t.com">link</a>`,
-		Timestamp: time.Date(2018, 12, 20, 15, 18, 22, 0, time.Local),
+		Timestamp: time.Date(2018, 12, 20, 15, 18, 22, 0, time.UTC),
 		Locator:   store.Locator{URL: "https://radio-t.com/2", SiteID: "radio-t"},
 		User:      store.User{ID: "user2", Name: "user name"},
 	}
@@ -1514,7 +1514,7 @@ func TestService_List(t *testing.T) {
 	// add one more for user2
 	comment := store.Comment{
 		ID:        "id-3",
-		Timestamp: time.Date(2018, 12, 20, 15, 18, 22, 0, time.Local),
+		Timestamp: time.Date(2018, 12, 20, 15, 18, 22, 0, time.UTC),
 		Text:      `some text, <a href="http://radio-t.com">link</a>`,
 		Locator:   store.Locator{URL: "https://radio-t.com/2", SiteID: "radio-t"},
 		User:      store.User{ID: "user2", Name: "user name"},
@@ -1527,13 +1527,13 @@ func TestService_List(t *testing.T) {
 	require.Equal(t, 2, len(res), "2 posts")
 	assert.Equal(t, "https://radio-t.com/2", res[0].URL)
 	assert.Equal(t, 1, res[0].Count)
-	assert.Equal(t, time.Date(2018, 12, 20, 15, 18, 22, 0, time.Local), res[0].FirstTS)
-	assert.Equal(t, time.Date(2018, 12, 20, 15, 18, 22, 0, time.Local), res[0].LastTS)
+	assert.Equal(t, time.Date(2018, 12, 20, 15, 18, 22, 0, time.UTC), res[0].FirstTS)
+	assert.Equal(t, time.Date(2018, 12, 20, 15, 18, 22, 0, time.UTC), res[0].LastTS)
 
 	assert.Equal(t, "https://radio-t.com", res[1].URL)
 	assert.Equal(t, 2, res[1].Count)
-	assert.Equal(t, time.Date(2017, 12, 20, 15, 18, 22, 0, time.Local), res[1].FirstTS)
-	assert.Equal(t, time.Date(2017, 12, 20, 15, 18, 23, 0, time.Local), res[1].LastTS)
+	assert.Equal(t, time.Date(2017, 12, 20, 15, 18, 22, 0, time.UTC), res[1].FirstTS)
+	assert.Equal(t, time.Date(2017, 12, 20, 15, 18, 23, 0, time.UTC), res[1].LastTS)
 }
 
 func TestService_Count(t *testing.T) {
@@ -1546,7 +1546,7 @@ func TestService_Count(t *testing.T) {
 	// add one more for user2
 	comment := store.Comment{
 		ID:        "id-3",
-		Timestamp: time.Date(2018, 12, 20, 15, 18, 22, 0, time.Local),
+		Timestamp: time.Date(2018, 12, 20, 15, 18, 22, 0, time.UTC),
 		Text:      `some text, <a href="http://radio-t.com">link</a>`,
 		Locator:   store.Locator{URL: "https://radio-t.com/2", SiteID: "radio-t"},
 		User:      store.User{ID: "user2", Name: "user name"},
@@ -1577,7 +1577,7 @@ func TestService_UserComments(t *testing.T) {
 	// add one more for user2
 	comment := store.Comment{
 		ID:        "id-3",
-		Timestamp: time.Date(2018, 12, 20, 15, 18, 22, 0, time.Local),
+		Timestamp: time.Date(2018, 12, 20, 15, 18, 22, 0, time.UTC),
 		Text:      `some text, <a href="http://radio-t.com">link</a>`,
 		Locator:   store.Locator{URL: "https://radio-t.com/2", SiteID: "radio-t"},
 		User:      store.User{ID: "user2", Name: "user name"},
@@ -1602,7 +1602,7 @@ func TestService_UserCount(t *testing.T) {
 	// add one more for user2
 	comment := store.Comment{
 		ID:        "id-3",
-		Timestamp: time.Date(2018, 12, 20, 15, 18, 22, 0, time.Local),
+		Timestamp: time.Date(2018, 12, 20, 15, 18, 22, 0, time.UTC),
 		Text:      `some text, <a href="http://radio-t.com">link</a>`,
 		Locator:   store.Locator{URL: "https://radio-t.com/2", SiteID: "radio-t"},
 		User:      store.User{ID: "user2", Name: "user name"},
@@ -1632,7 +1632,7 @@ func TestService_DeleteAll(t *testing.T) {
 	// add one more for user2
 	comment := store.Comment{
 		ID:        "id-3",
-		Timestamp: time.Date(2018, 12, 20, 15, 18, 22, 0, time.Local),
+		Timestamp: time.Date(2018, 12, 20, 15, 18, 22, 0, time.UTC),
 		Text:      `some text, <a href="http://radio-t.com">link</a>`,
 		Locator:   store.Locator{URL: "https://radio-t.com/2", SiteID: "radio-t"},
 		User:      store.User{ID: "user2", Name: "user name"},
@@ -1672,7 +1672,7 @@ func TestService_submitImages(t *testing.T) {
 	c := store.Comment{
 		ID:        "id-22",
 		Text:      `some text <img src="/images/dev/pic1.png"/> xx <img src="/images/dev/pic2.png"/>`,
-		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.Local),
+		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.UTC),
 		Locator:   store.Locator{URL: "https://radio-t.com", SiteID: "radio-t"},
 		User:      store.User{ID: "user1", Name: "user name"},
 	}
@@ -1718,7 +1718,7 @@ func TestService_ResubmitStagingImages(t *testing.T) {
                <img src="http://127.0.0.1:8080/api/v1/picture/dev_user/bqf321eq9r8ad657n3ng" alt="cat.png"><br/>
                <img src="http://127.0.0.1:8080/api/v1/img?src=aHR0cHM6Ly9ob21lcGFnZXMuY2FlLndpc2MuZWR1L35lY2U1MzMvaW1hZ2VzL2JvYXQucG5n" alt="cat.png"><br/>
                <img src="https://homepages.cae.wisc.edu/~ece533/images/boat.png" alt="boat.png">`,
-		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.Local),
+		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.UTC),
 		Locator:   store.Locator{URL: "https://radio-t.com", SiteID: "radio-t"},
 		User:      store.User{ID: "user1", Name: "user name"},
 	}
@@ -1885,7 +1885,7 @@ func Benchmark_ServiceCreate(b *testing.B) {
 		comment := store.Comment{
 			ID:        "id-" + strconv.Itoa(i),
 			Text:      `some text, <a href="http://radio-t.com">link</a>`,
-			Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.Local),
+			Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.UTC),
 			Locator:   store.Locator{URL: "https://radio-t.com", SiteID: "radio-t"},
 			User:      store.User{ID: "user1", Name: "user name"},
 		}
@@ -1932,7 +1932,7 @@ func prepStoreEngine(t *testing.T) (e engine.Interface, teardown func()) {
 	comment := store.Comment{
 		ID:        "id-1",
 		Text:      `some text, <a href="http://radio-t.com">link</a>`,
-		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.Local),
+		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.UTC),
 		Locator:   store.Locator{URL: "https://radio-t.com", SiteID: "radio-t"},
 		User:      store.User{ID: "user1", Name: "user name"},
 	}
@@ -1942,7 +1942,7 @@ func prepStoreEngine(t *testing.T) (e engine.Interface, teardown func()) {
 	comment = store.Comment{
 		ID:        "id-2",
 		Text:      "some text2",
-		Timestamp: time.Date(2017, 12, 20, 15, 18, 23, 0, time.Local),
+		Timestamp: time.Date(2017, 12, 20, 15, 18, 23, 0, time.UTC),
 		Locator:   store.Locator{URL: "https://radio-t.com", SiteID: "radio-t"},
 		User:      store.User{ID: "user1", Name: "user name"},
 	}


### PR DESCRIPTION
Pure test hygiene, no production-code change.

Store tests stored timestamps with `time.Local` in their fixtures and asserted equality against engine-returned values that round-trip through UTC. `assert.Equal` compares zone identity, so on UTC runners (CI, most cloud envs) `Local==UTC` and the tests passed; on a developer machine in any other timezone (here BST, UTC+1) `TestService_Put`, `TestService_List`, `TestBoltDB_InfoPost`, `TestBoltDB_InfoList` and several others failed with the same wall-clock numbers but mismatched zones.

Switched all test fixtures to `time.UTC` across:
- `store/comment_test.go`
- `store/formatter_test.go`
- `store/service/service_test.go`
- `store/engine/bolt_test.go`
- `store/engine/engine_test.go`

Production code unchanged.

## Verification

`go test ./store/...` — green on a non-UTC laptop (BST, UTC+1).