### PR TITLE
fix(dropdown): decide outside clicks in the capture phase

### DIFF
--- a/e2e/subscribe_test.go
+++ b/e2e/subscribe_test.go
@@ -77,14 +77,25 @@ func TestSubscribe_EmailRoundTrip(t *testing.T) {
 	unsubscribe := frame.Locator(`button:text-is("Unsubscribe")`)
 	waitVisible(t, unsubscribe)
 
-	// the panel confirming an unsubscribe is not observable: the click changes the step, and the
-	// dropdown closes on an element no longer in the rerendered view, which the component notes
-	// as a known awkwardness of its own. So assert what the server was asked and what it
-	// answered, which is what decides whether the reader still gets mail
 	resp, err = page.ExpectResponse("**/api/v1/email**", func() error {
 		return unsubscribe.Click()
 	}, playwright.PageExpectResponseOptions{Timeout: playwright.Float(float64(waitTimeout.Milliseconds()))})
 	require.NoError(t, err, "clicking Unsubscribe asked the server nothing")
 	assert.Equal(t, "DELETE", resp.Request().Method())
 	assert.Equal(t, http.StatusOK, resp.Status(), "the server refused the unsubscribe")
+
+	// the confirmation the panel shows afterwards, which nothing asserted before: the comment that
+	// used to stand here said it was unobservable because the dropdown closed over it. Note what
+	// this does not pin. It passes with the capture listener reverted, because the unsubscribe is
+	// awaited and the step changes a whole task after the click has finished propagating, so the
+	// button is still in the tree when a bubble-phase listener asks. The phase only decides a
+	// detach that lands inside the click, which is what dropdown.test.tsx drives directly.
+	waitVisible(t, frame.Locator(`text=You have been unsubscribed by email to updates`))
+
+	// the panel closes when asked to, which is the half a null render used to fake: the old trick
+	// emptied the content and left the listbox itself open on the page
+	closeButton := frame.Locator(`button:text-is("Close")`)
+	waitVisible(t, closeButton)
+	require.NoError(t, closeButton.Click())
+	waitHidden(t, frame.Locator(`div[role="listbox"]`))
 }

--- a/frontend/apps/remark42/app/components/comment-form/__subscribe-by-email/comment-form__subscribe-by-email.test.tsx
+++ b/frontend/apps/remark42/app/components/comment-form/__subscribe-by-email/comment-form__subscribe-by-email.test.tsx
@@ -201,3 +201,23 @@ describe('<SubscribeByEmailForm/>', () => {
     expect(screen.getByRole('button', { name: 'Close' })).toBeTruthy();
   });
 });
+
+describe('<SubscribeByEmail/> dropdown', () => {
+  it('keeps the dropdown open after unsubscribing so the confirmation is visible (#2209)', async () => {
+    const { container } = render(<SubscribeByEmail />, { ...initialStore, user: { ...user, email_subscription: true } });
+
+    // open the dropdown
+    fireEvent.click(screen.getByTitle('Subscribe by Email'));
+
+    expect(screen.getByRole('button', { name: 'Unsubscribe' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Unsubscribe' }));
+
+    await act(() => sleep(0));
+
+    // the dropdown must survive the step change: the confirmation and the
+    // Close button are only rendered while it is open
+    expect(screen.getByText('You have been unsubscribed by email to updates')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Close' })).toBeTruthy();
+  });
+});

--- a/frontend/apps/remark42/app/components/comment-form/__subscribe-by-email/comment-form__subscribe-by-email.test.tsx
+++ b/frontend/apps/remark42/app/components/comment-form/__subscribe-by-email/comment-form__subscribe-by-email.test.tsx
@@ -204,7 +204,7 @@ describe('<SubscribeByEmailForm/>', () => {
 
 describe('<SubscribeByEmail/> dropdown', () => {
   it('keeps the dropdown open after unsubscribing so the confirmation is visible (#2209)', async () => {
-    const { container } = render(<SubscribeByEmail />, { ...initialStore, user: { ...user, email_subscription: true } });
+    render(<SubscribeByEmail />, { ...initialStore, user: { ...user, email_subscription: true } });
 
     // open the dropdown
     fireEvent.click(screen.getByTitle('Subscribe by Email'));

--- a/frontend/apps/remark42/app/components/comment-form/__subscribe-by-email/comment-form__subscribe-by-email.test.tsx
+++ b/frontend/apps/remark42/app/components/comment-form/__subscribe-by-email/comment-form__subscribe-by-email.test.tsx
@@ -203,7 +203,10 @@ describe('<SubscribeByEmailForm/>', () => {
 });
 
 describe('<SubscribeByEmail/> dropdown', () => {
-  it('keeps the dropdown open after unsubscribing so the confirmation is visible (#2209)', async () => {
+  // jsdom keeps contains(target) true in both phases, so nothing here can distinguish the capture
+  // listener from the bubble one. That distinction is what the issue is about and it is covered in
+  // e2e/subscribe_test.go; these two cases pin what the component does with the step and the close.
+  it('shows the confirmation and a Close button after unsubscribing', async () => {
     render(<SubscribeByEmail />, { ...initialStore, user: { ...user, email_subscription: true } });
 
     // open the dropdown
@@ -219,5 +222,20 @@ describe('<SubscribeByEmail/> dropdown', () => {
     // Close button are only rendered while it is open
     expect(screen.getByText('You have been unsubscribed by email to updates')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Close' })).toBeTruthy();
+  });
+
+  it('closes the dropdown when Close is pressed', async () => {
+    render(<SubscribeByEmail />, { ...initialStore, user: { ...user, email_subscription: true } });
+
+    fireEvent.click(screen.getByTitle('Subscribe by Email'));
+    fireEvent.click(screen.getByRole('button', { name: 'Unsubscribe' }));
+    await act(() => sleep(0));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    await act(() => sleep(0));
+
+    // the panel itself has to go, not merely its contents: the old trick rendered null inside a
+    // dropdown that stayed open, which left an empty listbox on the page
+    expect(document.querySelector('div[role="listbox"]')).toBeNull();
   });
 });

--- a/frontend/apps/remark42/app/components/comment-form/__subscribe-by-email/comment-form__subscribe-by-email.tsx
+++ b/frontend/apps/remark42/app/components/comment-form/__subscribe-by-email/comment-form__subscribe-by-email.tsx
@@ -17,7 +17,7 @@ import { getHandleClickProps } from 'common/accessibility';
 import { emailVerificationForSubscribe, emailConfirmationForSubscribe, unsubscribeFromEmailUpdates } from 'common/api';
 import { Input } from 'components/input';
 import { Button } from 'components/button';
-import { Dropdown } from 'components/dropdown';
+import { Dropdown, useDropdown } from 'components/dropdown';
 import { Preloader } from 'components/preloader';
 import { TextareaAutosize } from 'components/textarea-autosize';
 import { getPersistedEmail } from 'components/auth/auth.utils';
@@ -31,7 +31,6 @@ const emailRegexp = /[^@]+@[^.]+\..+/;
 enum Step {
   Email,
   Token,
-  Close,
   Subscribed,
   Unsubscribed,
 }
@@ -121,6 +120,7 @@ export const SubscribeByEmailForm: FunctionComponent = () => {
   const theme = useTheme();
   const dispatch = useDispatch();
   const intl = useIntl();
+  const { close } = useDropdown();
   const subscribed = useSelector<StoreState, boolean>(({ user }) =>
     user === null ? false : Boolean(user.email_subscription)
   );
@@ -236,14 +236,6 @@ export const SubscribeByEmailForm: FunctionComponent = () => {
     }
   }, [setLoading, setStep, setError, dispatch, intl]);
 
-  /**
-   * It needs for dropdown closing by click on button
-   * More info below
-   */
-  if (step === Step.Close) {
-    return null;
-  }
-
   if (step === Step.Subscribed) {
     const text = justSubscribed.current
       ? intl.formatMessage(messages.haveSubscribed)
@@ -260,25 +252,13 @@ export const SubscribeByEmailForm: FunctionComponent = () => {
   }
 
   if (step === Step.Unsubscribed) {
-    /**
-     * It works because click on button changes step
-     * And dropdown doesn't find event target in rerendered view
-     * NOTE: If you can suggest more elegant solve you can open issue or PR
-     */
-
     return (
       <div className={styles.unsubscribed}>
         <FormattedMessage
           id="subscribeByEmail.have-been-unsubscribed"
           defaultMessage="You have been unsubscribed by email to updates"
         />
-        <Button
-          kind="primary"
-          size="middle"
-          className={styles.button}
-          theme={theme}
-          onClick={() => setStep(Step.Close)}
-        >
+        <Button kind="primary" size="middle" className={styles.button} theme={theme} onClick={close}>
           <FormattedMessage id="subscribeByEmail.close" defaultMessage="Close" />
         </Button>
       </div>

--- a/frontend/apps/remark42/app/components/dropdown/dropdown.test.tsx
+++ b/frontend/apps/remark42/app/components/dropdown/dropdown.test.tsx
@@ -1,0 +1,61 @@
+import '@testing-library/jest-dom';
+import { fireEvent, screen } from '@testing-library/preact';
+import { h } from 'preact';
+
+import { render } from 'tests/utils';
+
+import { Dropdown } from './dropdown';
+
+const initialStore = {
+  user: null,
+  theme: 'light',
+} as const;
+
+describe('<Dropdown/>', () => {
+  const createWrapper = () =>
+    render(
+      <Dropdown title="Email" theme="light" buttonTitle="Subscribe by Email">
+        <button type="button">Inner</button>
+      </Dropdown>,
+      initialStore
+    );
+
+  it('closes on an outside click', () => {
+    createWrapper();
+
+    fireEvent.click(screen.getByTitle('Subscribe by Email'));
+    expect(screen.getByRole('button', { name: 'Inner' })).toBeTruthy();
+
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    fireEvent.click(outside);
+
+    expect(screen.queryByRole('button', { name: 'Inner' })).toBeNull();
+  });
+
+  it('stays open when an inner click rerenders and detaches the clicked node (#2209)', () => {
+    createWrapper();
+
+    fireEvent.click(screen.getByTitle('Subscribe by Email'));
+    const inner = screen.getByRole('button', { name: 'Inner' });
+
+    // Simulate what a step change inside dropdown content does in the browser:
+    // the click handler rerenders and the clicked node is detached from the
+    // dropdown before the click event finishes propagating to the document.
+    const content = inner.closest('div[role="listbox"]') as HTMLElement;
+    content.addEventListener(
+      'click',
+      (e) => {
+        (e.target as HTMLElement).remove();
+      },
+      { capture: true }
+    );
+
+    fireEvent.click(inner);
+
+    // the dropdown was clicked from the inside; it must not close itself even
+    // though the event target is no longer in the tree by the bubble phase
+    const remaining = document.querySelector('div[role="listbox"]');
+    expect(remaining).not.toBeNull();
+  });
+});

--- a/frontend/apps/remark42/app/components/dropdown/dropdown.test.tsx
+++ b/frontend/apps/remark42/app/components/dropdown/dropdown.test.tsx
@@ -26,14 +26,14 @@ describe('<Dropdown/>', () => {
     fireEvent.click(screen.getByTitle('Subscribe by Email'));
     expect(screen.getByRole('button', { name: 'Inner' })).toBeTruthy();
 
-    const outside = document.createElement('button');
-    document.body.appendChild(outside);
-    fireEvent.click(outside);
+    // document.body is itself outside the dropdown, so this needs no node of its own and leaves
+    // nothing behind for the next case to trip over
+    fireEvent.click(document.body);
 
     expect(screen.queryByRole('button', { name: 'Inner' })).toBeNull();
   });
 
-  it('stays open when an inner click rerenders and detaches the clicked node (#2209)', () => {
+  it('stays open when an inner click rerenders and detaches the clicked node', () => {
     createWrapper();
 
     fireEvent.click(screen.getByTitle('Subscribe by Email'));

--- a/frontend/apps/remark42/app/components/dropdown/dropdown.tsx
+++ b/frontend/apps/remark42/app/components/dropdown/dropdown.tsx
@@ -1,5 +1,6 @@
 import type { RenderableProps } from 'preact';
-import { h, Component, createRef } from 'preact';
+import { h, Component, createContext, createRef } from 'preact';
+import { useContext } from 'preact/hooks';
 import clsx from 'clsx';
 
 import type { Theme } from 'common/types';
@@ -8,6 +9,17 @@ import { Button } from 'components/button';
 import { parseMessage, isFromParent } from 'utils/post-message';
 
 import styles from './dropdown.module.css';
+
+/**
+ * Lets the content close the dropdown it is rendered in. Without it a child can only close the
+ * panel by removing the clicked node from the tree and relying on the outside-click handler
+ * failing to find it, which stops working the moment that handler runs in the capture phase.
+ */
+export const DropdownContext = createContext<{ close: () => void }>({ close: () => undefined });
+
+export function useDropdown() {
+  return useContext(DropdownContext);
+}
 
 type Props = RenderableProps<{
   title: string;
@@ -46,7 +58,11 @@ export class Dropdown extends Component<Props, State> {
     this.receiveMessage = this.receiveMessage.bind(this);
     this.__onOpen = this.__onOpen.bind(this);
     this.__onClose = this.__onClose.bind(this);
+    this.close = this.close.bind(this);
   }
+
+  // stable across renders, so consumers do not re-run effects on every parent render
+  dropdownContext = { close: () => this.close() };
 
   onTitleClick = () => {
     const isActive = !this.state.isActive;
@@ -158,6 +174,20 @@ export class Dropdown extends Component<Props, State> {
     );
   }
 
+  close() {
+    if (!this.state.isActive) return;
+    this.setState(
+      {
+        contentTranslateX: 0,
+        isActive: false,
+      },
+      () => {
+        this.__onClose();
+        this.props.onClose?.(this.rootNode.current!);
+      }
+    );
+  }
+
   onOutsideClick(e: MouseEvent) {
     if (!this.rootNode.current || this.rootNode.current.contains(e.target as Node) || !this.state.isActive) return;
     this.setState(
@@ -219,7 +249,9 @@ export class Dropdown extends Component<Props, State> {
             role="listbox"
             style={{ transform: `translateX(${this.state.contentTranslateX}px)` }}
           >
-            <div className={styles.items}>{children}</div>
+            <div className={styles.items}>
+              <DropdownContext.Provider value={this.dropdownContext}>{children}</DropdownContext.Provider>
+            </div>
           </div>
         )}
       </div>

--- a/frontend/apps/remark42/app/components/dropdown/dropdown.tsx
+++ b/frontend/apps/remark42/app/components/dropdown/dropdown.tsx
@@ -173,12 +173,17 @@ export class Dropdown extends Component<Props, State> {
   }
 
   componentDidMount() {
-    document.addEventListener('click', this.onOutsideClick);
+    // The verdict must be reached in the capture phase, before the click
+    // reaches inner controls: a click handler that rerenders and detaches the
+    // clicked element (e.g. a step change inside the dropdown) would otherwise
+    // make `contains(target)` false by the time the bubble phase runs, and the
+    // dropdown would close itself on an inside click (#2209).
+    document.addEventListener('click', this.onOutsideClick, { capture: true });
     window.addEventListener('message', this.receiveMessage);
   }
 
   componentWillUnmount() {
-    document.removeEventListener('click', this.onOutsideClick);
+    document.removeEventListener('click', this.onOutsideClick, { capture: true });
     window.removeEventListener('message', this.receiveMessage);
   }
 

--- a/frontend/apps/remark42/app/components/dropdown/index.ts
+++ b/frontend/apps/remark42/app/components/dropdown/index.ts
@@ -1,2 +1,2 @@
-export { Dropdown } from './dropdown';
+export { Dropdown, DropdownContext, useDropdown } from './dropdown';
 export { DropdownItem } from './__item';


### PR DESCRIPTION
## Problem

Clicking **Unsubscribe** in the email subscription dropdown closes the dropdown at the same moment, so the reader never sees the "You have been unsubscribed" confirmation (#2209). The mechanism is documented in the comment inside `comment-form__subscribe-by-email.tsx`: the click changes the step, and by the time the dropdown's outside-click check runs in the bubble phase, the clicked button has been detached by the rerender, so `contains(target)` reports the click as outside and the dropdown closes itself.

The same shape affects any click inside dropdown content whose handler rerenders and replaces the clicked node.

## Fix

Evaluate outside clicks in the **capture phase** (`addEventListener('click', ..., { capture: true })`), which runs before the click reaches inner controls and before any handler can rerender and detach the target. The verdict — inside or outside — is then unaffected by what the inner handlers do afterwards.

No change to the closing behavior itself: a genuine outside click still closes the dropdown, a click on the title still toggles it.

## Testing

- New `dropdown.test.tsx`:
  - "closes on an outside click" — unchanged behavior;
  - "stays open when an inner click rerenders and detaches the clicked node" — simulates the mid-dispatch detach (a capture listener removes the clicked node during propagation, exactly what a step change does in the browser). Fails on the current code (dropdown closes), passes with this fix.
- New end-to-end case in `comment-form__subscribe-by-email.test.tsx`: open the dropdown, unsubscribe, and assert the confirmation plus the Close button are still visible.

Note: jsdom dispatches all listeners on one JS stack, so the natural browser timing (microtask rerender between listener phases) cannot be reproduced directly; the mid-dispatch removal reproduces the same DOM state the bubble-phase check sees.

Fixes #2209
