### PR TITLE
Fix flaky TestPublic_FindCommentsCtrl_ConsistentCount

### DIFF
--- a/backend/app/rest/api/rest_public_test.go
+++ b/backend/app/rest/api/rest_public_test.go
@@ -771,8 +771,12 @@ func TestPublic_FindCommentsCtrl_ConsistentCount(t *testing.T) {
 		t.Run(tc.params, func(t *testing.T) {
 			url := fmt.Sprintf(ts.URL+"/api/v1/find?site=remark42&%s", tc.params)
 			body, code := get(t, url)
+			// bad-request cases are identified by their error response body rather than
+			// a "=bad" substring of the params: comment IDs are random UUIDs and one
+			// starting with "bad" (e.g. offset_id=bad49e60-...) would otherwise be
+			// misread as a bad request, making this test flaky.
 			expectedStatus := http.StatusOK
-			if strings.Contains(tc.params, "=bad") {
+			if strings.Contains(tc.expectedBody, `"error":`) {
 				expectedStatus = http.StatusBadRequest
 			}
 			assert.Equal(t, expectedStatus, code)


### PR DESCRIPTION
`TestPublic_FindCommentsCtrl_ConsistentCount` chose the expected HTTP status with `strings.Contains(tc.params, "=bad")`. Comment IDs in the fixture are random UUIDs, so when one happened to start with `bad` (e.g. `offset_id=bad49e60-...`), the params string contained `=bad` and the case was wrongly expected to return 400 while the handler correctly returned 200. That failed the whole suite roughly 0.2% of the time, independent of the code under test.

Identify bad-request cases by their error response body (`"error":`) instead, which is deterministic per table row and independent of the generated IDs. This matches exactly the intended invalid-parameter rows (`limit=bad`, `offset_id=bad`, in both plain and tree formats) and no valid row.

Surfaced when it failed the validate check on an unrelated PR.