### PR TITLE
Cleanup of CSS colors

### DIFF
--- a/frontend/apps/remark42/app/components/auth/auth.module.css
+++ b/frontend/apps/remark42/app/components/auth/auth.module.css
@@ -26,7 +26,7 @@
   min-width: 240px;
   padding: 16px;
   background-color: rgb(var(--primary-background-color));
-  box-shadow: 0 10px 15px rgba(var(--black-color), 0.1), 0 -1px 6px rgba(var(--black-color), 0.05);
+  box-shadow: 0 10px 15px rgba(var(--shadow-color)), 0 -1px 6px rgba(var(--shadow-color));
   border-radius: 6px;
 }
 
@@ -54,7 +54,7 @@
     width: 100%;
     height: 0;
     content: '';
-    border-top: 1px solid var(--line-color);
+    border-top: 1px solid rgb(var(--line-color));
   }
 
   &::after {
@@ -72,7 +72,7 @@
 
 :global(.dark) .divider {
   &::after {
-    background-color: var(--color8);
+    background-color: rgb(var(--primary-background-color));
   }
 }
 
@@ -111,7 +111,7 @@
 }
 
 :global(.dark) .provider {
-  color: var(--color32);
+  color: rgb(var(--lighter-text-color));
 }
 
 .radio:checked + .provider {
@@ -122,7 +122,7 @@
 }
 
 :global(.dark) .radio:checked + .provider {
-  color: rgb(var(--white-color));
+  color: rgb(var(--inverse-text-color));
   background-color: rgba(var(--primary-color), 0.4);
 }
 
@@ -191,7 +191,7 @@
 .error {
   margin-bottom: 12px;
   padding: 6px 8px;
-  background-color: var(--error-background);
-  color: var(--error-color);
+  background-color: rgb(var(--error-background));
+  color: rgb(var(--error-color));
   line-height: 1.2;
 }

--- a/frontend/apps/remark42/app/components/auth/components/button.module.css
+++ b/frontend/apps/remark42/app/components/auth/components/button.module.css
@@ -16,7 +16,7 @@
   cursor: pointer;
   white-space: nowrap;
   background-color: rgb(var(--primary-color));
-  color: rgb(var(--white-color));
+  color: rgb(var(--inverse-text-color));
 
   &:hover {
     background-color: rgb(var(--primary-brighter-color));
@@ -30,7 +30,7 @@
   &:disabled {
     opacity: 0.6;
     cursor: default;
-    background-color: var(--color9);
+    background-color: rgb(var(--primary-color));
   }
 }
 

--- a/frontend/apps/remark42/app/components/auth/components/oauth.module.css
+++ b/frontend/apps/remark42/app/components/auth/components/oauth.module.css
@@ -22,7 +22,7 @@
   cursor: pointer;
   align-items: center;
   justify-content: center;
-  border: 1px solid var(--line-color);
+  border: 1px solid rgb(var(--line-color));
   border-radius: 50%;
 
   &::after {
@@ -32,7 +32,7 @@
 
   &:hover {
     transform: scale(1.05);
-    border-color: var(--line-brighter-color);
+    border-color: rgb(var(--line-brighter-color));
   }
 
   &:active {
@@ -40,8 +40,8 @@
   }
 
   &:focus {
-    border-color: var(--line-brighter-color);
-    box-shadow: 0 0 0 2px var(--line-color);
+    border-color: rgb(var(--line-brighter-color));
+    box-shadow: 0 0 0 2px rgb(var(--line-color));
   }
 }
 

--- a/frontend/apps/remark42/app/components/avatar/avatar.module.css
+++ b/frontend/apps/remark42/app/components/avatar/avatar.module.css
@@ -6,5 +6,4 @@
 
 .avatarGhost {
   box-sizing: border-box;
-  border: 1px solid var(--color40);
 }

--- a/frontend/apps/remark42/app/components/avatar/avatar.module.css
+++ b/frontend/apps/remark42/app/components/avatar/avatar.module.css
@@ -6,4 +6,5 @@
 
 .avatarGhost {
   box-sizing: border-box;
+  border: 1px solid rgb(var(--ghost-color));
 }

--- a/frontend/apps/remark42/app/components/button/button.module.css
+++ b/frontend/apps/remark42/app/components/button/button.module.css
@@ -10,7 +10,7 @@
   white-space: nowrap;
 
   &:focus {
-    box-shadow: 0 0 0 2px var(--color47);
+    box-shadow: 0 0 0 2px rgb(var(--primary-brighter-color));
     outline: none;
   }
 
@@ -23,37 +23,37 @@
 .kindLink {
   background: transparent;
   font-weight: 600;
-  color: var(--color9);
+  color: rgb(var(--primary-color));
 
   &:hover {
-    color: var(--color33);
+    color: rgb(var(--primary-brighter-color));
   }
 
   &:disabled,
   &:hover:disabled {
-    color: var(--color9);
+    color: rgb(var(--primary-color));
   }
 }
 
 .kindPrimary {
-  background: var(--color15);
-  color: var(--color6);
+  background: rgb(var(--primary-color));
+  color: rgb(var(--inverse-text-color));
 
   &:hover {
-    background: var(--color33);
+    background: rgb(var(--primary-brighter-color));
   }
 
   &:hover:disabled {
-    background: var(--color15);
+    background: rgb(var(--primary-brighter-color));
   }
 }
 
 .kindSecondary {
-  background: var(--color6);
-  color: inherit;
+  background: rgb(var(--inverse-text-color));
+  color: rgb(var(--primary-color));
 
   &:hover {
-    box-shadow: inset 0 0 0 2px var(--color33);
+    box-shadow: inset 0 0 0 2px rgb(var(--primary-brighter-color));
   }
 }
 
@@ -70,14 +70,14 @@
 
 .themeDark {
   &.kindSecondary {
-    background: var(--color8);
-    color: var(--color20);
+    background: rgb(var(--primary-background-color));
+    color: rgb(var(--primary-text-color));
   }
 
   &.kindLink {
     &:disabled,
     &:hover:disabled {
-      color: var(--color6);
+      color: rgb(var(--inverse-text-color));
     }
   }
 }

--- a/frontend/apps/remark42/app/components/button/button.module.css
+++ b/frontend/apps/remark42/app/components/button/button.module.css
@@ -10,7 +10,7 @@
   white-space: nowrap;
 
   &:focus {
-    box-shadow: 0 0 0 2px rgb(var(--primary-brighter-color));
+    box-shadow: 0 0 0 2px rgba(var(--primary-brighter-color), 0.4);
     outline: none;
   }
 
@@ -44,7 +44,7 @@
   }
 
   &:hover:disabled {
-    background: rgb(var(--primary-brighter-color));
+    background: rgb(var(--primary-color));
   }
 }
 

--- a/frontend/apps/remark42/app/components/comment-form/__subscribe-by-email/subscribe-by-email.module.css
+++ b/frontend/apps/remark42/app/components/comment-form/__subscribe-by-email/subscribe-by-email.module.css
@@ -31,7 +31,7 @@
 
 .tokenInput {
   resize: vertical;
-  border: 1px solid var(--color31);
+  border: 1px solid rgb(var(--line-brighter-color));
   padding: 4px;
   font-family: inherit;
   font-size: 0.8em;
@@ -39,8 +39,8 @@
   line-height: 1.5;
 
   &:focus {
-    box-shadow: 0 0 0 2px var(--color47);
-    border-color: var(--color15);
+    box-shadow: 0 0 0 2px rgba(var(--primary-color), 0.4);
+    border-color: rgb(var(--primary-brighter-color));
     outline: none;
   }
 }
@@ -52,11 +52,11 @@
 }
 
 .themeDark .error {
-  background: var(--color28);
-  color: var(--color27);
+  background: rgb(var(--error-background));
+  color: rgb(var(--error-color));
 }
 
 .themeLight .error {
-  background: var(--color26);
-  color: var(--color25);
+  background: rgb(var(--error-background));
+  color: rgb(var(--error-color));
 }

--- a/frontend/apps/remark42/app/components/comment-form/__subscribe-by-rss/subscribe-by-rss.module.css
+++ b/frontend/apps/remark42/app/components/comment-form/__subscribe-by-rss/subscribe-by-rss.module.css
@@ -7,9 +7,9 @@
   white-space: nowrap;
   text-decoration: none;
   cursor: pointer;
-  color: var(--color9);
+  color: rgb(var(--primary-color));
 
   &:hover {
-    color: var(--color33);
+    color: rgb(var(--primary-brighter-color));
   }
 }

--- a/frontend/apps/remark42/app/components/comment-form/comment-form.module.css
+++ b/frontend/apps/remark42/app/components/comment-form/comment-form.module.css
@@ -20,7 +20,7 @@
 
 .controlPanel {
   height: 30px;
-  background-color: var(--color5);
+  background-color: rgb(var(--secondary-background-color));
 }
 
 .fieldWrapper {
@@ -47,13 +47,13 @@
   transform: translateZ(0);
 
   &:focus {
-    box-shadow: 0 0 0 2px var(--color47);
-    border-color: var(--color15);
+    box-shadow: 0 0 0 2px rgba(var(--primary-color), 0.4);
+    border-color: rgb(var(--primary-brighter-color));
     outline: none;
   }
 
   &:disabled {
-    color: var(--color10);
+    color: rgb(var(--lighter-text-color));
   }
 }
 
@@ -63,7 +63,7 @@
   bottom: 4px;
   font-size: 10px;
   font-weight: 700;
-  color: var(--color38);
+  color: rgb(var(--error-color));
 }
 
 .error {
@@ -122,65 +122,67 @@
 }
 
 .themeDark {
-  border-color: var(--color7);
-  background: var(--color8);
+  border-color: rgb(var(--secondary-background-color));
+  background: rgb(var(--primary-background-color));
 
   & .actions {
-    background: var(--color7);
+    background: rgb(var(--secondary-background-color));
+    color: rgb(var(--secondary-text-color));
   }
 
   & .error {
-    border-top: 8px solid var(--color7);
-    background: var(--color28);
-    color: var(--color27);
+    border-top: 8px solid rgb(var(--line-color));
+    background: rgb(var(--error-background));
+    color: rgb(var(--error-color));
   }
 
   & .field {
-    background: var(--color8);
-    color: var(--color5);
+    background: rgb(var(--primary-background-color));
+    color: rgb(var(--primary-text-color));
   }
 
   & .preview {
-    border-color: var(--color8);
-    background: var(--color8);
-    color: var(--color20);
+    border-color: rgb(var(--primary-background-color));
+    background: rgb(var(--primary-background-color));
+    color: rgb(var(--primary-text-color));
   }
 
   & .previewWrapper {
-    background: var(--color7);
+    background: rgb(var(--secondary-background-color));
   }
 
   & .controlPanel {
-    background-color: var(--color7);
+    background-color: rgb(var(--secondary-background-color));
   }
 }
 
 .themeLight {
-  border-color: var(--color5);
-  background: var(--color6);
+  border-color: rgb(var(--secondary-background-color));
+  background: rgb(var(--primary-background-color));
 
   & .actions {
-    background: var(--color5);
+    background: rgb(var(--secondary-background-color));
+    color: rgb(var(--secondary-text-color));
   }
 
   & .error {
-    border-top: 8px solid var(--color5);
-    background: var(--color26);
-    color: var(--color25);
+    border-top: 8px solid rgb(var(--secondary-background-color));
+    background: rgb(var(--error-background));
+    color: rgb(var(--error-color));
   }
 
   & .field {
-    background: var(--color6);
-    color: var(--color0);
+    background: rgb(var(--primary-background-color));
+    color: rgb(var(--primary-text-color));
   }
 
   & .preview {
-    border-color: var(--color5);
-    background: var(--color6);
-    color: var(--color7);
+    border-color: rgb(var(--primary-background-color));
+    background: rgb(var(--primary-background-color));
+    color: rgb(var(--primary-text-color));
   }
 
   & .previewWrapper {
-    background: var(--color5);
+    background: rgb(var(--secondary-background-color));
   }
 }

--- a/frontend/apps/remark42/app/components/comment-form/comment-form.module.css
+++ b/frontend/apps/remark42/app/components/comment-form/comment-form.module.css
@@ -131,7 +131,7 @@
   }
 
   & .error {
-    border-top: 8px solid rgb(var(--line-color));
+    border-top: 8px solid rgb(var(--secondary-background-color));
     background: rgb(var(--error-background));
     color: rgb(var(--error-color));
   }
@@ -177,7 +177,7 @@
   }
 
   & .preview {
-    border-color: rgb(var(--primary-background-color));
+    border-color: rgb(var(--secondary-background-color));
     background: rgb(var(--primary-background-color));
     color: rgb(var(--primary-text-color));
   }

--- a/frontend/apps/remark42/app/components/comment-form/markdown-toolbar.module.css
+++ b/frontend/apps/remark42/app/components/comment-form/markdown-toolbar.module.css
@@ -14,7 +14,7 @@
 .item {
   background: none;
   border: 0;
-  color: var(--color37);
+  color: rgb(var(--secondary-text-color));
   display: flex;
   float: left;
   height: 24px;
@@ -24,7 +24,7 @@
   cursor: pointer;
 
   &:hover {
-    color: var(--color9);
+    color: rgb(var(--primary-color));
   }
 }
 
@@ -43,9 +43,9 @@
 }
 
 :global(.dark) .item {
-  color: var(--color20);
+  color: rgb(var(--secondary-text-color));
 
   &:hover {
-    color: var(--color9);
+    color: rgb(var(--primary-brighter-color));
   }
 }

--- a/frontend/apps/remark42/app/components/comment-form/text-expander.module.css
+++ b/frontend/apps/remark42/app/components/comment-form/text-expander.module.css
@@ -8,16 +8,16 @@
   margin: 24px 0 0;
   list-style: none;
   cursor: pointer;
-  background: var(--color6);
-  border: 1px solid var(--color16);
+  background: rgb(var(--primary-background-color));
+  border: 1px solid rgb(var(--line-color));
   border-radius: 3px;
-  box-shadow: 0 1px 5px var(--color46);
+  box-shadow: 0 1px 5px rgba(var(--shadow-color));
 }
 
 .suggesterDark {
-  background: var(--color8);
-  color: var(--color20);
-  border: 1px solid var(--color7);
+  background: rgb(var(--primary-background-color));
+  color: rgb(var(--secondary-text-color));
+  border: 1px solid rgb(var(--line-color));
 }
 
 .suggesterItem {
@@ -25,18 +25,18 @@
   padding: 4px 8px;
   font-size: 14px;
   font-weight: 600;
-  border-bottom: 1px solid var(--color16);
+  border-bottom: 1px solid rgb(var(--line-color));
 }
 
 .suggesterItemDark {
-  border-bottom: 1px solid var(--color7);
+  border-bottom: 1px solid rgb(var(--line-color));
 }
 
 .suggesterItem:hover,
 .suggesterItem[aria-selected='true'] {
-  color: var(--color6);
+  color: rgb(var(--primary-background-color));
   text-decoration: none;
-  background-color: var(--color48);
+  background-color: rgb(var(--primary-brighter-color));
 }
 
 .suggesterItem:first-child {

--- a/frontend/apps/remark42/app/components/comment-form/text-expander.module.css
+++ b/frontend/apps/remark42/app/components/comment-form/text-expander.module.css
@@ -36,7 +36,7 @@
 .suggesterItem[aria-selected='true'] {
   color: rgb(var(--primary-background-color));
   text-decoration: none;
-  background-color: rgb(var(--primary-brighter-color));
+  background-color: rgb(var(--inverse-text-color));
 }
 
 .suggesterItem:first-child {

--- a/frontend/apps/remark42/app/components/comment/comment-actions.module.css
+++ b/frontend/apps/remark42/app/components/comment/comment-actions.module.css
@@ -11,7 +11,7 @@
 }
 
 .countdown {
-  color: rgb(var(--secondary-darker-text-color));
+  color: rgb(var(--lighter-text-color));
 }
 
 @media (hover: hover) {

--- a/frontend/apps/remark42/app/components/comment/comment-votes.module.css
+++ b/frontend/apps/remark42/app/components/comment/comment-votes.module.css
@@ -20,7 +20,7 @@
   align-items: center;
   padding: 2px;
   opacity: 0.4;
-  color: var(--color13);
+  color: rgb(var(--lighter-text-color));
   transition: opacity 0.15s, color 0.15s;
 }
 
@@ -30,13 +30,13 @@
 
 .upVoteButton:hover,
 .upVoteButtonActive {
-  color: rgb(var(--color12));
+  color: rgb(var(--upvote-color));
   opacity: 1;
 }
 
 .downVoteButton:hover,
 .downVoteButtonActive {
-  color: rgb(var(--color30));
+  color: rgb(var(--downvote-color));
   opacity: 1;
 }
 
@@ -47,17 +47,17 @@
   border-radius: 3px;
   min-width: 16px;
   text-align: center;
-  color: rgb(var(--secondary-darker-text-color));
+  color: rgb(var(--lighter-text-color));
 }
 
 .votesNegative {
-  color: rgb(var(--color30));
-  background-color: rgba(var(--color30), 0.1);
+  color: rgb(var(--downvote-color));
+  background-color: rgba(var(--downvote-color), 0.1);
 }
 
 .votesPositive {
-  color: rgb(var(--color12));
-  background-color: rgba(var(--color12), 0.1);
+  color: rgb(var(--upvote-color));
+  background-color: rgba(var(--upvote-color), 0.1);
 }
 
 .upVoteIcon {

--- a/frontend/apps/remark42/app/components/comment/comment.module.css
+++ b/frontend/apps/remark42/app/components/comment/comment.module.css
@@ -17,11 +17,10 @@
 }
 
 .verificationIcon {
-  color: var(--color29);
+  color: rgb(var(--verified-color));
 }
 
 .verificationIconInactive {
-  color: var(--color1);
   transition: opacity 0.15s;
 
   &:hover {
@@ -33,20 +32,20 @@
   display: inline-flex;
   height: 1rem;
   width: 1rem;
-  color: var(--color1);
+  color: rgb(var(--lighter-text-color));
   justify-content: center;
   align-items: center;
 
   &:hover {
-    color: var(--color29);
+    color: rgb(var(--primary-text-color));
   }
 }
 
 :global(.dark) .threadStarterAnchor {
-  color: var(--color11);
+  color: rgb(var(--lighter-text-color));
 
   &:hover {
-    color: var(--color41);
+    color: rgb(var(--primary-text-color));
   }
 }
 
@@ -211,7 +210,7 @@
   &.themeLight,
   &.themeDark {
     & .username {
-      color: var(--color29);
+      color: rgb(var(--primary-color));
     }
   }
 }
@@ -227,11 +226,11 @@
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
-      color: var(--color9);
+      color: rgb(var(--primary-color));
     }
 
     & .titleLink {
-      color: var(--color9);
+      color: rgb(var(--primary-color));
       text-decoration: none;
 
       &:hover {
@@ -243,7 +242,7 @@
       display: inline;
       padding-right: 0;
       font-weight: 700;
-      color: var(--color10);
+      color: rgb(var(--lighter-text-color));
 
       &::after {
         content: ' ';
@@ -251,7 +250,7 @@
     }
 
     & .username {
-      color: var(--color9);
+      color: rgb(var(--primary-color));
     }
 
     & .text {
@@ -277,7 +276,7 @@
   }
 
   & .titleLink {
-    color: var(--color29);
+    color: rgb(var(--primary-color));
     font-weight: bold;
     text-decoration: none;
     text-overflow: ellipsis;
@@ -293,104 +292,104 @@
 
 .themeDark {
   & .status {
-    color: var(--color11);
+    color: rgb(var(--lighter-text-color));
   }
 
   & .time {
-    color: var(--color35);
+    color: rgb(var(--lighter-text-color));
 
     &:hover {
-      color: var(--color1);
+      color: rgb(var(--primary-text-color));
     }
   }
 
   & .username {
-    color: var(--color10);
+    color: rgb(var(--primary-color));
 
     &:hover {
-      color: var(--color33);
+      color: rgb(var(--primary-brighter-color));
     }
   }
 
   &.editing {
     & .input {
-      border-color: var(--color7);
+      border-color: rgb(var(--secondary-background-color));
     }
 
     @media (pointer: coarse) and (max-width: 768px) {
-      border-color: var(--color7);
+      border-color: rgb(var(--secondary-background-color));
     }
   }
 
   &.replying {
     & .input {
-      border-color: var(--color7);
+      border-color: rgb(var(--secondary-background-color));
     }
 
     @media (pointer: coarse) and (max-width: 768px) {
-      border-color: var(--color7);
+      border-color: rgb(var(--secondary-background-color));
     }
   }
 
   &.viewPreview {
     & .info {
       &::after {
-        color: var(--color10);
+        color: rgb(var(--lighter-text-color))
       }
     }
   }
 
   &:global(.comment_highlighting) {
-    background: var(--color19);
+    background: rgb(var(--highlight-color));
   }
 }
 
 .themeLight {
   & .status {
-    color: var(--color11);
+    color: rgb(var(--lighter-text-color));
   }
 
   & .time {
-    color: var(--color11);
+    color: rgb(var(--lighter-text-color));
 
     &:hover {
-      color: var(--color10);
+      color: rgb(var(--lighter-text-color));
     }
   }
 
   & .username {
-    color: var(--color10);
+    color: rgb(var(--primary-color));
   }
 
   &.editing {
     & .input {
-      border-color: var(--color5);
+      border-color: rgb(var(--secondary-background-color));
     }
 
     @media (pointer: coarse) and (max-width: 768px) {
-      border-color: var(--color5);
+      border-color: rgb(var(--secondary-background-color));
     }
   }
 
   &.replying {
     & .input {
-      border-color: var(--color5);
+      border-color: rgb(var(--secondary-background-color));
     }
 
     @media (pointer: coarse) and (max-width: 768px) {
-      border-color: var(--color5);
+      border-color: rgb(var(--secondary-background-color));
     }
   }
 
   &.viewPreview {
     & .info {
       &::after {
-        color: var(--color10);
+        color: rgb(var(--lighter-text-color))
       }
     }
   }
 
   &:global(.comment_highlighting) {
-    background: var(--color4);
+    background: rgb(var(--highlight-color));
   }
 }

--- a/frontend/apps/remark42/app/components/comment/comment.module.css
+++ b/frontend/apps/remark42/app/components/comment/comment.module.css
@@ -21,6 +21,7 @@
 }
 
 .verificationIconInactive {
+  color: rgb(var(--deactivated-color));
   transition: opacity 0.15s;
 
   &:hover {
@@ -210,7 +211,7 @@
   &.themeLight,
   &.themeDark {
     & .username {
-      color: rgb(var(--primary-color));
+      color: rgb(var(--lighter-text-color));
     }
   }
 }
@@ -250,7 +251,7 @@
     }
 
     & .username {
-      color: rgb(var(--primary-color));
+      color: rgb(var(--lighter-text-color));
     }
 
     & .text {
@@ -304,7 +305,7 @@
   }
 
   & .username {
-    color: rgb(var(--primary-color));
+    color: rgb(var(--lighter-text-color));
 
     &:hover {
       color: rgb(var(--primary-brighter-color));
@@ -334,7 +335,7 @@
   &.viewPreview {
     & .info {
       &::after {
-        color: rgb(var(--lighter-text-color))
+        color: rgb(var(--lighter-text-color));
       }
     }
   }
@@ -358,7 +359,7 @@
   }
 
   & .username {
-    color: rgb(var(--primary-color));
+    color: rgb(var(--lighter-text-color));
   }
 
   &.editing {
@@ -384,7 +385,7 @@
   &.viewPreview {
     & .info {
       &::after {
-        color: rgb(var(--lighter-text-color))
+        color: rgb(var(--lighter-text-color));
       }
     }
   }

--- a/frontend/apps/remark42/app/components/comment/raw-content.css
+++ b/frontend/apps/remark42/app/components/comment/raw-content.css
@@ -10,7 +10,7 @@
   }
 
   & a {
-    color: var(--color9);
+    color: rgb(var(--primary-color));
     text-decoration: underline;
 
     &:hover {
@@ -26,7 +26,7 @@
   & blockquote {
     padding: 12px 8px 12px 16px;
     border-left: 2px solid;
-    border-left-color: var(--color45);
+    border-left-color: rgba(var(--shadow-color));
   }
 
   & p,
@@ -43,20 +43,22 @@
     & th {
       text-align: left;
       font-weight: 600;
+      background-color: rgb(var(--primary-color));
+      color: rgb(var(--inverse-text-color));
     }
 
     & th,
     & td {
       padding: 6px 13px;
-      border: 1px solid var(--color16);
+      border: 1px solid rgb(var(--line-color));
     }
 
     & tr {
-      border-top: 1px solid var(--color43);
-      background-color: var(--color6);
+      border-top: 1px solid rgb(var(--line-color));
+      background-color: rgb(var(--primary-background-color));
 
       &:nth-child(2n) {
-        background-color: var(--color21);
+        background-color: rgb(var(--line-color));
       }
     }
   }
@@ -71,7 +73,7 @@
 
   & hr {
     border-width: 0 0 1px 0;
-    border-color: var(--color21);
+    border-color: rgb(var(--line-brighter-color));
   }
 
   & code {
@@ -219,25 +221,25 @@
   --chroma-07: #a1e6fb;
 
   & blockquote {
-    border-left-color: var(--color44);
+    border-left-color: rgb(var(--line-color));
   }
 
   & table {
     & th,
     & td {
-      border: 1px solid var(--color24);
+      border: 1px solid rgb(var(--line-color));
     }
 
     & tr {
-      background-color: var(--color8);
+      background-color: rgb(var(--primary-background-color));
 
       &:nth-child(2n) {
-        background-color: var(--color23);
+        background-color: rgb(var(--line-color));
       }
     }
   }
 
   & hr {
-    border-color: var(--color22);
+    border-color: rgb(var(--line-brighter-color));
   }
 }

--- a/frontend/apps/remark42/app/components/comment/raw-content.css
+++ b/frontend/apps/remark42/app/components/comment/raw-content.css
@@ -50,7 +50,7 @@
     & th,
     & td {
       padding: 6px 13px;
-      border: 1px solid rgb(var(--line-color));
+      border: 1px solid rgb(var(--line-brighter-color));
     }
 
     & tr {
@@ -227,7 +227,7 @@
   & table {
     & th,
     & td {
-      border: 1px solid rgb(var(--line-color));
+      border: 1px solid rgb(var(--line-brighter-color));
     }
 
     & tr {

--- a/frontend/apps/remark42/app/components/dropdown/__item/dropdown-item.module.css
+++ b/frontend/apps/remark42/app/components/dropdown/__item/dropdown-item.module.css
@@ -9,6 +9,6 @@
 }
 
 .separator {
-  border-bottom: 1px solid var(--color15);
+  border-bottom: 1px solid rgb(var(--primary-brighter-color));
   margin-bottom: 5px;
 }

--- a/frontend/apps/remark42/app/components/dropdown/dropdown.module.css
+++ b/frontend/apps/remark42/app/components/dropdown/dropdown.module.css
@@ -13,7 +13,7 @@
   transform: translate(-0.5em, 5px);
   min-width: 120px;
   max-width: 260px;
-  border: 2px solid var(--color15);
+  border: 2px solid rgb(var(--primary-brighter-color));
   border-radius: 3px;
   padding: 0 0 5px;
 }
@@ -38,9 +38,9 @@
 }
 
 .themeDark > .content {
-  background-color: var(--color8);
+  background-color: rgb(var(--primary-background-color));
 }
 
 .themeLight > .content {
-  background-color: var(--color6);
+  background-color: rgb(var(--primary-background-color));
 }

--- a/frontend/apps/remark42/app/components/input/input.module.css
+++ b/frontend/apps/remark42/app/components/input/input.module.css
@@ -2,58 +2,58 @@
 .input {
   width: 100%;
   box-sizing: border-box;
-  border: 1px solid var(--line-color);
+  border: 1px solid rgb(var(--line-color));
   border-radius: 4px;
   margin: 0;
   padding: 0 8px;
   height: 36px;
   font-size: 16px;
   font-family: inherit;
-  background-color: rgb(var(--white-color));
-  color: var(--color7);
+  background-color: rgb(var(--primary-background-color));
+  color: rgb(var(--primary-text-color));
 
   &:hover {
-    border-color: var(--line-brighter-color);
+    border-color: rgb(var(--line-brighter-color));
   }
 
   &:focus {
-    box-shadow: 0 0 0 2px var(--color47);
-    border-color: var(--color15);
+    box-shadow: 0 0 0 2px rgba(var(--primary-color), 0.4);
+    border-color: rgb(var(--primary-brighter-color));
     outline: none;
   }
 
   &:disabled {
-    background-color: var(--color21);
-    border-color: var(--line-color);
+    background-color: rgb(var(--line-brighter-color));
+    border-color: rgb(var(--line-color));
   }
 
   &::placeholder {
-    color: var(--color11);
-    -webkit-text-fill-color: var(--color11);
+    color: rgb(var(--lighter-text-color));
+    -webkit-text-fill-color: rgb(var(--lighter-text-color));
   }
 }
 
 .input:-webkit-autofill {
-  box-shadow: 0 0 0 1000px rgb(var(--white-color)) inset;
-  -webkit-text-fill-color: var(--color7);
+  box-shadow: 0 0 0 1000px rgb(var(--primary-background-color)) inset;
+  -webkit-text-fill-color: rgb(var(--primary-text-color));
 
   &:focus {
-    box-shadow: 0 0 0 1000px rgb(var(--white-color)) inset, 0 0 0 2px var(--color47);
+    box-shadow: 0 0 0 1000px rgb(var(--white-color)) inset, 0 0 0 2px rgba(var(--primary-color), 0.4);
   }
 
   &::placeholder {
-    -webkit-text-fill-color: var(--color11);
+    -webkit-text-fill-color: rgb(var(--lighter-text-color));
   }
 }
 
 :global(.dark) {
   & .input {
-    background-color: var(--color22);
+    background-color: rgb(var(--secondary-background-color));
     color: rgba(var(--white-color), 0.8);
 
     &:focus {
-      border-color: var(--color15);
-      box-shadow: 0 0 0 2px var(--color47);
+      border-color: rgb(var(--primary-brighter-color));
+      box-shadow: 0 0 0 2px rgba(var(--primary-color), 0.4);
     }
 
     &::placeholder {
@@ -62,11 +62,11 @@
   }
 
   & .input:-webkit-autofill {
-    box-shadow: 0 0 0 1000px var(--color22) inset;
+    box-shadow: 0 0 0 1000px rgb(var(--secondary-background-color)) inset;
     -webkit-text-fill-color: rgba(var(--white-color), 0.8);
 
     &:focus {
-      box-shadow: 0 0 0 1000px var(--color22) inset, 0 0 0 2px var(--color47);
+      box-shadow: 0 0 0 1000px rgb(var(--secondary-background-color)) inset, 0 0 0 2px rgba(var(--primary-color), 0.4);
       -webkit-text-fill-color: rgba(var(--white-color), 0.8);
     }
 
@@ -80,7 +80,7 @@
   &,
   &:hover,
   &:focus {
-    border-color: var(--error-color);
-    box-shadow: 0 0 0 2px var(--error-background);
+    border-color: rgb(var(--error-color));
+    box-shadow: 0 0 0 2px rgb(var(--error-background));
   }
 }

--- a/frontend/apps/remark42/app/components/input/input.module.css
+++ b/frontend/apps/remark42/app/components/input/input.module.css
@@ -49,7 +49,7 @@
 :global(.dark) {
   & .input {
     background-color: rgb(var(--secondary-background-color));
-    color: rgba(var(--white-color), 0.8);
+    color: rgba(var(--primary-text-color), 0.8);
 
     &:focus {
       border-color: rgb(var(--primary-brighter-color));
@@ -57,21 +57,21 @@
     }
 
     &::placeholder {
-      color: rgba(var(--white-color), 0.2);
+      color: rgba(var(--primary-text-color), 0.2);
     }
   }
 
   & .input:-webkit-autofill {
     box-shadow: 0 0 0 1000px rgb(var(--secondary-background-color)) inset;
-    -webkit-text-fill-color: rgba(var(--white-color), 0.8);
+    -webkit-text-fill-color: rgba(var(--primary-text-color), 0.8);
 
     &:focus {
       box-shadow: 0 0 0 1000px rgb(var(--secondary-background-color)) inset, 0 0 0 2px rgba(var(--primary-color), 0.4);
-      -webkit-text-fill-color: rgba(var(--white-color), 0.8);
+      -webkit-text-fill-color: rgba(var(--primary-text-color), 0.8);
     }
 
     &::placeholder {
-      -webkit-text-fill-color: rgba(var(--white-color), 0.4);
+      -webkit-text-fill-color: rgba(var(--primary-text-color), 0.4);
     }
   }
 }

--- a/frontend/apps/remark42/app/components/profile/components/counter/counter.module.css
+++ b/frontend/apps/remark42/app/components/profile/components/counter/counter.module.css
@@ -1,13 +1,14 @@
 .container {
   font-size: 14px;
   line-height: 1;
-  background-color: var(--color29);
-  color: var(--color6);
+  background-color: rgb(var(--primary-color));
+  color: rgb(var(--inverse-text-color));
   font-weight: 700;
   padding: 3px 4px 2px;
   border-radius: 2px;
 }
 
 :global(.dark) .container {
-  background-color: rgba(var(--white-color), 0.12);
+  background-color: rgb(var(--highlight-color));
+  color: rgb(var(--primary-text-color));
 }

--- a/frontend/apps/remark42/app/components/profile/components/counter/counter.module.css
+++ b/frontend/apps/remark42/app/components/profile/components/counter/counter.module.css
@@ -1,7 +1,7 @@
 .container {
   font-size: 14px;
   line-height: 1;
-  background-color: rgb(var(--primary-color));
+  background-color: rgb(var(--verified-color));
   color: rgb(var(--inverse-text-color));
   font-weight: 700;
   padding: 3px 4px 2px;

--- a/frontend/apps/remark42/app/components/profile/profile.module.css
+++ b/frontend/apps/remark42/app/components/profile/profile.module.css
@@ -132,7 +132,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 12px;
-  color: var(--color13);
+  color: rgb(var(--lighter-text-color));
 }
 
 .signout {
@@ -186,12 +186,12 @@
 
 .preloader {
   margin: auto;
-  color: var(--color13);
+  color: rgb(var(--deactivated-color));
 }
 
 .emptyState {
   margin: auto;
-  color: var(--color13);
+  color: rgb(var(--deactivated-color));
 }
 
 .loadMoreWrapper {

--- a/frontend/apps/remark42/app/components/root/root.module.css
+++ b/frontend/apps/remark42/app/components/root/root.module.css
@@ -2,7 +2,7 @@
   position: relative;
 
   &::selection {
-    background: var(--color42);
+    background: rgb(var(--selection-color));
   }
 }
 
@@ -55,41 +55,41 @@
 }
 
 .themeDark {
-  color: var(--color20);
+  color: rgb(var(--primary-text-color));
 
   & .copyright {
-    color: var(--color1);
+    color: rgb(var(--lighter-text-color));
   }
 
   & .copyrightLink {
-    color: var(--color1);
+    color: rgb(var(--primary-text-color));
   }
 
   & .pinnedComment {
-    border-bottom-color: var(--color18);
+    border-bottom-color: rgb(var(--line-color));
   }
 
   & .pinnedComments {
-    background: var(--color19);
+    background: rgb(var(--highlight-color));
   }
 }
 
 .themeLight {
-  color: var(--color0);
+  color: rgb(var(--primary-text-color));
 
   & .copyright {
-    color: var(--color1);
+    color: rgb(var(--lighter-text-color));
   }
 
   & .copyrightLink {
-    color: var(--color1);
+    color: rgb(var(--primary-text-color));
   }
 
   & .pinnedComment {
-    border-bottom-color: var(--color3);
+    border-bottom-color: rgb(var(--line-color));
   }
 
   & .pinnedComments {
-    background: var(--color4);
+    background: rgb(var(--highlight-color));
   }
 }

--- a/frontend/apps/remark42/app/components/settings/settings.module.css
+++ b/frontend/apps/remark42/app/components/settings/settings.module.css
@@ -9,11 +9,11 @@
 .action {
   margin-left: 8px;
   font-weight: 700;
-  color: var(--color9);
+  color: rgb(var(--primary-color));
   cursor: pointer;
 
   &:hover {
-    color: var(--color33);
+    color: rgb(var(--primary-brighter-color));
   }
 
   &::before {
@@ -65,7 +65,7 @@
 .themeDark {
   & .action {
     &::before {
-      color: var(--color20);
+      color: rgb(var(--lighter-text-color));
     }
   }
 }
@@ -73,7 +73,7 @@
 .themeLight {
   & .action {
     &::before {
-      color: var(--color10);
+      color: rgb(var(--lighter-text-color));
     }
   }
 }

--- a/frontend/apps/remark42/app/components/spinner/spinner.module.css
+++ b/frontend/apps/remark42/app/components/spinner/spinner.module.css
@@ -8,8 +8,8 @@
 }
 
 .dark {
-  border: 2px solid var(--color46);
-  border-right-color: var(--color37);
+  border: 2px solid rgba(var(--shadow-color));
+  border-right-color: rgb(var(--line-color));
 }
 
 :global(.dark) & {

--- a/frontend/apps/remark42/app/components/thread/thread.module.css
+++ b/frontend/apps/remark42/app/components/thread/thread.module.css
@@ -24,13 +24,13 @@
     position: absolute;
     left: 5px;
     top: 0;
-    border-left: 1px dotted var(--color35);
+    border-left: 1px dotted rgb(var(--line-color));
     height: 100%;
   }
 
   &:hover::after {
     transform: translateX(-1px);
-    border-left: 3px solid var(--color10);
+    border-left: 3px solid rgb(var(--line-brighter-color));
     z-index: 10;
   }
 }
@@ -87,11 +87,11 @@
 .themeDark {
   & .collapse {
     &::after {
-      border-color: var(--color36);
+      border-color: rgb(var(--line-color));
     }
 
     &:hover::after {
-      border-color: var(--color6);
+      border-color: rgb(var(--line-brighter-color));
     }
   }
 }

--- a/frontend/apps/remark42/app/components/tooltip/tooltip.module.css
+++ b/frontend/apps/remark42/app/components/tooltip/tooltip.module.css
@@ -7,8 +7,8 @@
   visibility: hidden;
   padding: 4px 6px;
   border-radius: 4px;
-  background-color: rgb(var(--black-color));
-  color: rgb(var(--white-color));
+  background-color: rgb(var(--primary-text-color));
+  color: rgb(var(--primary-background-color));
 }
 
 .tooltip::after {
@@ -42,7 +42,7 @@
   &::after {
     top: 100%;
     right: 10px;
-    border-top-color: rgb(var(--black-color));
+    border-top-color: rgb(var(--primary-text-color));
     border-bottom-width: 0;
   }
 }

--- a/frontend/apps/remark42/app/styles/custom-properties.css
+++ b/frontend/apps/remark42/app/styles/custom-properties.css
@@ -46,7 +46,7 @@
   --secondary-background-color: 51, 51, 51;
   --highlight-color: 64, 64, 64;
   --secondary-text-color: 209, 213, 219;
-  --error-color: 255, 160, 160
+  --error-color: 255, 160, 160;
   --error-background: 103, 35, 35;
   --line-brighter-color: 136, 136, 136;
 }

--- a/frontend/apps/remark42/app/styles/custom-properties.css
+++ b/frontend/apps/remark42/app/styles/custom-properties.css
@@ -1,51 +1,4 @@
 :root {
-  --color0: #0f172a;
-  --color8: #262626;
-  --color22: #2d2d2c;
-  --color24: #313133;
-  --color7: #333;
-  --color23: #393734;
-  --color18: #383838;
-  --color19: #404040;
-  --color36: #575757;
-  --color34: #555;
-  --color37: #586069;
-  --color14: #6a6a6a;
-  --color10: #777;
-  --color13: #888;
-  --color11: #969696;
-  --color32: #a6a6a6;
-  --color1: #aaa;
-  --color35: #d1d5db;
-  --color20: #ddd;
-  --color46: rgba(27, 31, 35, 0.15);
-  --color45: rgba(0, 0, 0, 0.1);
-  --color41: #efefef;
-  --color5: #eee;
-  --color44: rgba(255, 255, 255, 0.3);
-  --color6: #fff;
-  --color3: #e2efef;
-  --color4: #edf6f7;
-  --color16: #e2e8f0;
-  --color31: #cbd5e1;
-  --color21: #f1f5f9;
-  --color29: #0e7e9d;
-  --color9: #0aa;
-  --color15: #099;
-  --color33: #06c5c5;
-  --color40: #9cdddb;
-  --color43: #b7dddd;
-  --color42: #c6efef;
-  --color48: rgba(37, 156, 154, 0.6);
-  --color47: rgba(37, 156, 154, 0.4);
-  --color28: #672323;
-  --color25: #9a0000;
-  --color38: #ef0000;
-  --color27: #f98989;
-  --color26: #ffd7d7;
-  --color30: 204, 6, 6;
-  --color12: 37, 158, 6;
-
   /* code-highlight */
   --chroma-bg: rgba(0, 0, 0, 0.05);
   --chroma-base: #586e75;
@@ -59,31 +12,41 @@
   --chroma-07: #00aee2;
 
   /* Named variables */
+  --font-family: system-ui;
   --primary-color: 0, 170, 170;
-  --primary-brighter-color: 0, 153, 153;
+  --primary-brighter-color: 0, 197, 197;
   --primary-darker-color: 0, 102, 102;
   --primary-text-color: 38, 38, 38;
   --secondary-text-color: 100, 116, 139;
-  --secondary-darker-text-color: 150, 150, 150;
+  --inverse-text-color: 255, 255, 255;
+  --lighter-text-color: 150, 150, 150;
+  --deactivated-color: 136, 136, 136;
   --primary-background-color: 255, 255, 255;
-  --black-color: 0, 0, 0;
+  --secondary-background-color: 238, 238, 238;
+  --highlight-color: 241, 245, 249;
+  --selection-color: 198, 239, 239;
+  --shadow-color: 27, 31, 35, 0.15;
+  --downvote-color: 204, 6, 6;
+  --upvote-color: 37, 158, 6;
+  --verified-color: 14, 126, 157;
   --white-color: 255, 255, 255;
-  --error-color: #b91c1c;
-  --error-background: #ff466f2b;
-  --line-color: var(--color16);
-  --line-brighter-color: var(--color31);
-  --text-color: var(--black-color);
+  --error-color: 185, 28, 28;
+  --error-background: 255, 222, 230;
+  --line-color: 226, 239, 239;
+  --line-brighter-color: 203, 213, 225;
   --transparent: transparent;
 }
 
 :root .dark {
-  --line-color: var(--color36);
+  --line-color: 87, 87, 87;
   --primary-color: 0, 153, 153;
   --primary-brighter-color: 0, 170, 170;
   --primary-text-color: 241, 245, 249;
   --primary-background-color: 38, 38, 38;
+  --secondary-background-color: 51, 51, 51;
+  --highlight-color: 64, 64, 64;
   --secondary-text-color: 209, 213, 219;
-  --error-color: #ffa0a0;
-  --line-brighter-color: var(--color11);
-  --text-color: var(--white-color);
+  --error-color: 255, 160, 160
+  --error-background: 103, 35, 35;
+  --line-brighter-color: 136, 136, 136;
 }

--- a/frontend/apps/remark42/app/styles/custom-properties.css
+++ b/frontend/apps/remark42/app/styles/custom-properties.css
@@ -15,7 +15,6 @@
   --font-family: system-ui;
   --primary-color: 0, 170, 170;
   --primary-brighter-color: 0, 197, 197;
-  --primary-darker-color: 0, 102, 102;
   --primary-text-color: 38, 38, 38;
   --secondary-text-color: 100, 116, 139;
   --inverse-text-color: 255, 255, 255;
@@ -29,6 +28,7 @@
   --downvote-color: 204, 6, 6;
   --upvote-color: 37, 158, 6;
   --verified-color: 14, 126, 157;
+  --ghost-color: 156, 221, 219;
   --white-color: 255, 255, 255;
   --error-color: 185, 28, 28;
   --error-background: 255, 222, 230;

--- a/frontend/apps/remark42/app/styles/global.css
+++ b/frontend/apps/remark42/app/styles/global.css
@@ -3,7 +3,7 @@ body {
   -moz-osx-font-smoothing: grayscale;
   margin: 0;
   padding: 6px;
-  font-family: system-ui;
+  font-family: var(--font-family, "system-ui");
   font-size: 14px;
   color: rgb(var(--primary-text-color));
   background: transparent;
@@ -39,12 +39,12 @@ button {
 }
 
 a {
-  color: var(--color9);
+  color: rgb(var(--primary-color));
   text-decoration: none;
   cursor: pointer;
 
   &:hover {
-    color: var(--color33);
+    color: rgb(var(--primary-brighter-color));
   }
 }
 
@@ -68,7 +68,7 @@ a {
 }
 
 .preloader {
-  color: var(--color6, #fff);
+  color: var(--primary-background-color, #fff);
   position: relative;
   transform: translate3d(0, -10px, 0);
   animation-delay: -0.16s;
@@ -92,7 +92,7 @@ a {
 
 .preloader_view_iframe {
   margin: 0 auto;
-  color: var(--color13, #888);
+  color: rgb(var(--deactivated-color), (136, 136, 136));
 }
 
 :focus:not(.focus-visible):not(.button) {

--- a/frontend/apps/remark42/app/styles/global.css
+++ b/frontend/apps/remark42/app/styles/global.css
@@ -3,7 +3,7 @@ body {
   -moz-osx-font-smoothing: grayscale;
   margin: 0;
   padding: 0;
-  font-family: var(--font-family, "system-ui");
+  font-family: var(--font-family);
   font-size: 14px;
   color: rgb(var(--primary-text-color));
   background: transparent;
@@ -68,7 +68,7 @@ a {
 }
 
 .preloader {
-  color: var(--primary-background-color, #fff);
+  color: rgb(var(--primary-background-color, 255, 255, 255));
   position: relative;
   transform: translate3d(0, -10px, 0);
   animation-delay: -0.16s;
@@ -92,7 +92,7 @@ a {
 
 .preloader_view_iframe {
   margin: 0 auto;
-  color: rgb(var(--deactivated-color), (136, 136, 136));
+  color: rgb(var(--deactivated-color, 136, 136, 136));
 }
 
 :focus:not(.focus-visible):not(.button) {

--- a/frontend/apps/remark42/app/styles/global.css
+++ b/frontend/apps/remark42/app/styles/global.css
@@ -3,7 +3,7 @@ body {
   -moz-osx-font-smoothing: grayscale;
   margin: 0;
   padding: 0;
-  font-family: system-ui;
+  font-family: var(--font-family, "system-ui");
   font-size: 14px;
   color: rgb(var(--primary-text-color));
   background: transparent;
@@ -39,12 +39,12 @@ button {
 }
 
 a {
-  color: var(--color9);
+  color: rgb(var(--primary-color));
   text-decoration: none;
   cursor: pointer;
 
   &:hover {
-    color: var(--color33);
+    color: rgb(var(--primary-brighter-color));
   }
 }
 
@@ -68,7 +68,7 @@ a {
 }
 
 .preloader {
-  color: var(--color6, #fff);
+  color: var(--primary-background-color, #fff);
   position: relative;
   transform: translate3d(0, -10px, 0);
   animation-delay: -0.16s;
@@ -92,7 +92,7 @@ a {
 
 .preloader_view_iframe {
   margin: 0 auto;
-  color: var(--color13, #888);
+  color: rgb(var(--deactivated-color), (136, 136, 136));
 }
 
 :focus:not(.focus-visible):not(.button) {

--- a/frontend/apps/remark42/app/typings/global.d.ts
+++ b/frontend/apps/remark42/app/typings/global.d.ts
@@ -38,6 +38,11 @@ type RemarkConfig = {
   simple_view?: boolean;
   // Optional, 'false' by default. Hides footer with signature and links to Remark42.
   no_footer?: boolean;
+  // Optional, 'system-ui' by default. A string containing the fonts being used, delimited by commas for
+  // alternative fonts if the first one doesn't exist on the system.
+  __font__?: string;
+  // Optional. An array of different rgb values for changing the interface colors and an rgba value for
+  // changing the shadows.
   __colors__?: Record<string, string>;
 };
 

--- a/frontend/apps/remark42/app/typings/global.d.ts
+++ b/frontend/apps/remark42/app/typings/global.d.ts
@@ -41,7 +41,7 @@ type RemarkConfig = {
   // Optional, 'system-ui' by default. A string containing the fonts being used, delimited by commas for
   // alternative fonts if the first one doesn't exist on the system.
   __font__?: string;
-  // Optional. An array of different rgb values for changing the interface colors and an rgba value for
+  // Optional. An object of different rgb values for changing the interface colors and an rgba value for
   // changing the shadows.
   __colors__?: Record<string, string>;
 };

--- a/frontend/apps/remark42/app/utils/create-iframe.ts
+++ b/frontend/apps/remark42/app/utils/create-iframe.ts
@@ -5,6 +5,7 @@ import { setStyles, setAttributes, StylesDeclaration } from 'utils/set-dom-props
 type Params = {
   [key: string]: unknown;
   __colors__?: Record<string, string>;
+  __font__?: string;
   styles?: StylesDeclaration;
   onReveal?: () => void;
 };
@@ -28,13 +29,13 @@ const REVEAL_TIMEOUT = 5000;
  * `styles` is applied last, so a caller passing `visibility` overrides the hiding
  * and brings the white flash back.
  */
-export function createIframe({ __colors__, styles, onReveal, ...params }: Params) {
+export function createIframe({ __colors__, __font__, styles, onReveal, ...params }: Params) {
   const iframe = document.createElement('iframe');
   const query = new URLSearchParams(params as Record<string, string>).toString();
 
   setAttributes(iframe, {
     src: `${BASE_URL}/web/iframe.html?${query}`,
-    name: JSON.stringify({ __colors__ }),
+    name: JSON.stringify({ __colors__, __font__ }),
     tabindex: '0',
     title: 'Comments | Remark42',
   });

--- a/frontend/apps/remark42/templates/demo.ejs
+++ b/frontend/apps/remark42/templates/demo.ejs
@@ -127,7 +127,7 @@
         url: window.location.href,
         components: ['embed', 'counter'],
         // __colors__: {
-        //   "--color0": "red",
+        //   '--primary-color': '255, 255, 200'
         // },
         theme: theme,
         // locale: "ru",

--- a/frontend/apps/remark42/templates/demo.ejs
+++ b/frontend/apps/remark42/templates/demo.ejs
@@ -133,7 +133,7 @@
         url: window.location.href,
         components: ['embed', 'counter'],
         // __colors__: {
-        //   "--color0": "red",
+        //   '--primary-color': '255, 255, 200'
         // },
         theme: theme,
         // locale: "ru",

--- a/frontend/apps/remark42/templates/iframe.ejs
+++ b/frontend/apps/remark42/templates/iframe.ejs
@@ -41,6 +41,7 @@
           try {
             var name = JSON.parse(window.name);
             var colors = name.__colors__;
+            var font = name.__font__;
             var root = document.documentElement;
             if (colors) {
               for (var color in colors) {
@@ -50,6 +51,9 @@
                 }
                 root.style.setProperty(color, colors[color]);
               }
+            }
+            if (font) {
+              root.style.setProperty('--font-family', font);
             }
           } catch (e) {}
         }

--- a/site/src/docs/configuration/frontend/index.md
+++ b/site/src/docs/configuration/frontend/index.md
@@ -22,6 +22,8 @@ title: Frontend Configuration
 - **`show_rss_subscription`**`: boolean` (optional, `true` by default) – enables RSS subscription feature in interface
 - **`simple_view`**`: boolean` (optional, `false` by default) – overrides the parameter from the backend minimized UI with basic info only
 - **`no_footer`**`: boolean` (optional, `false` by default) – hides footer with signature and links to Remark42
+- **`__font__`**`: string` (optional, `system-ui` by default) - a string containing the fonts being used, delimited by commas for alternative fonts if the first one doesn't exist on the system.
+- **`__colors__`**`: ['--primary-color:': 'r, g, b', '--primary-text-color:' 'r, g, b', .., '--shadow.color:' 'r, g, b, a']` (optional) - An array containing different rgb values for changing the interface colors, and an rgba value for changing the shadows. Changing these settings will only work using the light theme. Colors not included in the array will have their default values. Note that interface elements might change their default color group in the future, so any changes made here are likely to break with future updates.
 
 Example with all of the params:
 
@@ -29,15 +31,43 @@ Example with all of the params:
 <script>
 	var remark_config = {
 		host: 'https://remark42.example.com',
+		url: '/blog/my-first-blog-post/',
 		site_id: 'my_site',
 		components: ['embed', 'last-comments'],
 		max_shown_comments: 100,
-		theme: 'dark',
+		max_last_comments: 100,
+		theme: 'light',
 		page_title: 'My custom title for a page',
 		locale: 'es',
 		show_email_subscription: false,
+		show_telegram_subscription: false,
+		show_rss_subscription: false,
 		simple_view: true,
-		no_footer: false
+		no_footer: false,
+		__font__: 'Comic Sans MS, Comic Sans, Chalkboard SE, Comic Neue, sans-serif',
+		__colors__: {
+		  '--primary-background-color': '0, 0, 255',
+			'--secondary-background-color': '255, 0, 0',
+			'--primary-color': '255, 255, 0',
+			'--primary-brighter-color': '255, 255, 0',
+			'--primary-darker-color': '0, 0, 0',
+			'--primary-text-color': '255, 255, 255',
+			'--secondary-text-color': '255, 255, 0',
+			'--inverse-text-color': '255, 0, 0',
+			'--lighter-text-color': '255, 255, 255',
+			'--line-color': '0, 0, 0',
+			'--line-brighter-color': '0, 0, 0',
+			'--deactivated-color': '255, 0, 0',
+			'--highlight-color': '255, 0, 255',
+			'--selection-color': '255, 255, 0',
+			'--downvote-color': '255, 0, 0',
+			'--upvote-color': '0, 255, 0',
+			'--verified-color': '0, 0, 255',
+			'--white-color': '255, 255, 255',
+			'--error-color': '255, 0, 0',
+			'--error-background': '255, 255, 0',
+			'--shadow-color': '0, 0, 0, 0.5'
+		}
 	}
 </script>
 ```

--- a/site/src/docs/configuration/frontend/index.md
+++ b/site/src/docs/configuration/frontend/index.md
@@ -22,8 +22,8 @@ title: Frontend Configuration
 - **`show_rss_subscription`**`: boolean` (optional, `true` by default) – enables RSS subscription feature in interface
 - **`simple_view`**`: boolean` (optional, `false` by default) – overrides the parameter from the backend minimized UI with basic info only
 - **`no_footer`**`: boolean` (optional, `false` by default) – hides footer with signature and links to Remark42
-- **`__font__`**`: string` (optional, `system-ui` by default) - a string containing the fonts being used, delimited by commas for alternative fonts if the first one doesn't exist on the system.
-- **`__colors__`**`: ['--primary-color:': 'r, g, b', '--primary-text-color:' 'r, g, b', .., '--shadow.color:' 'r, g, b, a']` (optional) - An array containing different rgb values for changing the interface colors, and an rgba value for changing the shadows. Changing these settings will only work using the light theme. Colors not included in the array will have their default values. Note that interface elements might change their default color group in the future, so any changes made here are likely to break with future updates.
+- **`__font__`**`: string` (optional, `system-ui` by default) - a string containing the fonts being used for the iframe module, delimited by commas for alternative fonts if the first one doesn't exist on the system.
+- **`__colors__`**`: {'--primary-color': 'r, g, b', '--primary-text-color': 'r, g, b', .., '--shadow-color': 'r, g, b, a'}` (optional) - An object containing different rgb values for changing the interface colors for the iframe module, and an rgba value for changing the shadows. Many of these settings will be overwritten by using the dark theme, so this is mainly to be used with the light theme as the base setting. Colors not included in the object will have their default values. Note that interface elements might change their default color group in the future, so any changes made here are likely to break with future updates. Previous versions included numbered colors as well (e.g. --color11), but these have been replaced with the named colors.
 
 Example with all of the params:
 
@@ -50,7 +50,6 @@ Example with all of the params:
 			'--secondary-background-color': '255, 0, 0',
 			'--primary-color': '255, 255, 0',
 			'--primary-brighter-color': '255, 255, 0',
-			'--primary-darker-color': '0, 0, 0',
 			'--primary-text-color': '255, 255, 255',
 			'--secondary-text-color': '255, 255, 0',
 			'--inverse-text-color': '255, 0, 0',
@@ -63,6 +62,7 @@ Example with all of the params:
 			'--downvote-color': '255, 0, 0',
 			'--upvote-color': '0, 255, 0',
 			'--verified-color': '0, 0, 255',
+			'--ghost-color': '0, 0, 0',
 			'--white-color': '255, 255, 255',
 			'--error-color': '255, 0, 0',
 			'--error-background': '255, 255, 0',


### PR DESCRIPTION
The intention of this cleanup is to make the interface more consistent with fewer different colors, to make it easier to make your own themes without changing a lot of colors. There's no intention of actually changing the look of the interface noticeably through this, and most users would hopefully not notice some slight color changes that has been made.

Before, there were many different colors used across the interface, but a lot of these were quite similar to each other, so colors close to each other have been changed into a slightly different one of the colors with a named feature instead of the numbered colors. A few extra named colors were added from the previous numbered colors, so now there's no numbered colors left. All variables are now in rgb or rgba values to make it consistent.

Some things have changed color more than slightly, like the indicator next to the comment actions and the comment collapse lines. This is to make the coloring more consistent across various elements, but there shouldn't be any extreme changes that stand out.

As there are now several things that are based on the named variables instead of color names, there now seems to be some pointless double definitions for light mode and dark mode. However, these have been left in the code for now to avoid changing too much at once. In the future, there's room for some further cleanups.

The usernames in dark mode were gray before, but are now using the primary color, as they are in light mode to make them stand out a bit more.

The coloring of verificationIconInactive in light mode was removed, so it's now the same gray color as in dark mode. This should show the difference between unverified and verified users more clearly.

There were different shadow colors where these were used, but it's now the same color everywhere. This makes the shadow slightly more visible around the login dropdown.

The tooltips were black in both light and dark mode, but are now inverted colors of the text vs. background colors.

--white-color is still being used in some places, and there might be more suitable options to change these into.

--inverse-text-color was added to be used for text on buttons etc. using the primary color as background, instead of just using white text. Before there were some inconsistencies with different colors on different buttons, but this should be fixed now.

--secondary-darker-text-color was renamed to --lighter-text-color, as that's what it's actually used for.

The ::selection color was transfered to a named selection-color without change, but the default color should probably be changed, at least in light mode, as it's close to other colors used, like the pinned comment background.

The border around the ghost avatar had a unique color before, but now the border is removed instead as this looks cleaner.

The table header now has a background color to make it stand out better.

The documentation is updated to describe how you change the colors using __colors__.

Along with __colors__, a new variable named __font__ has been added, to allow customization of the font used.

Interface using default colors:
<img width="749" height="448" alt="Using default colors" src="https://github.com/user-attachments/assets/824b767f-a0bf-4dd7-9a2c-ea8867063164" />

Interface using default colors in dark mode:
<img width="746" height="461" alt="Using default colors - dark mode" src="https://github.com/user-attachments/assets/09da039e-3a4a-4897-843e-01a9380d003b" />

Interface using customized colors and font, as in the example in the updated frontend documentation:
<img width="786" height="482" alt="Customized colors and font" src="https://github.com/user-attachments/assets/88f03290-1750-4b53-8e3a-720f7d0e18f7" />
<img width="751" height="454" alt="Customized colors and font - logged in" src="https://github.com/user-attachments/assets/8c06785b-3f77-46f9-b0b0-7e3da03c9dd4" />
