### PR TITLE
Modernise Docker build workflows

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -30,14 +30,6 @@ jobs:
       - name: set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: expose GitHub Actions cache
-        uses: actions/cache@v6
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
       - name: free disk space
         run: |
           sudo rm -rf /usr/share/dotnet
@@ -46,21 +38,26 @@ jobs:
           docker system prune -af
 
       - name: build docker image without pushing
-        run: |
-          docker buildx build --load \
-              --cache-from type=local,src=/tmp/.buildx-cache \
-              --cache-to type=local,dest=/tmp/.buildx-cache-new,mode=max \
-              --build-arg SKIP_BACKEND_TEST=true --build-arg SKIP_FRONTEND_TEST=true \
-              --platform linux/amd64 .
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64
+          load: true
+          cache-from: type=gha,scope=main
+          cache-to: type=gha,scope=main,mode=max,ignore-error=true
+          build-args: |
+            SKIP_BACKEND_TEST=true
+            SKIP_FRONTEND_TEST=true
 
       - name: build example docker image without pushing
-        run: |
-          docker buildx build --load \
-              --cache-from type=local,src=/tmp/.buildx-cache \
-              --build-arg SKIP_BACKEND_TEST=true --build-arg SKIP_FRONTEND_TEST=true \
-              --platform linux/amd64 -f backend/_example/memory_store/Dockerfile .
-
-      - name: rotate cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache || true
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: backend/_example/memory_store/Dockerfile
+          platforms: linux/amd64
+          load: true
+          cache-from: type=gha,scope=example
+          cache-to: type=gha,scope=example,mode=max,ignore-error=true
+          build-args: |
+            SKIP_BACKEND_TEST=true
+            SKIP_FRONTEND_TEST=true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,14 +62,14 @@ jobs:
           sudo rm -rf /usr/local/share/boost
           docker system prune -af
 
-      - name: build and push to ghcr.io by digest
-        id: build-ghcr
+      - name: build once and push to both registries by digest
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
           platforms: ${{ matrix.platform }}
           cache-from: type=gha,scope=${{ matrix.platform }}
-          cache-to: type=gha,scope=${{ matrix.platform }},mode=max
+          cache-to: type=gha,scope=${{ matrix.platform }},mode=max,ignore-error=true
           build-args: |
             SKIP_BACKEND_TEST=true
             SKIP_FRONTEND_TEST=true
@@ -77,31 +77,18 @@ jobs:
             GITHUB_SHA=${{ github.event.workflow_run.head_sha }}
             GIT_BRANCH=${{ github.event.workflow_run.head_branch }}
             GITHUB_REF=refs/heads/${{ github.event.workflow_run.head_branch }}
-          outputs: type=image,name=ghcr.io/umputun/remark42,push-by-digest=true,name-canonical=true,push=true
+          outputs: |
+            type=image,name=ghcr.io/umputun/remark42,push-by-digest=true,name-canonical=true,push=true
+            type=image,name=umputun/remark42,push-by-digest=true,name-canonical=true,push=true
 
-      - name: build and push to DockerHub by digest
-        id: build-dockerhub
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          platforms: ${{ matrix.platform }}
-          cache-from: type=gha,scope=${{ matrix.platform }}
-          build-args: |
-            SKIP_BACKEND_TEST=true
-            SKIP_FRONTEND_TEST=true
-            CI=github
-            GITHUB_SHA=${{ github.event.workflow_run.head_sha }}
-            GIT_BRANCH=${{ github.event.workflow_run.head_branch }}
-            GITHUB_REF=refs/heads/${{ github.event.workflow_run.head_branch }}
-          outputs: type=image,name=umputun/remark42,push-by-digest=true,name-canonical=true,push=true
-
-      - name: export digests
+      - name: export digest
         run: |
+          # both registries receive the same content-addressed image, so the
+          # single build digest applies to each
           mkdir -p /tmp/digests/ghcr /tmp/digests/dockerhub
-          digest_ghcr="${{ steps.build-ghcr.outputs.digest }}"
-          digest_dockerhub="${{ steps.build-dockerhub.outputs.digest }}"
-          touch "/tmp/digests/ghcr/${digest_ghcr#sha256:}"
-          touch "/tmp/digests/dockerhub/${digest_dockerhub#sha256:}"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/ghcr/${digest#sha256:}"
+          touch "/tmp/digests/dockerhub/${digest#sha256:}"
 
       - name: upload ghcr digest
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## ci-build.yml — buildx cache modernisation

Replaced the legacy `actions/cache` + `/tmp/.buildx-cache` local cache (with a manual rotate step) with buildx `type=gha` cache, separate scopes for the main and example images. The two build steps are now `docker/build-push-action@v7` (`load: true`, no push) rather than raw `docker buildx build` — required because `type=gha` needs the GitHub Actions cache URL/token that the action injects automatically but a raw shell `buildx` call does not. This workflow runs on PRs, so the change is exercised by this PR's own CI.

## docker.yml — build each image once

The publish job built each image twice per platform (one `build-push-action` call per registry). It now builds once and pushes the same content-addressed image to both ghcr.io and DockerHub via two `type=image` outputs; the single build digest is identical for both registries, so digest export is simplified. The multi-arch manifest merge is unchanged.

**Validation note:** `docker.yml` only runs on `workflow_run` (master / release tags), so it is **not** exercised by this PR's CI. The single-build/two-output digest handling was verified against the build-push-action and BuildKit docs (BuildKit's image exporter returns one root manifest digest, identical across registries for identical content), and the downstream "verify all digests present" step fails loudly if a digest were missing. Worth watching the first master run after merge.