### PR TITLE
Replace chi middleware.Throttle with rest.Throttle on the main router

### DIFF
--- a/backend/app/rest/api/rest.go
+++ b/backend/app/rest/api/rest.go
@@ -221,7 +221,7 @@ func (s *Rest) routes() chi.Router {
 		s.openRouteLimiter = openRouteLimiter
 	}
 	router := chi.NewRouter()
-	router.Use(middleware.Throttle(1000), middleware.RealIP, R.Recoverer(log.Default()))
+	router.Use(R.Throttle(1000), middleware.RealIP, R.Recoverer(log.Default()))
 	router.Use(securityHeadersMiddleware(s.ExternalImageProxy, s.AllowedAncestors))
 	if !s.DisableSignature {
 		router.Use(R.AppInfo("remark42", "umputun", s.Version))


### PR DESCRIPTION
First of the incremental per-middleware swaps on the main API router, chipping away at `go-chi/chi/v5/middleware` **without touching the chi router yet**.

`go-pkgz/rest.Throttle` has the same signature and concurrency-limit semantics as `chi`'s `middleware.Throttle`, so the global limiter is a one-line drop-in:

```go
-router.Use(middleware.Throttle(1000), middleware.RealIP, R.Recoverer(log.Default()))
+router.Use(R.Throttle(1000), middleware.RealIP, R.Recoverer(log.Default()))
```

`chi/middleware` stays imported (still used for `RealIP`, `Timeout`, `NoCache`) — those follow as their own small chunks. Build, vet, `go test -race`, golangci-lint all clean.