### PR TITLE
Fix comments iframe collapsing to preloader height on load

### DIFF
--- a/frontend/apps/remark42/app/components/root/root.spec.tsx
+++ b/frontend/apps/remark42/app/components/root/root.spec.tsx
@@ -1,0 +1,74 @@
+import '@testing-library/jest-dom';
+import { waitFor } from '@testing-library/preact';
+
+import { render } from 'tests/utils';
+import * as api from 'common/api';
+import * as postMessage from 'utils/post-message';
+import type { User } from 'common/types';
+import type { StoreState } from 'store';
+
+import { ConnectedRoot } from './root';
+
+const stateStub: Partial<StoreState> = {
+  comments: {
+    sort: '-active',
+    isFetching: false,
+    childComments: {},
+    topComments: [],
+    pinnedComments: [],
+    allComments: {},
+    activeComment: null,
+  },
+  collapsedThreads: {},
+  theme: 'light',
+  info: { url: 'test-url', count: 0, read_only: false },
+  hiddenUsers: {},
+  bannedUsers: [],
+  user: null,
+};
+
+describe('<ConnectedRoot />', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('reports iframe height only after the initial user fetch settles', async () => {
+    let resolveUser!: (user: User | null) => void;
+    jest.spyOn(api, 'getUser').mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveUser = resolve;
+        })
+    );
+    // keep comments loading so only the user fetch controls the first height report
+    jest.spyOn(api, 'getPostComments').mockImplementation(() => new Promise(() => undefined));
+    const updateIframeHeight = jest.spyOn(postMessage, 'updateIframeHeight').mockImplementation(() => undefined);
+
+    render(<ConnectedRoot />, stateStub);
+
+    // while the global preloader is shown, no height must be sent to the parent page,
+    // otherwise the parent shrinks the iframe to the preloader size and it blinks
+    expect(updateIframeHeight).not.toHaveBeenCalled();
+
+    resolveUser(null);
+
+    await waitFor(() => expect(updateIframeHeight).toHaveBeenCalled());
+  });
+
+  it('falls back to reporting iframe height when the user fetch hangs', () => {
+    jest.useFakeTimers();
+    try {
+      jest.spyOn(api, 'getUser').mockImplementation(() => new Promise(() => undefined));
+      jest.spyOn(api, 'getPostComments').mockImplementation(() => new Promise(() => undefined));
+      const updateIframeHeight = jest.spyOn(postMessage, 'updateIframeHeight').mockImplementation(() => undefined);
+
+      render(<ConnectedRoot />, stateStub);
+      expect(updateIframeHeight).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(5000);
+      expect(updateIframeHeight).toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/frontend/apps/remark42/app/components/root/root.tsx
+++ b/frontend/apps/remark42/app/components/root/root.tsx
@@ -1,5 +1,4 @@
 import { h, Component, Fragment } from 'preact';
-import { useEffect } from 'preact/hooks';
 import { useSelector } from 'react-redux';
 import { IntlShape, useIntl, FormattedMessage, defineMessages } from 'react-intl';
 import clsx from 'clsx';
@@ -112,8 +111,29 @@ export class Root extends Component<Props, State> {
     isSettingsVisible: false,
   };
 
+  heightObserver: ResizeObserver | null = null;
+  heightFallbackTimeout: number | null = null;
+
+  startHeightReporting = () => {
+    if (this.heightObserver) {
+      return;
+    }
+
+    updateIframeHeight();
+    this.heightObserver = new ResizeObserver(() => updateIframeHeight());
+    this.heightObserver.observe(document.body);
+  };
+
   componentDidMount() {
-    const userloading = this.props.fetchUser().finally(() => this.setState({ isUserLoading: false }));
+    // if the user fetch hangs, report the preloader height anyway so the parent page
+    // is not left with an unbounded iframe
+    this.heightFallbackTimeout = window.setTimeout(this.startHeightReporting, 5000);
+
+    const userloading = this.props.fetchUser().finally(() =>
+      // start reporting iframe height only after the global preloader is replaced with
+      // real content, so the parent page never shrinks the iframe to the preloader size
+      this.setState({ isUserLoading: false }, this.startHeightReporting)
+    );
 
     Promise.all([userloading, this.props.fetchComments()]).finally(() => {
       setTimeout(this.checkUrlHash);
@@ -121,6 +141,13 @@ export class Root extends Component<Props, State> {
     });
 
     window.addEventListener('message', this.onMessage);
+  }
+
+  componentWillUnmount() {
+    if (this.heightFallbackTimeout !== null) {
+      window.clearTimeout(this.heightFallbackTimeout);
+    }
+    this.heightObserver?.disconnect();
   }
 
   checkUrlHash = (e: Event & { newURL: string }) => {
@@ -324,14 +351,6 @@ export function ConnectedRoot() {
   const intl = useIntl();
   const props = useSelector(mapStateToProps);
   const actions = useActions(boundActions);
-
-  useEffect(() => {
-    const observer = new ResizeObserver(() => updateIframeHeight());
-
-    updateIframeHeight();
-    observer.observe(document.body);
-    return () => observer.disconnect();
-  }, []);
 
   return (
     <div className={clsx(styles.root, props.theme === 'dark' ? styles.themeDark : styles.themeLight, props.theme)}>


### PR DESCRIPTION
### Problem

On opening a page with comments the widget area goes white, then visibly blinks several times before settling (reported on radio-t.com, reproducible in any browser).

Measured mechanism, via a `postMessage` height listener on the parent page: the embed iframe starts at `height: 100%` of its container, then on radio-t receives `63px → 316px → 420px → 537px → 735px → 991px` within ~150ms. The first message is sent while the app still renders its global preloader, so the parent **shrinks the iframe from full container size to ~63px** and then grows it back step by step — each snap is a visible blink.

`ConnectedRoot`'s mount effect called `updateIframeHeight()` immediately and attached the `ResizeObserver` right away. The June dependency refresh (#2091) shifted render/effect timing enough that the premature preloader measurement now happens on **every** load, not only on slow connections: on an empty test page v1.16.1 sends a single `316px`, current master sends `63px` then `316px`.

### Fix

Move height reporting into `Root`, which owns the preloader state, and start it in the `setState` callback that replaces the preloader with real content — the first height message now always describes rendered content and the iframe never shrinks below it. Subsequent `ResizeObserver` updates only grow the frame as comments arrive.

- `startHeightReporting` is idempotent; a 5s fallback timer starts reporting even if `/auth/status` hangs, so the parent is never left with an unbounded iframe.
- Adds the previously missing observer disconnect (and timer cleanup) on unmount.
- The auth dropdown's own `updateIframeHeight(dropdown)` calls are unaffected.

### Verification

- New `root.spec.tsx`: no height reported while the user fetch is pending, reported after it settles; fallback fires on a hung fetch (fake timers). The first spec fails against the old code.
- Browser-level check with the patched build served by the master Docker image: height sequence is now `316, 316, 316` (was `63, 63, 316, 316`).
- 303 app tests, `tsc --noEmit`, and eslint all pass.