### PR TITLE
Release the response before tearing the test server down

### DIFF
--- a/backend/app/rest/api/middleware_test.go
+++ b/backend/app/rest/api/middleware_test.go
@@ -271,11 +271,14 @@ func TestRest_securityHeaders(t *testing.T) {
 	client := http.Client{}
 	resp, err := client.Get(ts.URL + "/web/index.html")
 	require.NoError(t, err)
-	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Contains(t, resp.Header.Get("Content-Security-Policy"), "img-src *;")
 	assert.Equal(t, "nosniff", resp.Header.Get("X-Content-Type-Options"))
 	assert.Equal(t, "strict-origin-when-cross-origin", resp.Header.Get("Referrer-Policy"))
+	// httptest.Server.Close waits on connections still in use, and a deferred close does not run
+	// until the test ends, so the body has to be released before the server is torn down here
+	require.NoError(t, resp.Body.Close())
+	client.CloseIdleConnections()
 	teardown()
 
 	// check CSP with proxy enabled

--- a/backend/app/rest/api/rest_test.go
+++ b/backend/app/rest/api/rest_test.go
@@ -573,9 +573,12 @@ func TestRest_frameAncestors(t *testing.T) {
 	client := http.Client{}
 	resp, err := client.Get(ts.URL + "/web/index.html")
 	require.NoError(t, err)
-	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Contains(t, resp.Header.Get("Content-Security-Policy"), "frame-ancestors 'self' https://example.com;")
+	// httptest.Server.Close waits on connections still in use, and a deferred close does not run
+	// until the test ends, so the body has to be released before the server is torn down here
+	require.NoError(t, resp.Body.Close())
+	client.CloseIdleConnections()
 	teardown()
 
 	// test case without frame-ancestors


### PR DESCRIPTION
`rest/api` cannot finish under go 1.27. `TestRest_securityHeaders` and `TestRest_frameAncestors` both hang, the package dies on the timeout, and nothing names a cause.

Both tests start a server, read one response, then call `teardown()` partway through so they can start a second server with different options. The first response body is only closed by a `defer`, which does not run until the test returns. `httptest.Server.Close` waits on connections still in use, so it waits on a body that will not be closed until after it returns.

CI pins go 1.25 and passes, which is why this has been invisible. The fix is to close the body and the client's idle connections before `teardown()` in both, which is what `CLAUDE.md` already says to do under "Close idle connections before shutting a test server down".

Measured on go 1.27.0: `rest/api` goes from a 300s timeout panic to 17s. Reverting either half brings the hang back.

One other test in the package fails on 1.27, `TestRest_QR` at `rest_public_test.go:995`, which compares a golden PNG byte for byte. That is #2200 and #2198 fixes it, so it is deliberately untouched here. With #2198 and this branch together the package is green on 1.27.

Related to #2200
