### PR TITLE
Document Microsoft supported account types, drop deprecated Twitter example

### DIFF
--- a/site/src/docs/configuration/authorization/index.md
+++ b/site/src/docs/configuration/authorization/index.md
@@ -78,11 +78,15 @@ _instructions for Google OAuth2 setup borrowed from [oauth2_proxy](https://githu
 ### Microsoft
 
 1. Register a new application [using the Azure portal](https://docs.microsoft.com/en-us/graph/auth-register-app-v2)
-2. Under **"Authentication/Platform configurations/Web"** enter the correct URL constructed as domain + `/auth/microsoft/callback`, i.e., `https://example.mysite.com/auth/microsoft/callback`
-3. In **"Overview"** take note of the **Application (client) ID** (`AUTH_MICROSOFT_CID`)
-4. Choose the new project from the top right project dropdown (only if another project is selected)
-5. Select **"Certificates & secrets"** and click on **"+ New Client Secret"** (`AUTH_MICROSOFT_CSEC`)
-6. For single-tenant Entra ID applications, set `AUTH_MICROSOFT_TENANT` to your tenant ID or domain name. The default value is `common`, which works for multi-tenant applications.
+2. Under **"Supported account types"** select **"Accounts in any organizational directory (Any Microsoft Entra directory - Multitenant) and personal Microsoft accounts"**
+3. Under **"Authentication/Platform configurations/Web"** enter the correct URL constructed as domain + `/auth/microsoft/callback`, i.e., `https://example.mysite.com/auth/microsoft/callback`
+4. In **"Overview"** take note of the **Application (client) ID** (`AUTH_MICROSOFT_CID`)
+5. Choose the new project from the top right project dropdown (only if another project is selected)
+6. Select **"Certificates & secrets"** and click on **"+ New Client Secret"** (`AUTH_MICROSOFT_CSEC`)
+
+By default, Remark42 authenticates against the `common` endpoint, which requires a multi-tenant application. A single-tenant application (`signInAudience: AzureADMyOrg`) is rejected there with [`AADSTS50194`](https://learn.microsoft.com/en-us/entra/identity-platform/reference-error-codes). The account types the application actually accepts are the intersection of the endpoint and the registration, so selecting personal Microsoft accounts as well is what makes them usable; choose `signInAudience: AzureADMultipleOrgs` instead to keep sign-in to work or school accounts only. You can check and change the value under **"Manifest"** for an application that already exists.
+
+To use a different endpoint, set `AUTH_MICROSOFT_TENANT` to your tenant ID or domain name for a single-tenant Entra ID application (`AzureADMyOrg`), to `organizations` for a multi-tenant application accepting work or school accounts only (`AzureADMultipleOrgs`), or to `consumers` for an application limited to personal Microsoft accounts (`PersonalMicrosoftAccount`).
 
 ### Yandex
 

--- a/site/src/docs/manuals/reproxy/index.md
+++ b/site/src/docs/manuals/reproxy/index.md
@@ -59,8 +59,6 @@ services:
       - ADMIN_SHARED_ID=github_ef0f706a79cc24b112345
       - ADMIN_SHARED_NAME=myname,anothername
       - ADMIN_SHARED_EMAIL=admin@example.com
-      - AUTH_TWITTER_CID=12345678
-      - AUTH_TWITTER_CSEC=asdfghjkl
       - AUTH_ANON=true
       - AUTH_EMAIL_ENABLE=true
       - AUTH_EMAIL_FROM=confirmation@example.com


### PR DESCRIPTION
The Microsoft setup instructions never mentioned supported account types. Remark42 builds its endpoint as `AzureADEndpoint(tenant)` with `AUTH_MICROSOFT_TENANT` defaulting to `common`, and that endpoint only accepts an application registered for both work or school accounts and personal Microsoft accounts, which is `signInAudience: AzureADandPersonalMicrosoftAccount`. An application created with any other value fails to authenticate, and nothing in the documentation pointed at the cause.

The instructions now name the **Supported account types** choice as its own step, explain the endpoint requirement afterwards, give the manifest value for checking an existing application, and cite `AADSTS50194` as the error a non-multitenant application gets at that endpoint. The tenant paragraph also gains `consumers`, which is the correct endpoint for an application limited to personal Microsoft accounts and became reachable when `AUTH_MICROSOFT_TENANT` was added in 1.16.0.

The same section in [go-pkgz/auth](https://github.com/go-pkgz/auth) is updated in a companion PR, since the setup steps are duplicated there.

Separately, the reproxy manual configured `AUTH_TWITTER_CID` and `AUTH_TWITTER_CSEC` in its example compose file. Those have been deprecated and non-functional since 1.14.0, so anyone copying that example was setting up a provider that cannot work. Removed. The deprecated-parameters table and the reserved-provider-name list still mention Twitter, which is correct in both cases.

Resolves #1823.
