### PR TITLE
Add govulncheck scan to backend CI

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -77,3 +77,34 @@ jobs:
         working-directory: backend
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  vulncheck:
+    name: Vulnerability scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: install go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.25"
+          # both go.sum files so the cache key covers the main and example modules scanned below
+          cache-dependency-path: |
+            backend/go.sum
+            backend/_example/memory_store/go.sum
+
+      - name: govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@v1.5.0
+          govulncheck ./...
+          (cd _example/memory_store && govulncheck ./...)
+        working-directory: backend
+        env:
+          # ignore the committed vendor dirs and resolve modules from the cache so
+          # both the main module and the nested example module scan consistently
+          GOFLAGS: "-mod=readonly"


### PR DESCRIPTION
Nothing in CI guarded against known vulnerabilities in the Go dependency tree. This adds a `vulncheck` job to the backend workflow that runs `govulncheck` over both the main `backend` module and the nested `backend/_example/memory_store` module on every backend change.

`govulncheck` is pinned to `@v1.5.0` rather than tracking latest for reproducible runs. The step sets `GOFLAGS=-mod=readonly` so it resolves modules from the cache instead of Go's default vendor mode — both modules commit/ignore vendor differently, and readonly scans them consistently without mutating `go.mod`/`go.sum`. The current tree scans clean (no vulnerabilities).