### PR TITLE
Drop armv7 build target and remove dead golangci settings

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,26 +26,17 @@ builds:
       - amd64
       - arm64
       - "386"
-      - arm
-    goarm:
-      - "7"
     ignore:
       - goos: darwin
         goarch: "386"
-      - goos: darwin
-        goarch: arm
       - goos: freebsd
         goarch: arm64
       - goos: freebsd
         goarch: "386"
-      - goos: freebsd
-        goarch: arm
       - goos: windows
         goarch: arm64
       - goos: windows
         goarch: "386"
-      - goos: windows
-        goarch: arm
     ldflags:
       - -s -w -X main.revision={{ .Tag }}-{{ .ShortCommit }}-{{ trimsuffix (replace (replace .CommitDate "-" "") ":" "") "Z" }}
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ docker:
 dockerx:
 	docker buildx build --build-arg GITHUB_REF=$(GITHUB_REF) --build-arg GITHUB_SHA=$(GITHUB_SHA) --build-arg CI=true \
 		--build-arg SKIP_FRONTEND_TEST=true --build-arg SKIP_BACKEND_TEST=true \
-		--progress=plain --platform linux/amd64,linux/arm/v7,linux/arm64 \
+		--progress=plain --platform linux/amd64,linux/arm64 \
 		-t ghcr.io/umputun/remark42:master -t umputun/remark42:master .
 
 release:

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -20,9 +20,6 @@ linters:
     - unparam
     - unused
   settings:
-    goconst:
-      min-len: 2
-      min-occurrences: 2
     gosec:
       excludes:
         - G117 # false positive: struct field name matches "secret" pattern
@@ -38,8 +35,6 @@ linters:
     govet:
       enable:
         - shadow
-    lll:
-      line-length: 140
     misspell:
       locale: US
   exclusions:


### PR DESCRIPTION
Two small build/tooling cleanups.

## Drop armv7

The published multi-arch Docker manifest is `amd64`+`arm64` only, but GoReleaser and the Makefile `dockerx` target still produced `linux/arm/v7` artifacts with no matching image. Remove the armv7 target (`goarch: arm` + `goarm: 7`, plus the now-redundant `goarch: arm` ignore entries) from `.goreleaser.yml`, and `linux/arm/v7` from the Makefile. The only net effect is linux no longer shipping armv7 binaries; all other platforms are unchanged.

## Remove dead golangci config

`goconst` and `lll` have `settings:` blocks in `backend/.golangci.yml`, but neither linter is in the `enable:` list (config uses `default: none`), so the settings were inert. Removed them; the remaining `gosec`/`gocritic`/`govet`/`misspell` settings are untouched (`golangci-lint config verify` passes).