### PR TITLE
Stop markdown-only changes triggering CI, and record the preact double pin

### DIFF
--- a/.github/workflows/ci-site.yml
+++ b/.github/workflows/ci-site.yml
@@ -9,10 +9,14 @@ on:
     paths:
       - ".github/workflows/ci-site.yml"
       - "site/**"
+      - "!**/CLAUDE.md"
+      - "!site/README.md"
   pull_request:
     paths:
       - ".github/workflows/ci-site.yml"
       - "site/**"
+      - "!**/CLAUDE.md"
+      - "!site/README.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -10,6 +10,7 @@ on:
       - "e2e/**"
       - "compose-e2e-test.yml"
       - "Dockerfile"
+      - "!**.md"
 
   pull_request:
     branches: [master]
@@ -20,6 +21,7 @@ on:
       - "e2e/**"
       - "compose-e2e-test.yml"
       - "Dockerfile"
+      - "!**.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ on:
       - "scripts/**"
       - "backend/**"
       - "frontend/**"
+      - "!backend/**.md"
+      - "!frontend/**.md"
       - "README.md"
       - "LICENSE"
-      - "CLAUDE.md"
-      - "site/content/docs/getting-started/installation/index.md"
 
 permissions:
   contents: read

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -16,6 +16,25 @@ When bumping pnpm/node, also re-check `frontend/apps/remark42/package.json`'s `e
 
 `engines.node` states the major we support, currently `>=24`, which is the active LTS; 22 has dropped to maintenance. `@babel/core` 8 wants `^22.18 || >=24.11` and `size-limit` 13 wants `^22.18 || ^24 || >=26`, so 22 was the floor rather than the target. Individual dev dependencies can be stricter within that major (`undici` wants `>=20.18.1`); do not chase those patch floors into `engines` or the docs, or every lockfile refresh becomes a documentation change.
 
+## preact's version is pinned twice, and the override is the one that wins
+
+- `frontend/apps/remark42/package.json`: the app's own dependency, an exact version
+- `frontend/package.json`: a `pnpm.overrides` entry holding an exact version too
+
+The override is authoritative over both, which is the part worth knowing. Give the app pin a
+different version and pnpm installs the override's version anyway, and writes the override's version
+into `pnpm-lock.yaml` as the app's own specifier. Move the override instead and that is what
+installs. Either way exactly one preact resolves.
+
+So editing the app manifest on its own achieves nothing except making it misstate what is installed,
+and nothing reports that. `pnpm install --frozen-lockfile` still succeeds with the manifest and the
+lockfile naming different versions, because the specifier the lockfile carries is the one the
+override produced. There is no syncpack or equivalent in the workflows, the package scripts or
+`tasks/` to compare the two either.
+
+Grep for the version rather than editing whichever manifest you happened to open, and change both in
+the same commit.
+
 ## pnpm 10's stricter `node-linker` layout needs explicit pins
 
 One dep is pinned specifically because of pnpm 10's hoisting changes, not because of the dep itself:


### PR DESCRIPTION
Two unrelated pieces of housekeeping, both small.

## `frontend/CLAUDE.md`: preact is pinned twice

Asked for in review on #2163 and marked as separate from that PR, so it never landed.

`preact` is declared twice: an exact version in `frontend/apps/remark42/package.json`, and a `pnpm.overrides` entry in `frontend/package.json`. Nothing said which one decides, and it is the override.

Measured both ways with `pnpm install --lockfile-only` on a copy of the workspace rather than reasoned about:

| app manifest | override | what installs | what the lockfile records as the app's specifier |
|---|---|---|---|
| `10.28.0` | `10.29.8` | `10.29.8` | `10.29.8` |
| `10.29.8` | `10.28.0` | `10.28.0` | `10.28.0` |

Exactly one preact resolves either way. So an app-only bump is a no-op that leaves the manifest misstating what is installed, and nothing catches it: `pnpm install --frozen-lockfile` succeeds with the manifest and the lockfile naming different versions, because the specifier the lockfile carries is the one the override produced. There is no syncpack or equivalent in the workflows, the package scripts or `tasks/` to compare them either.

## Markdown-only changes were starting the e2e and release workflows

This PR is the example. Editing one markdown file started a docker build and the full browser suite through `e2e-tests.yml`, and the whole backend race suite, the example module, the frontend checks and a GoReleaser snapshot through `release.yml`.

`ci-backend.yml`, `ci-build.yml` and `ci-frontend.yml` all end their path filters with `!**.md`. The e2e workflow did not, so any markdown under `frontend/` or `backend/` matched its `frontend/**` and `backend/**` entries.

`release.yml` had the same hole plus one of its own. A blanket `!**.md` would have been wrong there, because it names `README.md` and `LICENSE` deliberately and `.goreleaser.yml` packages both into the archives, so it now excludes markdown under `backend/` and `frontend/` only. `CLAUDE.md` and `site/content/docs/getting-started/installation/index.md` were also named there, both from the workflow's first commit in #2070. Neither is packaged, and outside their own trees the only reference to either in the whole repository is that filter, so the job they started could not check anything about them.

`ci-site.yml` goes on matching markdown, which is right, since the site is built from it. It excludes two names: `CLAUDE.md`, so a future `site/CLAUDE.md` cannot start a site build, and `site/README.md`, which documents how to build the site rather than being part of it. That leaves 34 markdown files able to start it, all of them content.

Checked by matching every workflow's path filter against all 133 tracked markdown files, before and after.
