### PR TITLE
fix(frontend): no_footer scrollbar regression introduced in v1.16.0

### DIFF
--- a/frontend/apps/remark42/app/components/root/root.module.css
+++ b/frontend/apps/remark42/app/components/root/root.module.css
@@ -31,18 +31,12 @@
   margin: 0 auto;
 }
 
-.thread {
-  &:last-child {
-    margin-bottom: -24px;
-  }
-}
-
 .threads {
   margin-top: 4px;
 }
 
 .copyright {
-  margin: 48px 0 0;
+  margin: 24px 0 0;
   font-size: 12px;
   text-align: right;
 }

--- a/frontend/apps/remark42/app/components/root/root.tsx
+++ b/frontend/apps/remark42/app/components/root/root.tsx
@@ -301,9 +301,7 @@ function Comments({ isLoading, topComments, commentsShown, showMore }: CommentsP
       ) : (
         <>
           {topComments.length > 0 &&
-            renderComments.map((id) => (
-              <Thread key={`thread-${id}`} id={id} mix={styles.thread} level={0} getPreview={getPreview} />
-            ))}
+            renderComments.map((id) => <Thread key={`thread-${id}`} id={id} level={0} getPreview={getPreview} />)}
           {isShowMoreButtonVisible && (
             <Button className={styles.moreComments} onClick={showMore}>
               <FormattedMessage id="root.show-more" defaultMessage="Show more" />

--- a/frontend/apps/remark42/app/components/thread/thread.tsx
+++ b/frontend/apps/remark42/app/components/thread/thread.tsx
@@ -19,7 +19,6 @@ interface Props {
   id: CommentInterface['id'];
   childs?: CommentInterface['id'][];
   level: number;
-  mix?: string;
 
   getPreview(text: string): Promise<string>;
 }
@@ -34,7 +33,7 @@ const commentSelector = (id: string) => (state: StoreState) => {
   return { comment, childs, collapsed, theme };
 };
 
-export const Thread: FunctionComponent<Props> = ({ id, level, mix, getPreview }) => {
+export const Thread: FunctionComponent<Props> = ({ id, level, getPreview }) => {
   const dispatch = useAppDispatch();
   const intl = useIntl();
   const { collapsed, comment, childs, theme } = useAppSelector(commentSelector(id), shallowEqual);
@@ -53,8 +52,7 @@ export const Thread: FunctionComponent<Props> = ({ id, level, mix, getPreview })
         styles.root,
         indented && styles.indented,
         level === 6 && styles.level6,
-        theme === 'dark' && styles.themeDark,
-        mix
+        theme === 'dark' && styles.themeDark
       )}
       role={['listitem'].concat(!collapsed && !!repliesCount ? 'list' : []).join(' ')}
       aria-expanded={!collapsed}

--- a/frontend/apps/remark42/app/styles/global.css
+++ b/frontend/apps/remark42/app/styles/global.css
@@ -8,6 +8,13 @@ body {
   color: rgb(var(--primary-text-color));
   background: transparent;
   box-sizing: border-box;
+
+  /* parent resizes the iframe element to fit content via postMessage, so the
+     iframe document never needs its own scrollbar. spec-correct replacement
+     for the deprecated `scrolling="no"` attribute removed in c26f45e5 — the
+     `overflow:hidden` on the iframe ELEMENT doesn't control the iframe
+     DOCUMENT's scrollbars, that has to be set inside the document. */
+  overflow: hidden;
 }
 
 input,


### PR DESCRIPTION
## Why

Reported in #2073. Setting `no_footer: true` in v1.16.0 introduces an unnecessary vertical scrollbar inside the iframe. Closes #2073.

## Root cause

Two unrelated v1.16.0 changes combined to surface the regression.

**1. Removed iframe scroll suppression (c26f45e5).**
That cleanup commit removed `scrolling="no"` from the iframe with the reasoning *"overflow is already hidden via CSS"*. The CSS in question is `overflow: hidden` in `createIframe`'s inline styles — but that's on the iframe ELEMENT in the parent page. It has no effect on the iframe DOCUMENT's own scrollbars. The spec-correct replacement for `scrolling="no"` is `overflow: hidden` on the iframe document's `<body>`, which `c26f45e5` omitted. So as of v1.16.0 the iframe document can show scrollbars when its content exceeds the iframe's assigned height — which is exactly what the next change set up.

**2. Negative-margin layout trick on the last thread.**
`root.module.css` had:

```css
.thread:last-child { margin-bottom: -24px; }
.copyright { margin: 48px 0 0; }
```

With the footer present the two margins collapse to a clean 24px gap. With `no_footer=true` the last thread's `-24px` has no positive sibling margin to collapse against and instead propagates up through `.root`, leaving `document.body.offsetHeight` ~24px shorter than the visual content. `updateIframeHeight` then sizes the iframe below the visible bottom of the last thread, and (thanks to change #1) the browser shows a scrollbar.

## Fix

1. **`global.css`** — add `overflow: hidden` to `body`. Restores the original `scrolling="no"` effect via CSS as `c26f45e5` originally intended.
2. **`root.module.css`** — drop the `.thread:last-child` negative margin and change `.copyright` to `margin: 24px 0 0`. Same 24px gap when the footer is shown, no propagation when it isn't.
3. **`root.tsx`** — drop `mix={styles.thread}` (now a dead reference).
4. **`thread.tsx`** — drop the now-dead `mix?: string` prop, its destructure, and its entry in the `clsx(...)` call (follow-up to point 3, raised by @umputun and Copilot on the first review pass).

Both #1 and #2 are required: #1 is the defence-in-depth (also fixes any other latent overflow), #2 is the root cause. #3 and #4 are dead-surface cleanup that fell out of #2.

## Verification

- `pnpm test` — 36 suites / 299 tests pass.
- `pnpm lint` — clean.
- `pnpm build` — succeeds.
- **Empirical:** built a static reproduction with the broken vs fixed CSS in a four-quadrant test page (broken/fixed × no_footer/with_footer), each iframe sized via the same `body.offsetHeight + 12` formula `updateIframeHeight` uses. Loaded in a real browser via agent-browser:

  | case | body.oH | body.sH | iframe.h | verdict |
  |------|---------|---------|----------|---------|
  | BROKEN + no_footer=true | 150 | 168 | 162 | **FAIL — content overflows iframe by 6px** |
  | BROKEN + footer present | 213 | 213 | 225 | PASS |
  | FIXED + no_footer=true  | 180 | 180 | 192 | **PASS — content fits** |
  | FIXED + footer present  | 213 | 213 | 225 | PASS (unchanged from broken) |

  The broken/no_footer case is the bug from #2073 — body.offsetHeight (150) was 18px smaller than body.scrollHeight (168) because the negative margin reduced the layout box without reducing the visual content. The fix removes that discrepancy (180 / 180) and the footer case is unaffected (same numbers as before).
