### PR TITLE
Pin staging ages in TestFsStore_Cleanup instead of sleeping

### DIFF
--- a/backend/app/store/image/fs_store_test.go
+++ b/backend/app/store/image/fs_store_test.go
@@ -215,15 +215,24 @@ func TestFsStore_Cleanup(t *testing.T) {
 		return img
 	}
 
+	// age is read from the file's modification time, so every file gets its mtime stamped right
+	// before each call: far past the ttl for the ones meant to go, at now for the ones meant to
+	// survive, leaving no window for a stalled runner to age a survivor into the wrong bucket
+	const ttl = 300 * time.Millisecond
+	age := func(file string, d time.Duration) {
+		mtime := time.Now().Add(-d)
+		require.NoError(t, os.Chtimes(file, mtime, mtime))
+	}
+
 	// save 3 images to staging
 	img1 := save("blah_ff1.png", "user1")
-	time.Sleep(100 * time.Millisecond)
 	img2 := save("blah_ff2.png", "user1")
-	time.Sleep(100 * time.Millisecond)
 	img3 := save("blah_ff3.png", "user2")
 
-	time.Sleep(200 * time.Millisecond) // make first image expired
-	err := svc.Cleanup(context.Background(), time.Millisecond*300)
+	age(img1, time.Hour) // past the ttl, collected
+	age(img2, 0)         // fresh, survives
+	age(img3, 0)
+	err := svc.Cleanup(context.Background(), ttl)
 	assert.NoError(t, err)
 
 	_, err = os.Stat(img1)
@@ -242,10 +251,11 @@ func TestFsStore_Cleanup(t *testing.T) {
 	_, err = os.Stat(img3)
 	assert.NoError(t, err, "file on staging")
 
-	time.Sleep(200 * time.Millisecond)                // make all images expired
+	age(img2, time.Hour)
+	age(img3, time.Hour)
 	err = svc.ResetCleanupTimer("user2/blah_ff3.png") // reset the time to cleanup for third image
 	assert.NoError(t, err)
-	err = svc.Cleanup(context.Background(), time.Millisecond*300)
+	err = svc.Cleanup(context.Background(), ttl)
 	assert.NoError(t, err)
 
 	_, err = os.Stat(img2)


### PR DESCRIPTION
`TestFsStore_Cleanup` slept 200ms, ran `Cleanup` with a 300ms TTL, and then asserted that the second and third staged images survived. `Cleanup` collects anything older than the TTL plus a 100ms commit grace, so the line sits at 400ms, and the second image was already 300ms old by the time the call ran. Roughly 100ms of stall anywhere in the setup aged it past the line and it was collected, failing with `file on staging`.

Age comes from the file's modification time, so the test now sets it with `os.Chtimes` immediately before each `Cleanup` call: the image meant to be collected is backdated an hour, the ones meant to survive are stamped at now. That leaves no window for a stalled runner to age a file into the wrong bucket, and it drops 600ms of sleeping.

Verified by injecting a stall into the setup: 250ms reproduces the failure on the current code, while the version here survives 2 seconds.

This has been caught failing on more than one branch in the same window, so it costs any PR that happens to be running at the time. It is kept separate from the wider test determinism work in #2190 for that reason; the same fix appears there, so whichever merges first the other needs a rebase.
