### PR TITLE
Carry forward coverage between the frontend workflows

### DIFF
--- a/.github/workflows/ci-frontend-api.yml
+++ b/.github/workflows/ci-frontend-api.yml
@@ -127,5 +127,6 @@ jobs:
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: api
           working-directory: ./frontend
           codecov_yml_path: ./frontend/apps/remark42/codecov.yml

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -191,5 +191,6 @@ jobs:
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: app
           working-directory: ./frontend/apps/remark42
           codecov_yml_path: ./frontend/apps/remark42/codecov.yml

--- a/frontend/apps/remark42/codecov.yml
+++ b/frontend/apps/remark42/codecov.yml
@@ -1,6 +1,19 @@
 codecov:
   require_ci_to_pass: false
 
+# the app and the api package are covered by separate workflows, each triggered by its own
+# paths filter. without carryforward a pull request touching only one of them uploads only
+# that report, and codecov reads the other's absence as a coverage drop.
+flags:
+  app:
+    paths:
+      - frontend/apps/remark42/
+    carryforward: true
+  api:
+    paths:
+      - frontend/packages/api/
+    carryforward: true
+
 ignore:
   - .editorconfig
   - .eslitnrc.js


### PR DESCRIPTION
`codecov/project` currently fails on any frontend pull request that touches the app but not `packages/api`, which is most of them. Both #2163 and #2164 are red on it right now, and neither has lost any coverage.

### What happens

Coverage is uploaded from two workflows, and each is gated by its own paths filter:

- `ci-frontend.yml` runs on `frontend/apps/remark42/**`
- `ci-frontend-api.yml` runs on `frontend/packages/**`

Neither upload sets a flag, so codecov cannot tell the two reports apart and treats whatever arrives as the complete picture. A pull request touching only the app uploads only the app's coverage, and the api package's files simply vanish from the report.

The arithmetic on #2163 matches exactly: `Files 144 → 136 (-8)`, with `Hits -148` against `Misses -2`. `frontend/packages/api` contains exactly 8 source files, and they are well covered, so removing them from the denominator drops the percentage by 1.49% while codecov's own comment says "all modified and coverable lines are covered by tests".

### The fix

Tag each upload with a flag and let codecov carry the other one forward from the base commit:

- `flags: app` on the app upload, `flags: api` on the api upload
- matching `flags` entries in `codecov.yml` with `carryforward: true` and the paths each covers

After this, a pull request that touches only the app is compared against the app's own history, with the api package's last known coverage carried forward instead of counted as deleted.

### Note

This does not change any threshold or weaken the gate. It makes the gate measure the same set of files on both sides of the comparison, which is what it was always meant to do.
