### PR TITLE
docs: close backtick in smtp.login_auth default cell

### DIFF
--- a/site/src/docs/configuration/parameters/index.md
+++ b/site/src/docs/configuration/parameters/index.md
@@ -139,7 +139,7 @@ Custom OAuth2 integration currently supports only one custom provider at a time,
 | smtp.port                      | SMTP_PORT                      |                         | SMTP port                                                |
 | smtp.username                  | SMTP_USERNAME                  |                         | SMTP user name                                           |
 | smtp.password                  | SMTP_PASSWORD                  |                         | SMTP password                                            |
-| smtp.login_auth                | SMTP_LOGIN_AUTH                | `false                  | enable LOGIN auth instead of PLAIN                       |
+| smtp.login_auth                | SMTP_LOGIN_AUTH                | `false`                 | enable LOGIN auth instead of PLAIN                       |
 | smtp.tls                       | SMTP_TLS                       | `false`                 | enable TLS for SMTP                                      |
 | smtp.starttls                  | SMTP_STARTTLS                  | `false`                 | enable StartTLS for SMTP                                 |
 | smtp.insecure_skip_verify      | SMTP_INSECURE_SKIP_VERIFY      | `false`                 | skip certificate verification for SMTP                   |


### PR DESCRIPTION
## Why

The parameters table on https://remark42.com/docs/configuration/parameters/ stopped rendering correctly partway through the SMTP section — roughly 40 rows from `smtp.login_auth` down to `dbg/DEBUG` appeared as raw pipe-delimited text instead of HTML table cells.

Cause: the `Default` column for `smtp.login_auth` had `` `false `` with an opening backtick but no closing one. kramdown saw an unclosed code span, gave up on the cell, and from that point on treated the rest of the table as literal text.

Introduced in cebe9291 — first shipped in **v1.11.0** (Oct 2022), so it's been broken for ~3.5 years.

Closes #2074

## What

One-character fix — add the missing backtick to close the code span.