### PR TITLE
Replace react-redux with a preact context binding

### DIFF
--- a/frontend/apps/remark42/app/components/auth-panel/auth-panel.test.tsx
+++ b/frontend/apps/remark42/app/components/auth-panel/auth-panel.test.tsx
@@ -1,7 +1,7 @@
 import { mount } from 'enzyme';
 import createMockStore from 'redux-mock-store';
 import { Middleware } from 'redux';
-import { Provider } from 'react-redux';
+import { Provider } from 'store/context';
 import { IntlProvider } from 'react-intl';
 
 import type { User } from 'common/types';

--- a/frontend/apps/remark42/app/components/auth/auth.tsx
+++ b/frontend/apps/remark42/app/components/auth/auth.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx';
 import { h, Fragment, JSX } from 'preact';
 import { useState, useRef } from 'preact/hooks';
 import { useIntl } from 'react-intl';
-import { useDispatch } from 'react-redux';
+import { useDispatch } from 'store/context';
 
 import { setUser } from 'store/user/actions';
 import { Input } from 'components/input';

--- a/frontend/apps/remark42/app/components/comment-form/__subscribe-by-email/comment-form__subscribe-by-email.test.tsx
+++ b/frontend/apps/remark42/app/components/comment-form/__subscribe-by-email/comment-form__subscribe-by-email.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from 'enzyme';
 import { act } from 'preact/test-utils';
-import { Provider } from 'react-redux';
+import { Provider } from 'store/context';
 import { Middleware } from 'redux';
 import createMockStore from 'redux-mock-store';
 import { IntlProvider } from 'react-intl';

--- a/frontend/apps/remark42/app/components/comment-form/__subscribe-by-email/comment-form__subscribe-by-email.tsx
+++ b/frontend/apps/remark42/app/components/comment-form/__subscribe-by-email/comment-form__subscribe-by-email.tsx
@@ -1,6 +1,6 @@
 import { h, FunctionComponent, Fragment } from 'preact';
 import { useState, useCallback, useRef } from 'preact/hooks';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector, useDispatch } from 'store/context';
 import clsx from 'clsx';
 import { useIntl, defineMessages, IntlShape, FormattedMessage } from 'react-intl';
 

--- a/frontend/apps/remark42/app/components/comment-form/__subscribe-by-rss/comment-form__subscribe-by-rss.test.tsx
+++ b/frontend/apps/remark42/app/components/comment-form/__subscribe-by-rss/comment-form__subscribe-by-rss.test.tsx
@@ -4,7 +4,7 @@ import { SubscribeByRSS, createSubscribeUrl } from '.';
 
 import styles from './subscribe-by-rss.module.css';
 
-jest.mock('react-redux', () => ({
+jest.mock('store/context', () => ({
   useSelector: jest.fn((fn) => fn({ theme: 'light' })),
 }));
 

--- a/frontend/apps/remark42/app/components/comment-form/__subscribe-by-telegram/comment-form__subscribe-by-telegram.tsx
+++ b/frontend/apps/remark42/app/components/comment-form/__subscribe-by-telegram/comment-form__subscribe-by-telegram.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import { h, FunctionComponent, Fragment } from 'preact';
 import { useState, useEffect } from 'preact/hooks';
-import { useSelector } from 'react-redux';
+import { useSelector } from 'store/context';
 import { useIntl, defineMessages } from 'react-intl';
 
 import { User } from 'common/types';

--- a/frontend/apps/remark42/app/components/comment/comment-votes.tsx
+++ b/frontend/apps/remark42/app/components/comment/comment-votes.tsx
@@ -3,7 +3,7 @@ import { h } from 'preact';
 import { useState } from 'preact/hooks';
 import { defineMessages, useIntl } from 'react-intl';
 
-import { useDispatch } from 'react-redux';
+import { useDispatch } from 'store/context';
 import { patchComment } from 'store/comments/actions';
 import { putCommentVote } from 'common/api';
 import { StaticStore } from 'common/static-store';

--- a/frontend/apps/remark42/app/components/root/root.tsx
+++ b/frontend/apps/remark42/app/components/root/root.tsx
@@ -1,5 +1,5 @@
 import { h, Component, Fragment } from 'preact';
-import { useSelector } from 'react-redux';
+import { useSelector } from 'store/context';
 import { IntlShape, useIntl, FormattedMessage, defineMessages } from 'react-intl';
 import clsx from 'clsx';
 

--- a/frontend/apps/remark42/app/components/thread/thread.tsx
+++ b/frontend/apps/remark42/app/components/thread/thread.tsx
@@ -1,5 +1,5 @@
 import { h, FunctionComponent, type AriaRole } from 'preact';
-import { shallowEqual } from 'react-redux';
+import { shallowEqual } from 'store/context';
 import { useCallback } from 'preact/hooks';
 import clsx from 'clsx';
 import { useIntl } from 'react-intl';

--- a/frontend/apps/remark42/app/hooks/useAction.ts
+++ b/frontend/apps/remark42/app/hooks/useAction.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useMemo } from 'preact/compat';
-import { useDispatch } from 'react-redux';
+import { useDispatch } from 'store/context';
 import { BoundActionCreator, BoundActionCreators } from 'utils/actionBinder';
 
 /** binds actions to dispatch */

--- a/frontend/apps/remark42/app/hooks/useTheme.ts
+++ b/frontend/apps/remark42/app/hooks/useTheme.ts
@@ -1,4 +1,4 @@
-import { useSelector } from 'react-redux';
+import { useSelector } from 'store/context';
 
 import { StoreState } from 'store';
 import { Theme } from 'common/types';

--- a/frontend/apps/remark42/app/remark.tsx
+++ b/frontend/apps/remark42/app/remark.tsx
@@ -1,6 +1,6 @@
 import { h, render } from 'preact';
 import { bindActionCreators } from 'redux';
-import { Provider } from 'react-redux';
+import { Provider } from 'store/context';
 import { IntlProvider } from 'react-intl';
 
 import { loadLocale } from 'utils/loadLocale';

--- a/frontend/apps/remark42/app/store/context.test.tsx
+++ b/frontend/apps/remark42/app/store/context.test.tsx
@@ -1,0 +1,67 @@
+import { h } from 'preact';
+import { render, screen, act } from '@testing-library/preact';
+import { createStore } from 'redux';
+
+import { Provider, useSelector } from './context';
+
+type State = { value: number };
+
+function reducer(state: State = { value: 0 }, action: { type: string }): State {
+  return action.type === 'bump' ? { value: state.value + 1 } : state;
+}
+
+function Display() {
+  const value = useSelector((s: State) => s.value);
+  return <span data-testid="value">{value}</span>;
+}
+
+describe('useSelector', () => {
+  it('renders the value at mount', () => {
+    const store = createStore(reducer);
+    render(
+      <Provider store={store}>
+        <Display />
+      </Provider>
+    );
+    expect(screen.getByTestId('value').textContent).toBe('0');
+  });
+
+  it('re-renders on a store change', () => {
+    const store = createStore(reducer);
+    render(
+      <Provider store={store}>
+        <Display />
+      </Provider>
+    );
+    act(() => {
+      store.dispatch({ type: 'bump' });
+    });
+    expect(screen.getByTestId('value').textContent).toBe('1');
+  });
+
+  it('does not miss a dispatch that lands between render and subscribe', () => {
+    const store = createStore(reducer);
+
+    // dispatch from inside the component body, which runs during render and so
+    // before the subscribing effect. this is the window a real async resolution
+    // can land in, and a subscription created afterwards never hears about it.
+    let dispatched = false;
+    function Racing() {
+      const value = useSelector((s: State) => s.value);
+      if (!dispatched) {
+        dispatched = true;
+        store.dispatch({ type: 'bump' });
+      }
+      return <span data-testid="value">{value}</span>;
+    }
+
+    render(
+      <Provider store={store}>
+        <Racing />
+      </Provider>
+    );
+
+    expect(store.getState().value).toBe(1);
+    expect(screen.getByTestId('value').textContent).toBe('1');
+  });
+});

--- a/frontend/apps/remark42/app/store/context.test.tsx
+++ b/frontend/apps/remark42/app/store/context.test.tsx
@@ -39,6 +39,30 @@ describe('useSelector', () => {
     expect(screen.getByTestId('value').textContent).toBe('1');
   });
 
+  // the subscribe-time check must not re-run a selector that builds a fresh object,
+  // or every connected component renders twice at mount
+  it('renders once at mount with an object-building selector', () => {
+    const store = createStore(reducer);
+    let renders = 0;
+
+    function Counting() {
+      const { value } = useSelector((s: State) => ({ value: s.value }));
+
+      renders += 1;
+
+      return <span data-testid="value">{value}</span>;
+    }
+
+    render(
+      <Provider store={store}>
+        <Counting />
+      </Provider>
+    );
+
+    expect(renders).toBe(1);
+    expect(screen.getByTestId('value').textContent).toBe('0');
+  });
+
   it('does not miss a dispatch that lands between render and subscribe', () => {
     const store = createStore(reducer);
 

--- a/frontend/apps/remark42/app/store/context.tsx
+++ b/frontend/apps/remark42/app/store/context.tsx
@@ -1,5 +1,5 @@
 import { createContext, h, type ComponentChildren } from 'preact';
-import { useContext, useEffect, useRef, useState } from 'preact/hooks';
+import { useContext, useLayoutEffect, useRef, useState } from 'preact/hooks';
 import type { Store, Dispatch, Action } from 'redux';
 
 /**
@@ -48,21 +48,27 @@ export function useSelector<S, R>(selector: (state: S) => R, equalityFn?: (a: R,
   equalityRef.current = equalityFn;
   selectedRef.current = selected;
 
-  useEffect(
-    () =>
-      store.subscribe(() => {
-        const next = selectorRef.current(store.getState());
-        const equal = equalityRef.current
-          ? equalityRef.current(selectedRef.current, next)
-          : Object.is(selectedRef.current, next);
+  useLayoutEffect(() => {
+    const checkForUpdates = () => {
+      const next = selectorRef.current(store.getState());
+      const equal = equalityRef.current
+        ? equalityRef.current(selectedRef.current, next)
+        : Object.is(selectedRef.current, next);
 
-        if (!equal) {
-          selectedRef.current = next;
-          setTick((n) => n + 1);
-        }
-      }),
-    [store]
-  );
+      if (!equal) {
+        selectedRef.current = next;
+        setTick((n) => n + 1);
+      }
+    };
+
+    const unsubscribe = store.subscribe(checkForUpdates);
+    // a dispatch landing between this render and the subscription above is not
+    // delivered, since the listener did not exist yet. check once on subscribe so
+    // that update cannot be lost until some later, unrelated dispatch
+    checkForUpdates();
+
+    return unsubscribe;
+  }, [store]);
 
   return selected;
 }

--- a/frontend/apps/remark42/app/store/context.tsx
+++ b/frontend/apps/remark42/app/store/context.tsx
@@ -37,16 +37,19 @@ export function useSelector<S, R>(selector: (state: S) => R, equalityFn?: (a: R,
   const store = useStore<S, Action>();
   const [, setTick] = useState(0);
 
-  const selected = selector(store.getState());
+  const state = store.getState();
+  const selected = selector(state);
 
   // refs keep the subscription stable while always comparing against the latest
   // render's selector and value, so a changed selector cannot resurrect a stale result
   const selectorRef = useRef(selector);
   const equalityRef = useRef(equalityFn);
   const selectedRef = useRef(selected);
+  const stateRef = useRef(state);
   selectorRef.current = selector;
   equalityRef.current = equalityFn;
   selectedRef.current = selected;
+  stateRef.current = state;
 
   useLayoutEffect(() => {
     const checkForUpdates = () => {
@@ -62,10 +65,19 @@ export function useSelector<S, R>(selector: (state: S) => R, equalityFn?: (a: R,
     };
 
     const unsubscribe = store.subscribe(checkForUpdates);
+
     // a dispatch landing between this render and the subscription above is not
     // delivered, since the listener did not exist yet. check once on subscribe so
-    // that update cannot be lost until some later, unrelated dispatch
-    checkForUpdates();
+    // that update cannot be lost until some later, unrelated dispatch.
+    //
+    // only when the state actually moved, though: reducers return a new root
+    // object on every change, so an unchanged reference means nothing was missed.
+    // checking unconditionally would re-run the selector, and one building a fresh
+    // object fails Object.is against the render's value and forces a second render
+    // of every connected component at mount
+    if (store.getState() !== stateRef.current) {
+      checkForUpdates();
+    }
 
     return unsubscribe;
   }, [store]);

--- a/frontend/apps/remark42/app/store/context.tsx
+++ b/frontend/apps/remark42/app/store/context.tsx
@@ -1,0 +1,91 @@
+import { createContext, h, type ComponentChildren } from 'preact';
+import { useContext, useEffect, useRef, useState } from 'preact/hooks';
+import type { Store, Dispatch, Action } from 'redux';
+
+/**
+ * Minimal store binding over preact context, replacing react-redux.
+ *
+ * Only what the widget uses: a provider, dispatch, and a selector with an optional
+ * equality function.
+ */
+
+const StoreContext = createContext<Store | null>(null);
+
+export function Provider<S, A extends Action>({
+  store,
+  children,
+}: {
+  store: Store<S, A>;
+  children?: ComponentChildren;
+}) {
+  return <StoreContext.Provider value={store as unknown as Store}>{children}</StoreContext.Provider>;
+}
+
+function useStore<S, A extends Action>(): Store<S, A> {
+  const store = useContext(StoreContext);
+  if (!store) {
+    throw new Error('store accessed outside of a Provider');
+  }
+  return store as unknown as Store<S, A>;
+}
+
+export function useDispatch<D extends Dispatch = Dispatch>(): D {
+  return useStore().dispatch as D;
+}
+
+export function useSelector<S, R>(selector: (state: S) => R, equalityFn?: (a: R, b: R) => boolean): R {
+  const store = useStore<S, Action>();
+  const [, setTick] = useState(0);
+
+  const selected = selector(store.getState());
+
+  // refs keep the subscription stable while always comparing against the latest
+  // render's selector and value, so a changed selector cannot resurrect a stale result
+  const selectorRef = useRef(selector);
+  const equalityRef = useRef(equalityFn);
+  const selectedRef = useRef(selected);
+  selectorRef.current = selector;
+  equalityRef.current = equalityFn;
+  selectedRef.current = selected;
+
+  useEffect(
+    () =>
+      store.subscribe(() => {
+        const next = selectorRef.current(store.getState());
+        const equal = equalityRef.current
+          ? equalityRef.current(selectedRef.current, next)
+          : Object.is(selectedRef.current, next);
+
+        if (!equal) {
+          selectedRef.current = next;
+          setTick((n) => n + 1);
+        }
+      }),
+    [store]
+  );
+
+  return selected;
+}
+
+export function shallowEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) {
+    return true;
+  }
+  if (typeof a !== 'object' || a === null || typeof b !== 'object' || b === null) {
+    return false;
+  }
+
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+
+  return (
+    aKeys.length === bKeys.length &&
+    aKeys.every(
+      (key) =>
+        Object.prototype.hasOwnProperty.call(b, key) &&
+        Object.is((a as Record<string, unknown>)[key], (b as Record<string, unknown>)[key])
+    )
+  );
+}
+
+export type TypedUseSelectorHook<S> = <R>(selector: (state: S) => R, equalityFn?: (a: R, b: R) => boolean) => R;

--- a/frontend/apps/remark42/app/store/index.ts
+++ b/frontend/apps/remark42/app/store/index.ts
@@ -1,5 +1,5 @@
 import { createStore, applyMiddleware, AnyAction, compose, combineReducers } from 'redux';
-import { useDispatch, useSelector, TypedUseSelectorHook } from 'react-redux';
+import { useDispatch, useSelector, type TypedUseSelectorHook } from './context';
 import thunk, { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { rootProvider } from './reducers';
 import { ACTIONS } from './actions';

--- a/frontend/apps/remark42/app/tests/utils.tsx
+++ b/frontend/apps/remark42/app/tests/utils.tsx
@@ -1,7 +1,7 @@
 import { h, ComponentChild } from 'preact';
 import { IntlProvider } from 'react-intl';
 import { render as originalRender } from '@testing-library/preact';
-import { Provider } from 'react-redux';
+import { Provider } from 'store/context';
 
 import en from 'locales/en.json';
 import { mockStore } from '__stubs__/store';

--- a/frontend/apps/remark42/package.json
+++ b/frontend/apps/remark42/package.json
@@ -65,7 +65,6 @@
     "@types/lodash-es": "^4.17.12",
     "@types/node": "^18.0.1",
     "@types/node-emoji": "^1.8.1",
-    "@types/react-redux": "^7.1.34",
     "@types/redux-mock-store": "^1.5.0",
     "@types/testing-library__jest-dom": "^5.14.5",
     "@types/webpack-env": "^1.18.8",

--- a/frontend/apps/remark42/package.json
+++ b/frontend/apps/remark42/package.json
@@ -39,7 +39,6 @@
     "react": "npm:@preact/compat@^18.3.2",
     "react-dom": "npm:@preact/compat@^18.3.2",
     "react-intl": "6.0.5",
-    "react-redux": "^8.0.2",
     "redux": "^4.2.0",
     "redux-thunk": "^2.4.1"
   },

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -122,9 +122,6 @@ importers:
       react-intl:
         specifier: 6.0.5
         version: 6.0.5(@preact/compat@18.3.2(preact@10.29.8))(typescript@5.9.3)
-      react-redux:
-        specifier: ^8.0.2
-        version: 8.1.3(@preact/compat@18.3.2(preact@10.29.8))(@preact/compat@18.3.2(preact@10.29.8))(@types/react@18.3.31)(redux@4.2.1)
       redux:
         specifier: ^4.2.0
         version: 4.2.1
@@ -198,9 +195,6 @@ importers:
       '@types/node-emoji':
         specifier: ^1.8.1
         version: 1.8.2
-      '@types/react-redux':
-        specifier: ^7.1.34
-        version: 7.1.34
       '@types/redux-mock-store':
         specifier: ^1.5.0
         version: 1.5.0
@@ -1926,17 +1920,11 @@ packages:
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
 
-  '@types/react-redux@7.1.34':
-    resolution: {integrity: sha512-GdFaVjEbYv4Fthm2ZLvj1VSCedV7TqE5y1kNwnjSdBOTXuRSgowux6J8TAct15T3CKBr63UMk+2CO7ilRhyrAQ==}
-
   '@types/react@16.14.70':
     resolution: {integrity: sha512-DM5Q7rSx9G6QYcVvMgxvEurL5P06OxcDNUXrLxlpBzG4ccUewcBCmsztYbxJBobzO8RIwwmjoaD5OsKqdHDuYQ==}
 
   '@types/react@18.3.31':
     resolution: {integrity: sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==}
-
-  '@types/react@19.2.17':
-    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
   '@types/redux-mock-store@1.5.0':
     resolution: {integrity: sha512-jcscBazm6j05Hs6xYCca6psTUBbFT2wqMxT7wZEHAYFxHB/I8jYk7d5msrHUlDiSL02HdTqTmkK2oIV8i3C8DA==}
@@ -1976,9 +1964,6 @@ packages:
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
-
-  '@types/use-sync-external-store@0.0.3':
-    resolution: {integrity: sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==}
 
   '@types/webpack-env@1.18.8':
     resolution: {integrity: sha512-G9eAoJRMLjcvN4I08wB5I7YofOb/kaJNd5uoCMX+LbKXTPCF+ZIHuqTnFaK9Jz1rgs035f9JUPUhNFtqgucy/A==}
@@ -5589,27 +5574,6 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
-  react-redux@8.1.3:
-    resolution: {integrity: sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==}
-    peerDependencies:
-      '@types/react': ^16.8 || ^17.0 || ^18.0
-      '@types/react-dom': ^16.8 || ^17.0 || ^18.0
-      react: ^16.8 || ^17.0 || ^18.0
-      react-dom: ^16.8 || ^17.0 || ^18.0
-      react-native: '>=0.59'
-      redux: ^4 || ^5.0.0-beta.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-      react-dom:
-        optional: true
-      react-native:
-        optional: true
-      redux:
-        optional: true
-
   read-pkg-up@7.0.1:
     resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
     engines: {node: '>=8'}
@@ -6384,11 +6348,6 @@ packages:
     peerDependenciesMeta:
       file-loader:
         optional: true
-
-  use-sync-external-store@1.6.0:
-    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -8483,11 +8442,6 @@ snapshots:
       '@types/react': 18.3.31
       hoist-non-react-statics: 3.3.2
 
-  '@types/hoist-non-react-statics@3.3.7(@types/react@19.2.17)':
-    dependencies:
-      '@types/react': 19.2.17
-      hoist-non-react-statics: 3.3.2
-
   '@types/html-minifier-terser@6.1.0': {}
 
   '@types/http-errors@2.0.5': {}
@@ -8553,13 +8507,6 @@ snapshots:
 
   '@types/range-parser@1.2.7': {}
 
-  '@types/react-redux@7.1.34':
-    dependencies:
-      '@types/hoist-non-react-statics': 3.3.7(@types/react@19.2.17)
-      '@types/react': 19.2.17
-      hoist-non-react-statics: 3.3.2
-      redux: 4.2.1
-
   '@types/react@16.14.70':
     dependencies:
       '@types/prop-types': 15.7.15
@@ -8569,10 +8516,6 @@ snapshots:
   '@types/react@18.3.31':
     dependencies:
       '@types/prop-types': 15.7.15
-      csstype: 3.2.3
-
-  '@types/react@19.2.17':
-    dependencies:
       csstype: 3.2.3
 
   '@types/redux-mock-store@1.5.0':
@@ -8620,8 +8563,6 @@ snapshots:
       '@types/jest': 28.1.8
 
   '@types/tough-cookie@4.0.5': {}
-
-  '@types/use-sync-external-store@0.0.3': {}
 
   '@types/webpack-env@1.18.8': {}
 
@@ -12830,20 +12771,6 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-redux@8.1.3(@preact/compat@18.3.2(preact@10.29.8))(@preact/compat@18.3.2(preact@10.29.8))(@types/react@18.3.31)(redux@4.2.1):
-    dependencies:
-      '@babel/runtime': 7.29.7
-      '@types/hoist-non-react-statics': 3.3.7(@types/react@18.3.31)
-      '@types/use-sync-external-store': 0.0.3
-      hoist-non-react-statics: 3.3.2
-      react: '@preact/compat@18.3.2(preact@10.29.8)'
-      react-is: 18.3.1
-      use-sync-external-store: 1.6.0(@preact/compat@18.3.2(preact@10.29.8))
-    optionalDependencies:
-      '@types/react': 18.3.31
-      react-dom: '@preact/compat@18.3.2(preact@10.29.8)'
-      redux: 4.2.1
-
   read-pkg-up@7.0.1:
     dependencies:
       find-up: 4.1.0
@@ -13771,10 +13698,6 @@ snapshots:
       webpack: 5.108.3(@swc/core@1.2.205)(cssnano@5.1.15(postcss@8.5.26))(postcss@8.5.26)(webpack-cli@4.10.0)
     optionalDependencies:
       file-loader: 6.2.0(webpack@5.108.3)
-
-  use-sync-external-store@1.6.0(@preact/compat@18.3.2(preact@10.29.8)):
-    dependencies:
-      react: '@preact/compat@18.3.2(preact@10.29.8)'
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
First step of #2166. `react-redux` is replaced by a small binding over Preact context, in `app/store/context.tsx`.

No behavioural change: the store, the reducers, the thunks and every selector stay exactly as they were. This only changes what connects components to the store.

It is not free, though, it is a saving. Measured against current master, `remark.mjs` goes from 77.64 kB to **76.15 kB** gzipped and `last-comments.mjs` from 38.81 kB to **37.97 kB**, so roughly 1.5 kB and 0.8 kB. The size limits are left where they are, so this shows up as headroom rather than a tighter gate.

### Why this one first

`react-redux` is one of exactly two packages holding the `@preact/compat` alias in place, and it is by far the more contained of the pair. The store's own logic is plain `redux` plus `redux-thunk`; the only react-redux import inside `app/store` was a single line in `index.ts` re-exporting typed hooks. Everything else is 9 files across components and hooks. `@types/react-redux` goes with it, having no remaining source usage.

It also carries a real react into the tree: `react-redux` pulls `use-sync-external-store`, which resolves an actual `react` in the lockfile rather than the compat shim.

### What the binding provides

Only what the widget uses, which is less than react-redux offers:

- `Provider`
- `useDispatch`
- `useSelector(selector)` and `useSelector(selector, equalityFn)`, the second form used once, in `thread.tsx`
- `shallowEqual`
- the `TypedUseSelectorHook` type that `store/index.ts` re-exports as `useAppSelector`

The subscription keeps the selector, the equality function and the last selected value in refs, so the subscription itself stays stable across renders while always comparing against the current render's selector. A changed selector therefore cannot resurrect a stale result.

It subscribes in `useLayoutEffect` rather than `useEffect`, and runs the comparison once immediately on subscribing. Both are needed for the same reason react-redux does them: an effect that runs after paint leaves a window in which a dispatch is not delivered, because the listener does not exist yet, and the component then renders a stale value until some later unrelated dispatch happens to differ from it. `context.test.tsx` covers that case and fails without the immediate check.

### Tests

The four test files that imported `Provider` from `react-redux` now import it from the same place the app does, and `comment-form__subscribe-by-rss.test.tsx`, which mocked the `react-redux` module, mocks `store/context` instead. `redux-mock-store` is unaffected and stays, since it mocks the store rather than the bindings.

The binding also gets its own tests, in `app/store/context.test.tsx`, which it did not have when it was a dependency: initial value, re-render on dispatch, and the subscribe-window case described above.

323 tests across 40 suites pass. The 320 pre-existing ones are unchanged and exercise the connected components heavily, which is the point: no test was adjusted to accommodate the new binding.

### Verified

Rebased onto current master, then verified from a wiped `node_modules`: `pnpm install --frozen-lockfile`, `pnpm lint`, `pnpm type-check`, `pnpm test` (323 of 323), `pnpm build`, `pnpm size-check` and `pnpm translation-check`.

### Next

`react-intl` is the other half, and the larger one at 27 non-test files. Once both are gone the `react` and `react-dom` aliases, the `@preact/compat` dependency and the `paths` entries in `tsconfig.json` can be deleted, which is what #2166 is actually after.



