### PR TITLE
Run backend CI on PR updates and freeze frontend lockfile installs

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -10,7 +10,6 @@ on:
       - "!backend/scripts/**"
       - "!**.md"
   pull_request:
-    types: [opened, reopened]
     paths:
       - ".github/workflows/ci-backend.yml"
       - "backend/**"

--- a/.github/workflows/ci-frontend-api.yml
+++ b/.github/workflows/ci-frontend-api.yml
@@ -44,7 +44,7 @@ jobs:
           cache-dependency-path: frontend/pnpm-lock.yaml
 
       - name: Install dependencies
-        run: pnpm i
+        run: pnpm install --frozen-lockfile
         working-directory: ./frontend
 
       - name: Run type check
@@ -80,7 +80,7 @@ jobs:
           cache-dependency-path: frontend/pnpm-lock.yaml
 
       - name: Install dependencies
-        run: pnpm i
+        run: pnpm install --frozen-lockfile
         working-directory: ./frontend
 
       - name: Run linters
@@ -116,7 +116,7 @@ jobs:
           cache-dependency-path: frontend/pnpm-lock.yaml
 
       - name: Install dependencies
-        run: pnpm i
+        run: pnpm install --frozen-lockfile
         working-directory: ./frontend
 
       - name: Test & Coverage

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -44,7 +44,7 @@ jobs:
           cache-dependency-path: frontend/pnpm-lock.yaml
 
       - name: Install dependencies
-        run: pnpm i
+        run: pnpm install --frozen-lockfile
         working-directory: ./frontend
 
       - name: Translations check
@@ -80,7 +80,7 @@ jobs:
           cache-dependency-path: frontend/pnpm-lock.yaml
 
       - name: Install dependencies
-        run: pnpm i
+        run: pnpm install --frozen-lockfile
         working-directory: ./frontend
 
       - name: Run type check
@@ -116,7 +116,7 @@ jobs:
           cache-dependency-path: frontend/pnpm-lock.yaml
 
       - name: Install dependencies
-        run: pnpm i
+        run: pnpm install --frozen-lockfile
         working-directory: ./frontend
 
       - name: Run linters
@@ -180,7 +180,7 @@ jobs:
           cache-dependency-path: frontend/pnpm-lock.yaml
 
       - name: Install dependencies
-        run: pnpm i
+        run: pnpm install --frozen-lockfile
         working-directory: ./frontend
 
       - name: Test & Coverage


### PR DESCRIPTION
Two CI hygiene changes, split out of #2106.

## Backend CI skipped pushed PR updates

`ci-backend.yml` had `pull_request: types: [opened, reopened]`, which excludes `synchronize`. Pushes to an open PR branch therefore did not re-run backend tests, lint or coverage, so a broken follow-up commit could land after the first green run. Removing the `types` filter restores the default activity set (`opened`, `synchronize`, `reopened`) without broadening to every PR event; the workflow stays on `pull_request` with `contents: read`.

## Frontend installs weren't frozen

`ci-frontend.yml` and `ci-frontend-api.yml` ran `pnpm i`, which can mutate the lockfile and produce non-reproducible installs. They now use `pnpm install --frozen-lockfile`, matching `release.yml` and making the intended CI behaviour explicit.