### PR TITLE
Replace chi middleware.RealIP with rest.RealIP on the main router

### DIFF
--- a/backend/app/rest/api/rest.go
+++ b/backend/app/rest/api/rest.go
@@ -221,7 +221,7 @@ func (s *Rest) routes() chi.Router {
 		s.openRouteLimiter = openRouteLimiter
 	}
 	router := chi.NewRouter()
-	router.Use(R.Throttle(1000), middleware.RealIP, R.Recoverer(log.Default()))
+	router.Use(R.Throttle(1000), R.RealIP, R.Recoverer(log.Default()))
 	router.Use(securityHeadersMiddleware(s.ExternalImageProxy, s.AllowedAncestors))
 	if !s.DisableSignature {
 		router.Use(R.AppInfo("remark42", "umputun", s.Version))
@@ -785,7 +785,7 @@ func parseError(err error, defaultCode int) (code int) {
 
 // rateLimiter creates a rate limiting middleware with proper IP lookup configuration.
 // tollbooth v8 requires explicit IP lookup method to be set.
-// uses RemoteAddr which is set by chi's middleware.RealIP to the real client IP
+// uses RemoteAddr which is set by rest.RealIP to the real client IP
 // from X-Forwarded-For, X-Real-IP, or True-Client-IP headers.
 func rateLimiter(maxReq float64) func(http.Handler) http.Handler {
 	lmt := tollbooth.NewLimiter(maxReq, nil)


### PR DESCRIPTION
Per-middleware chip on the main router (chi router still in place). Behaviour-preserving swap: `go-pkgz/rest.RealIP` sets `r.RemoteAddr` from `X-Real-IP`/`X-Forwarded-For` just like chi's `middleware.RealIP` — it removes chi from the RealIP path **without** changing the trust model, so **GHSA-56x6-q882-mf27 stays present** (this is the prep, not the fix; the trusted-proxy fix is a follow-up once the router migration lands).

`chi/middleware` stays imported for `Timeout`; whichever of this and the Timeout PR (#2097) merges last drops the import entirely. Drop-in to an already-tested `rest` middleware; covered by the existing api router tests.