### PR TITLE
Remove obsolete version key from compose files

### DIFF
--- a/compose-dev-backend.yml
+++ b/compose-dev-backend.yml
@@ -4,7 +4,6 @@
 #
 # build remark42 docker image - docker compose -f compose-dev-backend.yml build
 # start remark42 service - docker compose -f compose-dev-backend.yml up
-version: "2"
 
 services:
   remark42:

--- a/compose-dev-frontend.yml
+++ b/compose-dev-frontend.yml
@@ -4,7 +4,6 @@
 #
 # build remark42 docker image - docker compose -f compose-dev-frontend.yml build
 # start remark42 service - docker compose -f compose-dev-frontend.yml up
-version: "2"
 
 services:
   remark42:

--- a/compose-e2e-test.yml
+++ b/compose-e2e-test.yml
@@ -1,5 +1,4 @@
 # compose for running e2e tests in CI
-version: "2"
 
 services:
   remark42:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "2"
-
 services:
   remark:
     # remove the next line in case you want to use this Docker Compose file separately


### PR DESCRIPTION
Split out of #2106.

The top-level `version: "2"` field is obsolete in the current Compose file format; Docker Compose ignores it and prints a warning on every invocation. Removed it from `docker-compose.yml`, `compose-dev-backend.yml`, `compose-dev-frontend.yml` and `compose-e2e-test.yml`.

`docker compose config` output is byte-identical to master for all four files, so there is no functional change.