### PR TITLE
Require node 20 and record every place the version is pinned

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,38 +23,6 @@
   - The example module replaces `github.com/umputun/remark42/backend` with `../../`, so it carries the backend's dependencies as indirect entries. Leaving them stale fails the `test examples` CI step with `go: updates to go.mod needed; to update it: go mod tidy`.
   - This applies to Dependabot pull requests too: the bot updates `backend/` only, so its Go module PRs need the example tidied before they can go green.
 
-## Node and pnpm versions live in many places
-
-Changing the required Node or pnpm version means changing **every** entry below in the same commit.
-They drift otherwise: the docs sat on "Node 16+" and "PNPM 8" while CI, Docker and `.nvmrc` had all
-moved to Node 20 and pnpm 10.
-
-Version declarations:
-- `frontend/apps/remark42/package.json` - `engines.node`, `engines.pnpm`, `packageManager`
-- `site/package.json` - `engines.node`, `engines.yarn`, `packageManager` (site uses yarn, not pnpm)
-- `frontend/package.json` and `frontend/packages/api/package.json` - `packageManager` only, and they
-  are easy to miss because neither declares `engines`
-- `frontend/.nvmrc` and `site/.nvmrc`
-
-CI (every matrix entry, not just the first):
-- `.github/workflows/ci-frontend.yml` - four `node:` matrices
-- `.github/workflows/ci-frontend-api.yml` - three `node:` matrices
-- `.github/workflows/release.yml` - two `node-version:` values, plus the pnpm `version:` inputs
-
-Container images:
-- `Dockerfile` - `node:<v>-alpine` in the frontend build stage
-- `site/Dockerfile` and `site/Dockerfile.dev`
-
-Documentation:
-- `site/README.md`
-- `site/src/docs/contributing/frontend/index.md`
-- `site/src/docs/getting-started/installation/index.md` - mentioned twice
-- this file, in the Release Procedure section
-
-Note that `engines.node` describes the floor we support, while `.nvmrc`, CI and Docker pin what we
-actually build with, so they are allowed to differ in form but never in major version. Some
-transitive dev dependencies are already stricter than the declared floor: `undici` requires
-`>=20.18.1`, which any current Node 20 satisfies.
 
 ## Release Procedure
 
@@ -75,7 +43,7 @@ git push origin backend/vX.Y.Z
 
 GoReleaser must ignore `backend/*` tags in `.goreleaser.yml` so release notes and current-tag detection use only product tags. Docker image publishing stays separate and is handled by the existing Docker workflow.
 
-For local artifact runs, install GoReleaser, Go 1.25, Node 20+, PNPM 10, and Perl, then use `make release`. The target runs a snapshot/no-publish GoReleaser build, leaves local artifacts and metadata in `dist/`, and cleans generated frontend embed files after GoReleaser exits. Do not run raw `goreleaser release` for local artifacts unless you also run `./scripts/cleanup-release-assets.sh` afterward.
+For local artifact runs, install GoReleaser, Go 1.25, Node 20.18.1+, PNPM 10, and Perl, then use `make release`. The target runs a snapshot/no-publish GoReleaser build, leaves local artifacts and metadata in `dist/`, and cleans generated frontend embed files after GoReleaser exits. Do not run raw `goreleaser release` for local artifacts unless you also run `./scripts/cleanup-release-assets.sh` afterward.
 
 ## Milestones and Issue Labels
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,39 @@
   - The example module replaces `github.com/umputun/remark42/backend` with `../../`, so it carries the backend's dependencies as indirect entries. Leaving them stale fails the `test examples` CI step with `go: updates to go.mod needed; to update it: go mod tidy`.
   - This applies to Dependabot pull requests too: the bot updates `backend/` only, so its Go module PRs need the example tidied before they can go green.
 
+## Node and pnpm versions live in many places
+
+Changing the required Node or pnpm version means changing **every** entry below in the same commit.
+They drift otherwise: the docs sat on "Node 16+" and "PNPM 8" while CI, Docker and `.nvmrc` had all
+moved to Node 20 and pnpm 10.
+
+Version declarations:
+- `frontend/apps/remark42/package.json` - `engines.node`, `engines.pnpm`, `packageManager`
+- `site/package.json` - `engines.node`, `engines.yarn`, `packageManager` (site uses yarn, not pnpm)
+- `frontend/package.json` and `frontend/packages/api/package.json` - `packageManager` only, and they
+  are easy to miss because neither declares `engines`
+- `frontend/.nvmrc` and `site/.nvmrc`
+
+CI (every matrix entry, not just the first):
+- `.github/workflows/ci-frontend.yml` - four `node:` matrices
+- `.github/workflows/ci-frontend-api.yml` - three `node:` matrices
+- `.github/workflows/release.yml` - two `node-version:` values, plus the pnpm `version:` inputs
+
+Container images:
+- `Dockerfile` - `node:<v>-alpine` in the frontend build stage
+- `site/Dockerfile` and `site/Dockerfile.dev`
+
+Documentation:
+- `site/README.md`
+- `site/src/docs/contributing/frontend/index.md`
+- `site/src/docs/getting-started/installation/index.md` - mentioned twice
+- this file, in the Release Procedure section
+
+Note that `engines.node` describes the floor we support, while `.nvmrc`, CI and Docker pin what we
+actually build with, so they are allowed to differ in form but never in major version. Some
+transitive dev dependencies are already stricter than the declared floor: `undici` requires
+`>=20.18.1`, which any current Node 20 satisfies.
+
 ## Release Procedure
 
 Remark42 uses two tags for each release:
@@ -42,7 +75,7 @@ git push origin backend/vX.Y.Z
 
 GoReleaser must ignore `backend/*` tags in `.goreleaser.yml` so release notes and current-tag detection use only product tags. Docker image publishing stays separate and is handled by the existing Docker workflow.
 
-For local artifact runs, install GoReleaser, Go 1.25, Node 16+, PNPM 8, and Perl, then use `make release`. The target runs a snapshot/no-publish GoReleaser build, leaves local artifacts and metadata in `dist/`, and cleans generated frontend embed files after GoReleaser exits. Do not run raw `goreleaser release` for local artifacts unless you also run `./scripts/cleanup-release-assets.sh` afterward.
+For local artifact runs, install GoReleaser, Go 1.25, Node 20+, PNPM 10, and Perl, then use `make release`. The target runs a snapshot/no-publish GoReleaser build, leaves local artifacts and metadata in `dist/`, and cleans generated frontend embed files after GoReleaser exits. Do not run raw `goreleaser release` for local artifacts unless you also run `./scripts/cleanup-release-assets.sh` afterward.
 
 ## Milestones and Issue Labels
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ git push origin backend/vX.Y.Z
 
 GoReleaser must ignore `backend/*` tags in `.goreleaser.yml` so release notes and current-tag detection use only product tags. Docker image publishing stays separate and is handled by the existing Docker workflow.
 
-For local artifact runs, install GoReleaser, Go 1.25, Node 20.18.1+, PNPM 10, and Perl, then use `make release`. The target runs a snapshot/no-publish GoReleaser build, leaves local artifacts and metadata in `dist/`, and cleans generated frontend embed files after GoReleaser exits. Do not run raw `goreleaser release` for local artifacts unless you also run `./scripts/cleanup-release-assets.sh` afterward.
+For local artifact runs, install GoReleaser, Go 1.25, Node 20+, PNPM 10, and Perl, then use `make release`. The target runs a snapshot/no-publish GoReleaser build, leaves local artifacts and metadata in `dist/`, and cleans generated frontend embed files after GoReleaser exits. Do not run raw `goreleaser release` for local artifacts unless you also run `./scripts/cleanup-release-assets.sh` afterward.
 
 ## Milestones and Issue Labels
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -18,7 +18,7 @@ CI staying green does **not** mean every pin is consistent — `.nvmrc` in parti
 
 When bumping pnpm/node, also re-check `frontend/apps/remark42/package.json`'s `engines` field — it's separate from `packageManager` and won't update itself.
 
-`engines.node` must not sit below the strictest dependency requirement: `undici` needs `>=20.18.1`, so a bare `>=20` would advertise support for 20.0 through 20.18.0, which fail dependency engine checks. The docs must state the same floor.
+`engines.node` states the major we support, currently `>=20`, and the docs say the same. Individual dev dependencies can be stricter within that major (`undici` wants `>=20.18.1`), which any current Node 20 satisfies; do not chase those patch floors into `engines` or the docs, or every lockfile refresh becomes a documentation change.
 
 ## pnpm 10's stricter `node-linker` layout needs explicit pins
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -12,9 +12,13 @@ CI staying green does **not** mean every pin is consistent — `.nvmrc` in parti
 - `frontend/.nvmrc`, `site/.nvmrc` — not read by CI at all; only matters to a human running `nvm use` locally. This is the one that drifted unnoticed: it sat at `16` through the whole node-20 migration because nothing red ever pointed at it.
 - Every `package.json`'s `packageManager` field (`frontend/package.json`, `frontend/apps/remark42/package.json` — `frontend/e2e/package.json` has none) and `frontend/apps/remark42/package.json`'s `engines` block
 - `pnpm/action-setup@vN` blocks in `.github/workflows/ci-frontend.yml` (5) and `release.yml` (2) — pin `version:` to the **exact** patch (e.g. `10.10.0`), matching `packageManager`, not just the major. A floating major here is silent in CI (it just resolves to whatever the latest patch is at run time) but breaks the "Dockerfile and CI use the same pnpm" guarantee.
+- `node:` matrices in `.github/workflows/ci-frontend.yml` (every entry, not just the first) and the `node-version:` values in `release.yml`
+- `site/package.json`'s `engines.node` and `engines.yarn` (site uses yarn, so its `packageManager` moves independently)
 - `frontend/e2e/package.json`'s `@playwright/test`/`playwright` versions must match `frontend/Dockerfile.e2e`'s base image tag exactly, or the e2e container's bundled browser revision mismatches what the npm package expects.
 
 When bumping pnpm/node, also re-check `frontend/apps/remark42/package.json`'s `engines` field — it's separate from `packageManager` and won't update itself.
+
+`engines.node` must not sit below the strictest dependency requirement: `undici` needs `>=20.18.1`, so a bare `>=20` would advertise support for 20.0 through 20.18.0, which fail dependency engine checks. The docs must state the same floor.
 
 ## pnpm 10's stricter `node-linker` layout needs explicit pins
 

--- a/frontend/apps/remark42/package.json
+++ b/frontend/apps/remark42/package.json
@@ -22,7 +22,7 @@
     "translation:check": "node ./tasks/checkTranslation.js"
   },
   "engines": {
-    "node": ">=20",
+    "node": ">=20.18.1",
     "pnpm": ">=10"
   },
   "packageManager": "pnpm@10.10.0",

--- a/frontend/apps/remark42/package.json
+++ b/frontend/apps/remark42/package.json
@@ -22,7 +22,7 @@
     "translation:check": "node ./tasks/checkTranslation.js"
   },
   "engines": {
-    "node": ">=18",
+    "node": ">=20",
     "pnpm": ">=10"
   },
   "packageManager": "pnpm@10.10.0",

--- a/frontend/apps/remark42/package.json
+++ b/frontend/apps/remark42/package.json
@@ -22,7 +22,7 @@
     "translation:check": "node ./tasks/checkTranslation.js"
   },
   "engines": {
-    "node": ">=20.18.1",
+    "node": ">=20",
     "pnpm": ">=10"
   },
   "packageManager": "pnpm@10.10.0",

--- a/site/src/docs/contributing/frontend/index.md
+++ b/site/src/docs/contributing/frontend/index.md
@@ -20,7 +20,7 @@ While developing, we set up environment which imitates real world example. We se
 
 You must have at least 2GB RAM or swap enabled for building.
 
-- install [Node.js 20.18.1](https://nodejs.org/en/) or higher (we recommend using [NVM](https://github.com/nvm-sh/nvm) for node version autoswitch)
+- install [Node.js 20](https://nodejs.org/en/) or higher (we recommend using [NVM](https://github.com/nvm-sh/nvm) for node version autoswitch)
 - install [PNPM 10](https://pnpm.io/installation)
 - run `pnpm i` inside `./frontend`
 

--- a/site/src/docs/contributing/frontend/index.md
+++ b/site/src/docs/contributing/frontend/index.md
@@ -20,8 +20,8 @@ While developing, we set up environment which imitates real world example. We se
 
 You must have at least 2GB RAM or swap enabled for building.
 
-- install [Node.js 16](https://nodejs.org/en/) or higher (we recommend using [NVM](https://github.com/nvm-sh/nvm) for node version autoswitch)
-- install [PNPM 8](https://pnpm.io/installation)
+- install [Node.js 20](https://nodejs.org/en/) or higher (we recommend using [NVM](https://github.com/nvm-sh/nvm) for node version autoswitch)
+- install [PNPM 10](https://pnpm.io/installation)
 - run `pnpm i` inside `./frontend`
 
 Running `pnpm i` will set up pre-commit hooks into your git repository. They are used to reformat your frontend code using `prettier` and lint with `eslint` and `stylelint` before every commit.

--- a/site/src/docs/contributing/frontend/index.md
+++ b/site/src/docs/contributing/frontend/index.md
@@ -20,7 +20,7 @@ While developing, we set up environment which imitates real world example. We se
 
 You must have at least 2GB RAM or swap enabled for building.
 
-- install [Node.js 20](https://nodejs.org/en/) or higher (we recommend using [NVM](https://github.com/nvm-sh/nvm) for node version autoswitch)
+- install [Node.js 20.18.1](https://nodejs.org/en/) or higher (we recommend using [NVM](https://github.com/nvm-sh/nvm) for node version autoswitch)
 - install [PNPM 10](https://pnpm.io/installation)
 - run `pnpm i` inside `./frontend`
 

--- a/site/src/docs/getting-started/installation/index.md
+++ b/site/src/docs/getting-started/installation/index.md
@@ -29,7 +29,7 @@ _This is the recommended way to run Remark42_
 - download [archive for the stable release](https://github.com/umputun/remark42/releases)
 - unpack with `gunzip` (Linux, macOS) or with `zip` (Windows)
 - run as `remark42.{os}-{arch} server {parameters...}`, i.e., `remark42.linux-amd64 server --secret=12345 --url=http://127.0.0.1:8080`
-- alternatively compile from the sources - `make OS=[linux|darwin|windows] ARCH=[amd64,386,arm64,arm]`. Source binary builds require Go 1.25, Node 20.18.1+, PNPM 10, and Perl because the frontend assets are built and embedded locally.
+- alternatively compile from the sources - `make OS=[linux|darwin|windows] ARCH=[amd64,386,arm64,arm]`. Source binary builds require Go 1.25, Node 20+, PNPM 10, and Perl because the frontend assets are built and embedded locally.
 
 #### Installation as a systemd Service
 
@@ -129,4 +129,4 @@ To verify if Remark42 has been properly installed, check a demo page at `${REMAR
 ### Build from the source
 
 - to build Docker container - `make docker`. This command will produce container `ghcr.io/umputun/remark42`
-- to build a single binary for direct execution - `make OS=<linux|windows|darwin> ARCH=<amd64|386>`. This requires Go 1.25, Node 20.18.1+, PNPM 10, and Perl, builds frontend assets locally, and produces an executable `remark42` file with everything embedded
+- to build a single binary for direct execution - `make OS=<linux|windows|darwin> ARCH=<amd64|386>`. This requires Go 1.25, Node 20+, PNPM 10, and Perl, builds frontend assets locally, and produces an executable `remark42` file with everything embedded

--- a/site/src/docs/getting-started/installation/index.md
+++ b/site/src/docs/getting-started/installation/index.md
@@ -29,7 +29,7 @@ _This is the recommended way to run Remark42_
 - download [archive for the stable release](https://github.com/umputun/remark42/releases)
 - unpack with `gunzip` (Linux, macOS) or with `zip` (Windows)
 - run as `remark42.{os}-{arch} server {parameters...}`, i.e., `remark42.linux-amd64 server --secret=12345 --url=http://127.0.0.1:8080`
-- alternatively compile from the sources - `make OS=[linux|darwin|windows] ARCH=[amd64,386,arm64,arm]`. Source binary builds require Go 1.25, Node 20+, PNPM 10, and Perl because the frontend assets are built and embedded locally.
+- alternatively compile from the sources - `make OS=[linux|darwin|windows] ARCH=[amd64,386,arm64,arm]`. Source binary builds require Go 1.25, Node 20.18.1+, PNPM 10, and Perl because the frontend assets are built and embedded locally.
 
 #### Installation as a systemd Service
 
@@ -129,4 +129,4 @@ To verify if Remark42 has been properly installed, check a demo page at `${REMAR
 ### Build from the source
 
 - to build Docker container - `make docker`. This command will produce container `ghcr.io/umputun/remark42`
-- to build a single binary for direct execution - `make OS=<linux|windows|darwin> ARCH=<amd64|386>`. This requires Go 1.25, Node 20+, PNPM 10, and Perl, builds frontend assets locally, and produces an executable `remark42` file with everything embedded
+- to build a single binary for direct execution - `make OS=<linux|windows|darwin> ARCH=<amd64|386>`. This requires Go 1.25, Node 20.18.1+, PNPM 10, and Perl, builds frontend assets locally, and produces an executable `remark42` file with everything embedded

--- a/site/src/docs/getting-started/installation/index.md
+++ b/site/src/docs/getting-started/installation/index.md
@@ -29,7 +29,7 @@ _This is the recommended way to run Remark42_
 - download [archive for the stable release](https://github.com/umputun/remark42/releases)
 - unpack with `gunzip` (Linux, macOS) or with `zip` (Windows)
 - run as `remark42.{os}-{arch} server {parameters...}`, i.e., `remark42.linux-amd64 server --secret=12345 --url=http://127.0.0.1:8080`
-- alternatively compile from the sources - `make OS=[linux|darwin|windows] ARCH=[amd64,386,arm64,arm]`. Source binary builds require Go 1.25, Node 16+, PNPM 8, and Perl because the frontend assets are built and embedded locally.
+- alternatively compile from the sources - `make OS=[linux|darwin|windows] ARCH=[amd64,386,arm64,arm]`. Source binary builds require Go 1.25, Node 20+, PNPM 10, and Perl because the frontend assets are built and embedded locally.
 
 #### Installation as a systemd Service
 
@@ -129,4 +129,4 @@ To verify if Remark42 has been properly installed, check a demo page at `${REMAR
 ### Build from the source
 
 - to build Docker container - `make docker`. This command will produce container `ghcr.io/umputun/remark42`
-- to build a single binary for direct execution - `make OS=<linux|windows|darwin> ARCH=<amd64|386>`. This requires Go 1.25, Node 16+, PNPM 8, and Perl, builds frontend assets locally, and produces an executable `remark42` file with everything embedded
+- to build a single binary for direct execution - `make OS=<linux|windows|darwin> ARCH=<amd64|386>`. This requires Go 1.25, Node 20+, PNPM 10, and Perl, builds frontend assets locally, and produces an executable `remark42` file with everything embedded


### PR DESCRIPTION
`frontend/apps/remark42/package.json` declared `engines.node: ">=18"` while everything that actually runs has been on 20 since the pnpm 8 to 10 migration. Raised to `>=20`.

Deliberately a plain major rather than a patch floor. Some dev dependencies are stricter within Node 20 (`undici` wants `>=20.18.1`, `brace-expansion` `20 || >=22`), and any current Node 20 satisfies them. Following those patch floors into `engines` and four documentation files would turn every lockfile refresh into a documentation change; `frontend/CLAUDE.md` records that reasoning so it does not get re-litigated.

### The documentation had drifted much further

Four references were stale, all of them what a new contributor reads first:

- `site/src/docs/contributing/frontend/index.md` told people to install Node.js 16 and PNPM 8
- `site/src/docs/getting-started/installation/index.md` said "Go 1.25, Node 16+, PNPM 8, and Perl", twice
- `CLAUDE.md` repeated the same line for local release builds

All now say Node 20 and PNPM 10, matching `.nvmrc`, the CI matrices and the container images.

### Why the version keeps drifting

It is pinned across five categories with nothing linking them: `engines` and `packageManager` fields in several manifests, both `.nvmrc` files, the `node:` matrices and `pnpm/action-setup` blocks in `ci-frontend.yml` and `release.yml`, four container images including `frontend/Dockerfile.e2e`, and the documentation above.

`frontend/CLAUDE.md` already carried a checklist for this, so the entries it was missing are folded into it rather than starting a second list. An earlier revision of this branch did start one in the root `CLAUDE.md`; that duplicate is removed, because two lists of the same thing drift apart. The additions are the `node:` CI matrices, `site/package.json`'s `engines`, and the rule about keeping the floor at the major.

Two traps are called out there: `frontend/package.json` carries `packageManager` but no `engines`, so grepping for `engines` misses it, and `site` uses yarn rather than pnpm so its `packageManager` moves independently.

### Verified

Manifests parse and the site builds clean (`yarn build`, 35 pages), which matters here because `ci-site.yml` gates its only build job to master and tags, so site changes get no pull request validation.

Raised by Copilot on #2163. Kept separate from that PR because it grew past the one-line `engines` change.
