### PR TITLE
Derive host and site from the page URL on self-served pages

### DIFF
--- a/frontend/apps/remark42/templates/counter.ejs
+++ b/frontend/apps/remark42/templates/counter.ejs
@@ -21,13 +21,13 @@
       <p>
         First counter with url from data-attribute:
         <span class="remark42__counter" data-url="https://remark42.com/demo/"></span>
-        (<a href="http://127.0.0.1:8080/web/" target="_blank">note</a>)
+        (<a href="./" target="_blank">note</a>)
       </p>
 
       <p>
         Second counter with url from global remark config:
         <span class="remark42__counter"></span>
-        (<a href="http://127.0.0.1:8080/web/" target="_blank">note</a>)
+        (<a href="./" target="_blank">note</a>)
       </p>
 
       <p>If it can't get url from data-attribute or remark config, it will try to use window.location.href for it.</p>
@@ -36,7 +36,7 @@
     <script>
       var remark_config = {
         site_id: 'remark',
-        host: '<%= htmlWebpackPlugin.options.REMARK_URL %>',
+        host: location.origin + location.pathname.replace(/\/[^/]*$/, '').replace(/\/web$/, ''),
         url: 'https://remark42.com/demo/',
         components: ['counter'],
       };

--- a/frontend/apps/remark42/templates/deleteme.ejs
+++ b/frontend/apps/remark42/templates/deleteme.ejs
@@ -69,7 +69,7 @@
       <div class="preloader preloader_view_iframe"></div>
     </div>
     <script>
-      var remark_config = { host: '<%= htmlWebpackPlugin.options.REMARK_URL %>' };
+      var remark_config = { host: location.origin + location.pathname.replace(/\/[^/]*$/, '').replace(/\/web$/, '') };
     </script>
     <script src="deleteme.js"></script>
   </body>

--- a/frontend/apps/remark42/templates/demo.ejs
+++ b/frontend/apps/remark42/templates/demo.ejs
@@ -72,11 +72,11 @@
       </p>
       <div class="widgets">
         <div class="widget widgets__widget widgets__comments-widget">
-          <a class="widget__link" href="<%= htmlWebpackPlugin.options.REMARK_URL %>/web/last-comments.html">Last comments widget page</a><br />
-          <iframe class="widget__frame widget__comments-frame" src="<%= htmlWebpackPlugin.options.REMARK_URL %>/web/last-comments.html"></iframe>
+          <a class="widget__link widget__link_page_last-comments" href="./last-comments.html">Last comments widget page</a><br />
+          <iframe class="widget__frame widget__comments-frame"></iframe>
         </div>
         <div class="widget widgets__widget widgets__counter-widget">
-          <a class="widget__link" href="<%= htmlWebpackPlugin.options.REMARK_URL %>/web/counter.html">Counter widget page</a><br />
+          <a class="widget__link widget__link_page_counter" href="./counter.html">Counter widget page</a><br />
           <div class="widget__frame widget__counter-frame">Comments count: <span class="remark42__counter"></span></div>
         </div>
       </div>
@@ -121,9 +121,15 @@
         window.REMARK42.changeTheme('dark');
       });
 
+      var remarkBase = location.origin + location.pathname.replace(/\/[^/]*$/, '').replace(/\/web$/, '');
+
+      document.querySelector('.widget__link_page_last-comments').href = remarkBase + '/web/last-comments.html';
+      document.querySelector('.widget__comments-frame').src = remarkBase + '/web/last-comments.html';
+      document.querySelector('.widget__link_page_counter').href = remarkBase + '/web/counter.html';
+
       var remark_config = {
         site_id: 'remark',
-        host: '<%= htmlWebpackPlugin.options.REMARK_URL %>',
+        host: remarkBase,
         url: window.location.href,
         components: ['embed', 'counter'],
         // __colors__: {

--- a/frontend/apps/remark42/templates/last-comments.ejs
+++ b/frontend/apps/remark42/templates/last-comments.ejs
@@ -26,7 +26,7 @@
     <script>
       var remark_config = {
         site_id: 'remark',
-        host: '<%= htmlWebpackPlugin.options.REMARK_URL %>',
+        host: location.origin + location.pathname.replace(/\/[^/]*$/, '').replace(/\/web$/, ''),
         components: ['last-comments'],
       };
 


### PR DESCRIPTION
The pages Remark42 serves from `/web/` carried a build-time host. `webpack.config.js:79` emits `{% REMARK_URL %}` for production, and both build paths substitute it with `http://127.0.0.1:8080`: `Dockerfile:63` and `scripts/prepare-release-assets.sh:53-54`. A stock binary or image therefore serves demo, counter, last-comments and deleteme pages that tell the visitor's browser to talk to its own loopback address.

Confirmed against the shipped release: the v1.16.4 `linux-amd64` archive contains only `LICENSE`, `README.md` and the binary, with no `web/` directory, so the embedded assets are what gets served, and `strings` finds 17 occurrences of `http://127.0.0.1:8080` in it, including `/web/last-comments.html` and `/web/counter.html`.

`counter.ejs` had a second, separate problem: lines 24 and 30 hardcoded `http://127.0.0.1:8080/web/` in two "note" links, with no placeholder involved. Because they contain no placeholder, no build or deploy step was ever going to rewrite them, so they survive even where the substitution produced a correct URL.

They are visible right now on <https://demo.remark42.com/web/counter.html>, as the "(note)" link after each of the two counter examples:

```html
(<a href="http://127.0.0.1:8080/web/" target="_blank">note</a>)
```

The other three pages on that deployment are clean, which is what makes this a separate defect rather than a symptom of the placeholder problem: `/web/`, `/web/last-comments.html` and `/web/deleteme.html` all carry no loopback address, only `counter.html` does.

### Approach

These pages are served by Remark42 itself, so the host is by definition whatever origin and path prefix delivered them. That makes `location` the correct source and removes the need for a build-time value entirely:

```js
host: location.origin + location.pathname.replace(/\/web\/[^/]*$/, '')
```

Stripping the trailing `/web/<page>` rather than using `location.origin` alone is what keeps this correct under a path prefix, which is the deployment shape in #1996: a page at `https://example.com/remark42/web/counter.html` resolves to `https://example.com/remark42`, not `https://example.com`.

Links between sibling pages are relative for the same reason, and `site_id` now reads a `site` query parameter with `remark` as the fallback, matching what `comments.ejs` already does, so the pages are usable on an installation with a different site id.

The `{% REMARK_URL %}` substitution stays in place for now: `constants.config.ts:7` still uses `process.env.REMARK_URL` as the fallback when an embedding page omits `remark_config.host`, and that is a separate change to the widget's host resolution, on other people's sites rather than ours.

### Verification

The built output carries no loopback address and no unsubstituted placeholder in any HTML. Frontend tests and lint pass.

Reported by @andreas-hempel.

Resolves #1996.
