### PR TITLE
docs(claude): require an example tidy on any go.mod change

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,11 @@
   - **IMPORTANT**: Example lint: `cd backend/_example/memory_store && golangci-lint run --config ../../.golangci.yml`
   - Frontend: `cd frontend && pnpm lint`
   - **Before committing**: Always run tests and linter on both main backend AND examples
-- **Dependency Updates**:
-  - When updating Go modules in `backend/`, also run `go mod tidy` (and `go mod vendor`) in `backend/_example/memory_store` to keep indirect deps in sync. The example module replaces `github.com/umputun/remark42/backend` with `../../` so stale indirect deps there will break the example build.
+- **Go module changes**:
+  - **Any** change to `backend/go.mod` or `backend/go.sum` requires `go mod tidy` in `backend/_example/memory_store` in the same commit. That covers dependency bumps, adding or removing a dependency, and changing the `go` directive, not only version updates.
+  - Only `go mod tidy` there, not `go mod vendor`: the example's vendor directory is gitignored (`.gitignore:26`), so its output is never committed, while a stale local copy silently becomes what the example resolves against.
+  - The example module replaces `github.com/umputun/remark42/backend` with `../../`, so it carries the backend's dependencies as indirect entries. Leaving them stale fails the `test examples` CI step with `go: updates to go.mod needed; to update it: go mod tidy`.
+  - This applies to Dependabot pull requests too: the bot updates `backend/` only, so its Go module PRs need the example tidied before they can go green.
 
 ## Release Procedure
 


### PR DESCRIPTION
The existing rule was scoped to "updating Go modules in `backend/`", which reads as version bumps. Adding or removing a dependency, or changing the `go` directive, leaves the example module out of step in exactly the same way, so the wording now covers any change to `backend/go.mod` or `backend/go.sum`.

Two things are added because they are what makes the rule recognisable when it bites. The first is the failure signature: the `test examples` CI step reports `go: updates to go.mod needed; to update it: go mod tidy`, which is not obviously about the example module until you have seen it once. The second is that Dependabot Go module PRs need this too, since the bot updates `backend/` alone and its PRs cannot go green without the example being tidied by hand.

Prompted by #2152, which fails on exactly this.
