### PR TITLE
Stop Dependabot npm updates, including security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
+
+# npm updates are switched off entirely. open-pull-requests-limit bounds version
+# updates only, so the ignore entries below are what also stops security updates;
+# removing the npm entries would not work, as security updates come from alerts
+# rather than from this file.
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -23,6 +28,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/frontend"
     open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"
     schedule:
       interval: "monthly"
     groups:
@@ -33,6 +40,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/frontend/packages/api"
     open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"
     schedule:
       interval: "monthly"
     groups:
@@ -43,6 +52,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/frontend/e2e"
     open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"
     schedule:
       interval: "monthly"
     groups:
@@ -53,6 +64,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/frontend/apps/remark42"
     open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"
     schedule:
       interval: "monthly"
     groups:
@@ -63,6 +76,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/site"
     open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"
     schedule:
       interval: "monthly"
     groups:


### PR DESCRIPTION
The npm entries already carried `open-pull-requests-limit: 0`, which reads as switching npm off but does not. GitHub documents that setting as the way to keep security updates while excluding version updates: *"If you only require security updates and want to exclude version updates, you can set `open-pull-requests-limit` to `0`."* Security updates are unlimited and do not count against it.

That is what has been arriving. All five open npm pull requests match open Dependabot alerts rather than version bumps: nanoid, linkify-it, postcss and webpack-dev-server, out of 30 open npm alerts in total.

The `ignore` option applies to both version and security updates, so a blanket `dependency-name: "*"` per npm entry is what actually stops them. `gomod` and `github-actions` are untouched and keep both kinds.

Worth recording for whoever reads this next, which is why it is also a comment in the file: removing the npm entries would not have worked. Security updates are driven by alerts rather than by `dependabot.yml`, so deleting the blocks would have removed the only place an ignore can be expressed while the pull requests carried on.

Existing open npm pull requests are not closed by this change, since `ignore` only prevents new ones. They are being closed separately.
