### PR TITLE
ci: track the latest Go 1.25 patch instead of pinning one

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -42,7 +42,8 @@ jobs:
       - name: install go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.12"
+          go-version: "1.25"
+          check-latest: true
           cache-dependency-path: backend
 
       - name: test and build backend
@@ -97,7 +98,8 @@ jobs:
       - name: install go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.12"
+          go-version: "1.25"
+          check-latest: true
           # both go.sum files so the cache key covers the main and example modules scanned below
           cache-dependency-path: |
             backend/go.sum

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,8 @@ jobs:
       - name: install go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.12"
+          go-version: "1.25"
+          check-latest: true
           cache-dependency-path: backend/go.sum
 
       - name: install pnpm
@@ -107,7 +108,8 @@ jobs:
       - name: install go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.12"
+          go-version: "1.25"
+          check-latest: true
           cache-dependency-path: backend/go.sum
 
       - name: install pnpm


### PR DESCRIPTION
`govulncheck` fails on master, and on every open backend PR, against the pinned `go-version: "1.25.12"`. Seven stdlib advisories are reported, all with `Fixed in: go1.25.13`:

`GO-2026-5026`, `GO-2026-5972`, `GO-2026-6088`, `GO-2026-6089`, `GO-2026-6090`, `GO-2026-6091` and `GO-2026-6218`, across `crypto/tls`, `encoding/asn1`, `encoding/xml`, `html/template`, `net/http` and `net/url`.

None of them needs a source change; they are toolchain-only reports that clear with the patch release. But pinning 1.25.13 would only move the problem to the next advisory, which is what happened with `76d0cc2c`, where 1.25.12 was pinned for `GO-2026-5856` and is now itself out of date.

`setup-go` accepts a minor-only spec, so `"1.25"` resolves to the newest patch on that line at run time and this stops recurring. Staying on `1.25` rather than `stable` keeps a move to a new minor a deliberate change, and matches the `go 1.25.0` directive in both `backend/go.mod` and the example module. All four pins are in `ci-backend.yml` and `release.yml`; nothing else in the repo fixes a Go version.

Worth noting that this is also what is red on #2155, whose own changes are unrelated to these reports.
