### PR TITLE
Cover the locale chunks, the delete page and the last-comments stylesheet

### DIFF
--- a/e2e/thread_test.go
+++ b/e2e/thread_test.go
@@ -4,6 +4,7 @@ package e2e
 
 import (
 	"fmt"
+	neturl "net/url"
 	"strings"
 	"testing"
 
@@ -119,4 +120,25 @@ func TestThread_CollapsePersistsAcrossReload(t *testing.T) {
 	})
 
 	assert.Equal(t, 1, articleCount(t, frame), "a collapsed thread should not render its replies after reload")
+}
+
+// TestThread_LocaleLoadsItsTranslationChunk covers the locale bundles, which nothing else asks
+// for. loadLocale imports the chunk dynamically and falls back to the English defaults on any
+// error, so a missing or broken chunk renders a perfectly good English widget and says nothing.
+// The widget document is opened directly, since the demo page has no way to pass a locale.
+func TestThread_LocaleLoadsItsTranslationChunk(t *testing.T) {
+	page := newPage(t)
+
+	pauseForAuthLimit()
+	// the widget document, not the demo page, since nothing there can pass a locale. it has to
+	// be opened on the instance's own origin: the bundle addresses the host the build was
+	// substituted with, and its CSP is `self`, so a mismatched origin blocks its own chunk
+	_, err := page.Goto(fmt.Sprintf("%s/web/iframe.html?site_id=remark&locale=ru&url=%s",
+		baseURL, neturl.QueryEscape(threadURL(t))))
+	require.NoError(t, err)
+
+	// two strings rather than one, and both from the chunk rather than from the code's own
+	// defaults: the sort label is always present, and the sign-in button only while signed out
+	waitVisible(t, page.Locator("text=Сортировать по"))
+	waitVisible(t, page.Locator(`text=Войти`))
 }

--- a/e2e/widgets_test.go
+++ b/e2e/widgets_test.go
@@ -26,13 +26,36 @@ func TestWidgets_LastCommentsRendersIntoTheHostPage(t *testing.T) {
 	postComment(t, frame, text)
 
 	page := newPage(t)
+
+	// the stylesheet is appended at runtime and nothing waits for it, so the comments render
+	// whether or not it arrives. wait for the response itself rather than sampling afterwards,
+	// which reads whatever has landed by then and passes when the miss is still in flight
 	pauseForAuthLimit()
-	_, err := page.Goto(baseURL + "/web/last-comments.html")
-	require.NoError(t, err)
+	css, err := page.ExpectResponse("**/last-comments.css", func() error {
+		_, gerr := page.Goto(baseURL + "/web/last-comments.html")
+		return gerr
+	}, playwright.PageExpectResponseOptions{Timeout: playwright.Float(float64(waitTimeout.Milliseconds()))})
+	require.NoError(t, err, "the page never asked for its stylesheet")
+	assert.Equal(t, 200, css.Status(), "the last-comments stylesheet did not load")
 
 	list := page.Locator(".remark42__last-comments")
 	waitVisible(t, list)
 	waitVisible(t, list.Locator("text="+text))
+}
+
+// TestWidgets_DeleteMePageServesAndRuns covers the GDPR delete page, which nothing else opens. It
+// needs an admin token to do its work, so this drives the branch it takes without one: reaching
+// that message proves the html and its bundle were both served and executed.
+func TestWidgets_DeleteMePageServesAndRuns(t *testing.T) {
+	page := newPage(t)
+
+	pauseForAuthLimit()
+	resp, err := page.Goto(baseURL + "/web/deleteme.html")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, 200, resp.Status())
+
+	waitVisible(t, page.Locator("text=You are not logged in"))
 }
 
 // TestWidgets_CounterFillsInTheCommentCount covers the other host-page script.


### PR DESCRIPTION
Three things the e2e suite could lose without going red. Each was found the same way: remove the asset from the running instance, run the whole suite, and watch every test stay green.

**The locale bundles.** Nothing asked for one, so every run was English. `loadLocale` imports the chunk dynamically and falls back to the English defaults on any error, so a missing or broken chunk renders a perfectly good widget and says nothing. The test opens the widget document with `locale=ru` and asserts two strings that only come from the chunk. It has to be the widget document rather than the demo page, which has no way to pass a locale, and on the instance's own origin, since the bundle addresses the host it was substituted with and its CSP is `self`.

**The delete page.** `deleteme.html` and its bundle had no coverage of any kind. It needs an admin token to do its work, so the test drives the branch it takes without one: reaching that message proves the page and its bundle were both served and executed.

**The last-comments stylesheet.** It is appended at runtime and nothing waits for it, so the comments render whether or not it arrives. The test now waits for that response and asserts its status.

That last one is worth spelling out, because the first version of it was useless. It collected failed responses and asserted the list was empty after the comments appeared, which passed with the file deleted: the 404 had not landed yet when the assertion ran. Waiting for the specific response is what makes it fail.

Each test was verified by deleting the asset it covers from the running instance and confirming it goes red.
