### PR TITLE
Create the e2e trace directory before writing a trace

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -274,6 +274,11 @@ func newPageOn(t *testing.T, b playwright.Browser) playwright.Page {
 			// overwriting each other: the counter restarts with every process
 			name := strings.ReplaceAll(t.Name(), "/", "-")
 			path := filepath.Join(traceDir, fmt.Sprintf("%s-%d-%d.zip", name, os.Getpid(), seq))
+			// the driver creates the parent of the trace path too, but nothing here states or
+			// tests that, so the suite makes the directory itself
+			if derr := os.MkdirAll(traceDir, 0o750); derr != nil {
+				t.Logf("could not create %s: %v", traceDir, derr)
+			}
 			if serr := ctx.Tracing().Stop(path); serr != nil {
 				t.Logf("could not write the trace to %s: %v", path, serr)
 			}


### PR DESCRIPTION
`newPageOn` writes a Playwright trace into `traces/` when a test fails, and never creates that directory. It is gitignored, so a fresh checkout does not have it.

Traces were not in fact being dropped. The driver creates the parent of the trace path itself, which I checked against the version this module pins rather than assuming: launch chromium, open a context, start tracing, open a page, then `Tracing().Stop` into a path whose parent directory was removed immediately beforehand.

```go
dir := filepath.Join(os.TempDir(), "r42-trace-probe-does-not-exist")
_ = os.RemoveAll(dir)
path := filepath.Join(dir, "probe.zip")

stopErr := ctx.Tracing().Stop(path)
_, statErr := os.Stat(path)
fmt.Printf("stop error: %v\nfile written: %v\n", stopErr, statErr == nil)
```

```
stop error: <nil>
file written: true
```

The reason to add the `MkdirAll` anyway is that the code reads as though it depends on that, without saying so anywhere, and the missing directory has been raised in review twice, on #2180 and again on #2193, each time needing the driver checked before it could be answered. Owning the directory is cheaper than answering the question a third time.

It is not quite a no-op, so worth stating: on a fresh checkout the directory now arrives at `0750` rather than the `0755` the driver's own recursive mkdir leaves. Both measured on this machine, not read off the documentation.

It runs only on a test that has already failed, and logs its error rather than swallowing it, matching the `Stop` call below it.
