### PR TITLE
ci(site): skip BuildKit cache on release events so the new version reaches the live site

### DIFF
--- a/.github/workflows/ci-site.yml
+++ b/.github/workflows/ci-site.yml
@@ -53,13 +53,22 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.PKG_TOKEN }}
 
+      # cache-from is skipped on release events: the site embeds the latest
+      # remark42 version at build time (site/src/data/github.js fetches it from
+      # the GitHub releases API and Eleventy bakes it into the HTML). On a
+      # release-triggered run no site/** file has changed since the last
+      # master build, so Buildx would reuse the cached "yarn build" layer and
+      # ship the previous tag's version. Discarding the cache only for release
+      # events forces a fresh build that picks up the new tag; non-release
+      # runs keep the cache for fast iteration. cache-to is still populated
+      # so the next non-release run reuses what we just built.
       - name: build and push by digest
         id: build
         uses: docker/build-push-action@v7
         with:
           context: ./site
           platforms: ${{ matrix.platform }}
-          cache-from: type=gha,scope=site-${{ matrix.platform }}
+          cache-from: ${{ github.event_name == 'release' && '' || format('type=gha,scope=site-{0}', matrix.platform) }}
           cache-to: type=gha,scope=site-${{ matrix.platform }},mode=max
           outputs: type=image,name=ghcr.io/umputun/remark42-site,push-by-digest=true,name-canonical=true,push=true
 


### PR DESCRIPTION
## Summary

The site embeds the latest remark42 version at build time — `site/src/data/github.js` fetches it from the GitHub releases API and Eleventy bakes it into every page (the version badge in the header). The ci-site.yml workflow already triggers on `release: published`, but the build step uses `cache-from: type=gha,scope=site-<platform>`, so on a release-triggered run — where no `site/**` file has changed since the last master build — Buildx reuses the cached `yarn build` layer and ships the previous tag's version.

v1.16.0 is the concrete case: the release workflow ran and succeeded at 2026-05-22T18:29:56Z, but the deployed site kept showing v1.15.0 because the cached layer was hit.

## Fix

Drop `cache-from` only for `release` events; `cache-to` keeps populating so the next non-release master build still benefits from the cache.

```yaml
cache-from: ${{ github.event_name == 'release' && '' || format('type=gha,scope=site-{0}', matrix.platform) }}
```

Targeted at the smallest blast radius — every other trigger path (master push, PR) behaves exactly as before.

## Why not Option B (build-arg)

A more surgical alternative is to pass the release tag as a build arg and have the data file prefer it over the GitHub API call. That avoids both the cache hit AND any GitHub API propagation race (the workflow fired 2 seconds after release publication; even with a fresh build, the API might still have returned the previous tag at that exact moment). I went with the simple cache-disable here because release events are rare (handful per year), the cold rebuild adds a couple of minutes, and the change has obvious correctness — no extra coupling between Dockerfile, workflow inputs, and data file. If the cold-build cost ever bites, we can revisit and switch to the build-arg approach.

## Verification

- Diff is a single line under a 9-line explanatory comment.
- Non-release branches: `cache-from` resolves to the same `type=gha,scope=site-<platform>` value as before.
- Release events: `cache-from` resolves to empty string → Buildx skips the import step.
- `cache-to` unchanged, so the cache layer continues to populate.