### PR TITLE
Guard against falsy outputPath in eleventy htmlmin transform

### DIFF
--- a/site/.eleventy.js
+++ b/site/.eleventy.js
@@ -87,7 +87,8 @@ module.exports = function (eleventyConfig) {
 
 	// Minify HTML output
 	eleventyConfig.addTransform('htmlmin', async function (content, outputPath) {
-		if (!outputPath.endsWith('.html')) {
+		// outputPath is falsy for templates rendered without a written file (e.g. permalink: false)
+		if (!outputPath || !outputPath.endsWith('.html')) {
 			return content
 		}
 


### PR DESCRIPTION
Small hardening follow-up to #2091. Copilot flagged that the `htmlmin` eleventy transform calls `outputPath.endsWith(...)` without guarding for a falsy `outputPath`, which Eleventy passes for templates rendered without a written file (e.g. `permalink: false`). remark42's site currently has no such templates so it never triggers, but the guard is correct and cheap. Verified `yarn build` still passes.