### PR TITLE
Remove the widget body padding and the surplus reported height

### DIFF
--- a/frontend/apps/remark42/app/styles/global.css
+++ b/frontend/apps/remark42/app/styles/global.css
@@ -2,7 +2,7 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   margin: 0;
-  padding: 6px;
+  padding: 0;
   font-family: system-ui;
   font-size: 14px;
   color: rgb(var(--primary-text-color));

--- a/frontend/apps/remark42/app/utils/post-message.spec.ts
+++ b/frontend/apps/remark42/app/utils/post-message.spec.ts
@@ -1,0 +1,54 @@
+import { updateIframeHeight } from './post-message';
+
+describe('updateIframeHeight', () => {
+  const postMessage = jest.fn();
+  let originalParent: Window;
+
+  beforeAll(() => {
+    originalParent = window.parent;
+    // postMessageToParent bails out when window.parent is window, which is the case in jsdom
+    Object.defineProperty(window, 'parent', { value: { postMessage }, writable: true, configurable: true });
+  });
+
+  afterAll(() => {
+    Object.defineProperty(window, 'parent', { value: originalParent, writable: true, configurable: true });
+  });
+
+  beforeEach(() => {
+    postMessage.mockClear();
+    jest.spyOn(document.body, 'offsetHeight', 'get').mockReturnValue(500);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should report the document height without adding to it', () => {
+    updateIframeHeight();
+
+    expect(postMessage).toHaveBeenCalledWith({ height: 500 }, '*');
+  });
+
+  it('should report the dropdown height when it exceeds the document height', () => {
+    const dropdown = document.createElement('div');
+
+    jest.spyOn(dropdown, 'getBoundingClientRect').mockReturnValue({ top: 100 } as DOMRect);
+    jest.spyOn(dropdown, 'scrollHeight', 'get').mockReturnValue(600);
+
+    updateIframeHeight(dropdown);
+
+    // 20px allowance for the shadow under the dropdown
+    expect(postMessage).toHaveBeenCalledWith({ height: 720 }, '*');
+  });
+
+  it('should report the document height when it exceeds the dropdown height', () => {
+    const dropdown = document.createElement('div');
+
+    jest.spyOn(dropdown, 'getBoundingClientRect').mockReturnValue({ top: 10 } as DOMRect);
+    jest.spyOn(dropdown, 'scrollHeight', 'get').mockReturnValue(50);
+
+    updateIframeHeight(dropdown);
+
+    expect(postMessage).toHaveBeenCalledWith({ height: 500 }, '*');
+  });
+});

--- a/frontend/apps/remark42/app/utils/post-message.ts
+++ b/frontend/apps/remark42/app/utils/post-message.ts
@@ -78,8 +78,8 @@ export function updateIframeHeight(dropdown?: HTMLElement) {
     scrollHeight = window.scrollY + Math.abs(top) + dropdown.scrollHeight + 20;
   }
 
-  // The size of vertical padding on body is 12px
-  const bodyHeight = document.body.offsetHeight + 12;
+  // offsetHeight already covers padding and border, so it is the full document height
+  const bodyHeight = document.body.offsetHeight;
 
   postMessageToParent({ height: Math.max(scrollHeight, bodyHeight) });
 }


### PR DESCRIPTION
The widget document set `padding: 6px` on the body, so every embedded widget sat 6px inside its container and could not align flush with the host layout. That is what #1487 reports, originally raised in discussion #1465: the integrator expects the widget to fill the element they gave it, and instead gets a gutter they cannot remove from outside the iframe.

There is a second defect behind the same padding. `updateIframeHeight` reported `document.body.offsetHeight + 12`, with a comment explaining that the body has 12px of vertical padding. But the body is `box-sizing: border-box`, and `offsetHeight` already includes padding, so the addition double-counted it.

### Measured on the deployed widget

Loading `iframe.html` standalone against the demo and reading the live values:

| | px |
|---|---|
| content actually needs | 20610 |
| `body.offsetHeight` with the 6px padding | 20622 |
| height reported to the parent | 20634 |

So every embed carried 24px of empty space below the content, not the 12px the comment implies, plus a 6px inset on each side: `#remark42` measured `left: 6` and 12px narrower than the viewport.

### This changes rendering for every existing embed

Worth being explicit, because it lands on everyone rather than only on people who wanted it:

- content moves 6px left and becomes 12px wider, reaching the edges of the host element
- the iframe becomes 24px shorter
- anyone relying on the gutter for visual separation needs to add padding to their own container, which is the point of the change but is still work for them
- custom CSS written against the inset may need adjusting
- the thread collapse control sits at `left: -4px` (`thread.module.css:18`), so on top-level threads it now starts outside the body box and `overflow: hidden` clips it: the clickable target narrows from 11px to 7px, and focus rings and dropdown shadows at the left edge are cut. Measured at 6px padding it sits at `left: 2`; at zero it sits at `-4`. Repositioning that control is a separate change from removing the padding, so it is not in this PR

Avatars now sit flush against the left edge, visible in the screenshots below. That reads as tight on its own, and as correct once the integrator controls the spacing. Worth a release-note line either way.

### Visual check

Verified in Chrome against the deployed widget, toggling the padding live on the same page and scroll position so the two shots differ only in this property. The red outline marks the body edge.

Before, at `padding: 6px`, and after, at `padding: 0`: the grey comment-form block and the avatars move out to the edge, and the gap between the body edge and the content closes.

before:
<img width="1280" height="577" alt="remark42-1487-before-padding-6px" src="https://github.com/user-attachments/assets/4e79ceae-b1d4-4a43-9011-bf1772f2feac" />

after:
<img width="1280" height="577" alt="remark42-1487-after-padding-0" src="https://github.com/user-attachments/assets/8794601b-cd6e-4b3e-9fbb-e3226306515a" />

### On clipping

Padding suppresses margin collapse through the body edge, so removing it could in principle let a trailing margin escape the body box and leave the last comment clipped. It does not happen here. With the padding at zero, `body.offsetHeight`, `body.scrollHeight` and `documentElement.scrollHeight` all agree at 20610, and the last child resolves to `margin-bottom: 0`.

The profile view already ran with zero body padding, set imperatively in `profile.tsx`, so that configuration was in use before this change.

### Tests

`post-message.spec.ts` is new and covers `updateIframeHeight`: the plain document height, and both directions of the `Math.max` against a dropdown, whose separate 20px shadow allowance is unchanged. Two of the three fail on master.

Resolves #1487.

