### PR TITLE
Close the login dropdown only on a genuine outside click

### DIFF
--- a/frontend/apps/remark42/app/components/auth/auth.hooks.ts
+++ b/frontend/apps/remark42/app/components/auth/auth.hooks.ts
@@ -23,9 +23,16 @@ export function useDropdown(disableClosing?: boolean) {
     }
 
     function handleMessageFromParent(evt: MessageEvent) {
+      // only the embedding page may close the dropdown, and only by reporting a click
+      // outside the widget. the parent also posts hash, title and theme messages, and
+      // extensions post their own, none of which should interrupt an active login
+      if (evt.source !== window.parent) {
+        return;
+      }
+
       const data = parseMessage(evt);
 
-      if (disableClosing && data.clickOutside) {
+      if (!data.clickOutside || disableClosing) {
         return;
       }
 

--- a/frontend/apps/remark42/app/components/auth/auth.spec.tsx
+++ b/frontend/apps/remark42/app/components/auth/auth.spec.tsx
@@ -22,6 +22,13 @@ describe('<Auth/>', () => {
     StaticStore.config.auth_providers = defaultProviders;
   });
 
+  // the embedding page posts into the widget with iframe.contentWindow.postMessage, which
+  // arrives with source set to the parent. jsdom leaves source unset on window.postMessage,
+  // so it is set here explicitly
+  function postFromParent(data: unknown) {
+    window.dispatchEvent(new MessageEvent('message', { data, source: window.parent }));
+  }
+
   // TODO: separate tests of `useDropdown` mechanics with the hook
   describe('useDropdown', () => {
     it('should render auth with hidden dropdown', () => {
@@ -54,7 +61,7 @@ describe('<Auth/>', () => {
       expect(container.querySelector('.auth-dropdown')).not.toBeInTheDocument();
     });
 
-    it('should close dropdown by message from parent', async () => {
+    it('should close dropdown by clickOutside message from parent', async () => {
       const { container } = render(<Auth />);
 
       expect(container.querySelector('.auth-dropdown')).not.toBeInTheDocument();
@@ -62,8 +69,37 @@ describe('<Auth/>', () => {
       fireEvent.click(screen.getByText('Sign In'));
       expect(container.querySelector('.auth-dropdown')).toBeInTheDocument();
 
-      window.postMessage('{"clickOutside": true}', '*');
+      postFromParent({ clickOutside: true });
       await waitFor(() => expect(container.querySelector('.auth-dropdown')).not.toBeInTheDocument());
+    });
+
+    it.each([
+      ['title', { title: 'New title' }],
+      ['hash', { hash: '#comment-1' }],
+      ['theme', { theme: 'dark' }],
+      ['an unparsable payload', 'clickOutside'],
+    ])('should not close dropdown by %s message from parent', async (_, message) => {
+      const { container } = render(<Auth />);
+
+      fireEvent.click(screen.getByText('Sign In'));
+      expect(container.querySelector('.auth-dropdown')).toBeInTheDocument();
+
+      postFromParent(message);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(container.querySelector('.auth-dropdown')).toBeInTheDocument();
+    });
+
+    it('should not close dropdown by clickOutside message from a foreign source', async () => {
+      const { container } = render(<Auth />);
+
+      fireEvent.click(screen.getByText('Sign In'));
+      expect(container.querySelector('.auth-dropdown')).toBeInTheDocument();
+
+      window.dispatchEvent(new MessageEvent('message', { data: { clickOutside: true }, source: null }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(container.querySelector('.auth-dropdown')).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
Any message reaching the widget closed the Sign In dropdown. The handler returned early only for a `clickOutside` payload while closing was disabled, and fell through to closing in every other case, so the payload was never actually checked on the path that matters.

That is a problem because plenty of messages arrive that have nothing to do with clicking. `embed.ts` installs a `MutationObserver` on the host page's `<title>` and posts `{title}` on every mutation, and it also posts `hash` and `theme`. Browser extensions posting into the page have the same effect. Each one closes an open login form and discards whatever was typed into it, since the form unmounts on close.

Reproduced against the deployed demo at v1.16.4. With the dropdown open on the email form and a username filled in, a single `document.title` assignment from the host page console removed it. As a control, leaving the dropdown open for three seconds without touching the title left every element in place, and repeating the assignment closed it again. This is why the issue does not reproduce on the demo by hand: nothing there mutates the title unless you do it deliberately, which is also consistent with the reporter seeing it on their own site but not in Incognito, where extensions are disabled.

After this change the dropdown closes only for a `clickOutside` payload originating from `window.parent`.

### Tests

Four payload cases and one foreign-source case are added, all of which fail on master. The existing "close by message from parent" test posted a JSON *string* rather than an object, so `parseMessage` discarded it and the dropdown closed only because any message closed it; it now posts a real payload and asserts the behaviour it was named for.

Note for reviewers: jsdom leaves `source` unset on same-window `window.postMessage`, so the tests dispatch a `MessageEvent` with `source` set explicitly. In the browser the parent posts through `iframe.contentWindow.postMessage`, which arrives with `source` set to the parent window.

### What this does not cover

#1761 reports the Bitwarden overlay closing the login window. If the extension's click reaches the host document, it produces a genuine `clickOutside` from the parent and this change will not stop it; closing that case needs a decision about whether an outside click should dismiss a form holding typed credentials, which is a behavioural change rather than a bug fix. Worth confirming with the reporter before deciding.

Resolves #2139.
