### PR TITLE
fix: parameter docs + --help text inconsistencies (audit)

### DIFF
--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -90,7 +90,7 @@ type ServerCommand struct {
 	EnableEmoji                bool          `long:"emoji" env:"EMOJI" description:"enable emoji"`
 	SimpleView                 bool          `long:"simple-view" env:"SIMPLE_VIEW" description:"minimal comment editor mode"`
 	ProxyCORS                  bool          `long:"proxy-cors" env:"PROXY_CORS" description:"disable internal CORS and delegate it to proxy"`
-	AllowedHosts               []string      `long:"allowed-hosts" env:"ALLOWED_HOSTS" description:"limit hosts/sources allowed to embed comments via CSP 'frame-ancestors''" env-delim:","`
+	AllowedHosts               []string      `long:"allowed-hosts" env:"ALLOWED_HOSTS" description:"limit hosts/sources allowed to embed comments via CSP 'frame-ancestors'" env-delim:","`
 	SubscribersOnly            bool          `long:"subscribers-only" env:"SUBSCRIBERS_ONLY" description:"enable commenting only for Patreon subscribers"`
 	DisableSignature           bool          `long:"disable-signature" env:"DISABLE_SIGNATURE" description:"disable server signature in headers"`
 	DisableFancyTextFormatting bool          `long:"disable-fancy-text-formatting" env:"DISABLE_FANCY_TEXT_FORMATTING" description:"disable fancy comments text formatting (replacement of quotes, dashes, fractions, etc)"`
@@ -123,10 +123,10 @@ type ServerCommand struct {
 			Subject      string        `long:"subj" env:"SUBJ" default:"remark42 confirmation" description:"email's subject"`
 			ContentType  string        `long:"content-type" env:"CONTENT_TYPE" default:"text/html" description:"content type"`
 			Host         string        `long:"host" env:"HOST" description:"[deprecated, use --smtp.host] SMTP host"`
-			Port         int           `long:"port" env:"PORT" description:"[deprecated, use --smtp.port] SMTP password"`
-			SMTPPassword string        `long:"passwd" env:"PASSWD" description:"[deprecated, use --smtp.password] SMTP port"`
-			SMTPUserName string        `long:"user" env:"USER" description:"[deprecated, use --smtp.username] enable TLS"`
-			TLS          bool          `long:"tls" env:"TLS" description:"[deprecated, use --smtp.tls] SMTP TCP connection timeout"`
+			Port         int           `long:"port" env:"PORT" description:"[deprecated, use --smtp.port] SMTP port"`
+			SMTPPassword string        `long:"passwd" env:"PASSWD" description:"[deprecated, use --smtp.password] SMTP password"`
+			SMTPUserName string        `long:"user" env:"USER" description:"[deprecated, use --smtp.username] SMTP user name"`
+			TLS          bool          `long:"tls" env:"TLS" description:"[deprecated, use --smtp.tls] enable TLS"`
 			TimeOut      time.Duration `long:"timeout" env:"TIMEOUT" default:"10s" description:"[deprecated, use --smtp.timeout] SMTP TCP connection timeout"`
 			MsgTemplate  string        `long:"template" env:"TEMPLATE" description:"[deprecated] message template file" default:"email_confirmation_login.html.tmpl"`
 		} `group:"email" namespace:"email" env-namespace:"EMAIL"`

--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -283,8 +283,8 @@ type NotifyGroup struct {
 	} `group:"slack" namespace:"slack" env-namespace:"SLACK"`
 	Webhook struct {
 		URL      string        `long:"url" env:"URL" description:"webhook URL for admin notifications"`
-		Template string        `long:"template" env:"TEMPLATE" description:"webhook authentication template" default:"{\"text\": \"{{.Text}}\"}"`
-		Headers  []string      `long:"headers" description:"webhook authentication headers in format --notify.webhook.headers=Header1:Value1,Value2,... [$NOTIFY_WEBHOOK_HEADERS]"` // env NOTIFY_WEBHOOK_HEADERS split in code bellow to allow , inside ""
+		Template string        `long:"template" env:"TEMPLATE" description:"webhook payload template (Go text/template); falls back to {\"text\": {{.Text | escapeJSONString}}} when empty"`
+		Headers  []string      `long:"headers" description:"webhook headers in format --notify.webhook.headers=Header1:Value1,Value2,... [$NOTIFY_WEBHOOK_HEADERS]"` // env NOTIFY_WEBHOOK_HEADERS split in code below to allow , inside ""
 		Timeout  time.Duration `long:"timeout" env:"TIMEOUT" description:"webhook timeout" default:"5s"`
 	} `group:"webhook" namespace:"webhook" env-namespace:"WEBHOOK"`
 }

--- a/site/src/docs/configuration/parameters/index.md
+++ b/site/src/docs/configuration/parameters/index.md
@@ -125,7 +125,7 @@ services:
 | notify.slack.token             | NOTIFY_SLACK_TOKEN             |                         | Slack token                                              |
 | notify.slack.chan              | NOTIFY_SLACK_CHAN              | `general`               | Slack channel for admin notifications                    |
 | notify.webhook.url             | NOTIFY_WEBHOOK_URL             |                         | Webhook notification URL for admin notifications         |
-| notify.webhook.template        | NOTIFY_WEBHOOK_TEMPLATE        | `{"text": "{{.Text}}"}` | Webhook payload template                                 |
+| notify.webhook.template        | NOTIFY_WEBHOOK_TEMPLATE        | `{"text": {{.Text \| escapeJSONString}}}` | Webhook payload template (Go text/template) |
 | notify.webhook.headers         | NOTIFY_WEBHOOK_HEADERS         |                         | HTTP header in format Header1:Value1,Header2:Value2,...  |
 | notify.webhook.timeout         | NOTIFY_WEBHOOK_TIMEOUT         | `5s`                    | Webhook connection timeout                               |
 | notify.email.from_address      | NOTIFY_EMAIL_FROM              |                         | from email address (e.g. `john.doe@example.com` or `"John Doe"<john.doe@example.com>`) |

--- a/site/src/docs/configuration/parameters/index.md
+++ b/site/src/docs/configuration/parameters/index.md
@@ -69,7 +69,7 @@ services:
 | image.fs.path                  | IMAGE_FS_PATH                  | `./var/pictures`        | permanent location of images                             |
 | image.fs.staging               | IMAGE_FS_STAGING               | `./var/pictures.staging` | staging location of images                               |
 | image.fs.partitions            | IMAGE_FS_PARTITIONS            | `100`                   | number of image partitions                               |
-| image.bolt.file                | IMAGE_BOLT_FILE                | `/var/pictures.db`      | images bolt file location                                |
+| image.bolt.file                | IMAGE_BOLT_FILE                | `./var/pictures.db`     | images bolt file location                                |
 | image.rpc.api                  | IMAGE_RPC_API                  |                         | rpc extension api url                                    |
 | image.rpc.timeout              | IMAGE_RPC_TIMEOUT              |                         | http timeout (default: 5s)                               |
 | image.rpc.auth_user            | IMAGE_RPC_AUTH_USER            |                         | basic auth user name                                     |
@@ -109,9 +109,6 @@ services:
 | auth.custom.name-field         | AUTH_CUSTOM_NAME_FIELD         | `name`                  | user info field used as display name                     |
 | auth.custom.picture-field      | AUTH_CUSTOM_PICTURE_FIELD      | `picture`               | user info field used as avatar URL                       |
 | auth.custom.email-field        | AUTH_CUSTOM_EMAIL_FIELD        | `email`                 | user info field used as email                            |
-
-Custom OAuth2 integration currently supports only one custom provider at a time, and `AUTH_CUSTOM_NAME` must match `^[a-z0-9][a-z0-9_-]*$`.
-
 | auth.telegram                  | AUTH_TELEGRAM                  | `false`                 | Enable Telegram auth (telegram.token must be present)    |
 | auth.yandex.cid                | AUTH_YANDEX_CID                |                         | Yandex OAuth client ID                                   |
 | auth.yandex.csec               | AUTH_YANDEX_CSEC               |                         | Yandex OAuth client secret                               |
@@ -128,7 +125,7 @@ Custom OAuth2 integration currently supports only one custom provider at a time,
 | notify.slack.token             | NOTIFY_SLACK_TOKEN             |                         | Slack token                                              |
 | notify.slack.chan              | NOTIFY_SLACK_CHAN              | `general`               | Slack channel for admin notifications                    |
 | notify.webhook.url             | NOTIFY_WEBHOOK_URL             |                         | Webhook notification URL for admin notifications         |
-| notify.webhook.template        | NOTIFY_WEBHOOK_TEMPLATE        | `{"text": {{.Text | escapeJSONString}}}`  | Webhook payload template                 |
+| notify.webhook.template        | NOTIFY_WEBHOOK_TEMPLATE        | `{"text": "{{.Text}}"}` | Webhook payload template                                 |
 | notify.webhook.headers         | NOTIFY_WEBHOOK_HEADERS         |                         | HTTP header in format Header1:Value1,Header2:Value2,...  |
 | notify.webhook.timeout         | NOTIFY_WEBHOOK_TIMEOUT         | `5s`                    | Webhook connection timeout                               |
 | notify.email.from_address      | NOTIFY_EMAIL_FROM              |                         | from email address (e.g. `john.doe@example.com` or `"John Doe"<john.doe@example.com>`) |
@@ -183,6 +180,10 @@ Custom OAuth2 integration currently supports only one custom provider at a time,
 - command-line parameters are long-form `--<key>=value`, i.e., `--site=https://demo.remark42.com`
 - _multi_ parameters separated by `,` in the environment or repeated with command-line keys, like `--site=s1 --site=s2 ...`
 - _required_ parameters have to be presented in the environment or provided in the command-line
+
+### Custom OAuth2 integration
+
+Custom OAuth2 integration currently supports only one custom provider at a time, and `AUTH_CUSTOM_NAME` must match `^[a-z0-9][a-z0-9_-]*$`.
 
 ### Security Considerations for auth.send-jwt-header
 


### PR DESCRIPTION
## Why

Doc audit against the backend Go flag tags surfaced a small batch of inconsistencies — wrong defaults, a typo that broke a table column, a paragraph wedged inside a table that terminated rendering of the second half, and shuffled `--help` strings on deprecated flags. Fixing them as a single pass.

## Docs (`site/src/docs/configuration/parameters/index.md`)

- **`image.bolt.file`** default — was `` `/var/pictures.db` `` (looked like an absolute system path), actual default is `./var/pictures.db` (relative to the working dir, per `server.go:202`).
- **`notify.webhook.template`** default — the docs row was both wrong (claimed default `` `{"text": "{{.Text}}"}` ``) and broken (the unescaped `|` inside the cell collapsed the Description column). Updated to the correct effective default `{"text": {{.Text | escapeJSONString}}}` with `\|` to escape the table column separator.
- **"Custom OAuth2 integration currently supports only one custom provider"** — was a free-standing paragraph wedged between two table rows. kramdown terminated the main parameters table on that paragraph and restarted a new headerless table for the remaining 60+ rows. Moved the paragraph to its own `### Custom OAuth2 integration` subsection below the table so the table stays contiguous.

## Backend `--help` text (`backend/app/cmd/server.go`)

- **`allowed-hosts`** — description ended with a stray double apostrophe: `CSP 'frame-ancestors''`. Dropped the trailing `'`.
- **Deprecated `auth.email.{port,passwd,user,tls}` descriptions** were shuffled:
  - `port` said *"SMTP password"*
  - `passwd` said *"SMTP port"*
  - `user` said *"enable TLS"*
  - `tls` said *"SMTP TCP connection timeout"*

  Each now matches the flag it's actually describing. (`auth.email.timeout` was the only one already correct.) The docs table already had the correct descriptions for these deprecated flags — only `--help` was wrong.
- **`notify.webhook.template` description and headers description** — said "webhook *authentication* template / authentication headers" but the template is the payload body (not auth-related). Reworded to "payload template" / "webhook headers".

## Behaviour change ⚠️

**`notify.webhook.template` default switches from the literal `{"text": "{{.Text}}"}` to `{"text": {{.Text | escapeJSONString}}}`.**

`server.go:286` had `default:"{\"text\": \"{{.Text}}\"}"`. go-flags applies the default tag at parse time, so `Notify.Webhook.Template` was never empty when the user omitted the flag — and that meant the safer `webhookDefaultTemplate` fallback in `backend/app/notify/webhook.go:50` (which uses `escapeJSONString`) was dead code. The unescaped literal default produces malformed JSON whenever a comment contains a `"`, newline, or backslash.

This PR drops the `default:` tag so the package-level fallback now takes effect. For comments without special characters the payload is byte-identical; for comments with special characters the new payload is valid JSON where the old one was malformed. Webhook receivers that previously failed to parse such payloads will now succeed.

If a deployment explicitly *relied* on the unescaped form (e.g. their receiver tolerated malformed JSON or did string-matching), they can restore the prior behaviour by setting `NOTIFY_WEBHOOK_TEMPLATE='{"text": "{{.Text}}"}'`.

## Verification

- `go test ./app/cmd/ ./app/notify/` — passes.
- `golangci-lint run ./app/cmd/` — 0 issues.
- `go build ./...` in `backend/_example/memory_store` — clean.
- `yarn build` in `site/` — clean; rebuilt HTML shows the smtp.login_auth row + every subsequent row rendering as proper `<td>` cells (157 `<tr>` total across the two tables, up from the truncated render before). The `notify.webhook.template` cell renders with the pipe inside `<code>` as expected.
