### PR TITLE
Report the widget height when the sign-in panel closes

### DIFF
--- a/frontend/apps/remark42/app/components/auth/auth.hooks.ts
+++ b/frontend/apps/remark42/app/components/auth/auth.hooks.ts
@@ -85,6 +85,11 @@ export function useDropdown(disableClosing?: boolean) {
     return () => {
       document.body.style.removeProperty('min-height');
       observer.disconnect();
+      // the panel is positioned absolutely, so closing it resizes no box any observer here
+      // watches: the one above is gone with the element and the document one in root never sees
+      // a change. without a report of its own the parent keeps the open panel's height, leaving
+      // a hole under the widget for as long as the reader stays on the page
+      updateIframeHeight();
     };
   }, [showDropdown]);
 

--- a/frontend/apps/remark42/app/components/auth/auth.spec.tsx
+++ b/frontend/apps/remark42/app/components/auth/auth.spec.tsx
@@ -7,6 +7,7 @@ import type { OAuthProvider, User } from 'common/types';
 import { StaticStore } from 'common/static-store';
 import { BASE_URL } from 'common/constants.config';
 import * as userActions from 'store/user/actions';
+import * as postMessage from 'utils/post-message';
 
 import { Auth } from './auth';
 import * as utils from './auth.utils';
@@ -88,6 +89,25 @@ describe('<Auth/>', () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       expect(container.querySelector('.auth-dropdown')).toBeInTheDocument();
+    });
+
+    // the panel is positioned absolutely, so it grows the iframe without growing the document:
+    // the parent is told a height nothing else will ever correct, and closing the panel resizes
+    // no box either observer watches. a close that reports nothing leaves the iframe at the open
+    // panel's height, which is a hole in the embedding page under the widget
+    it('should report the height when the dropdown closes', async () => {
+      const updateIframeHeight = jest.spyOn(postMessage, 'updateIframeHeight');
+      const { container } = render(<Auth />);
+
+      fireEvent.click(screen.getByText('Sign In'));
+      expect(container.querySelector('.auth-dropdown')).toBeInTheDocument();
+
+      updateIframeHeight.mockClear();
+      fireEvent.click(document);
+      expect(container.querySelector('.auth-dropdown')).not.toBeInTheDocument();
+
+      // with no element, so the height is the document's own and not the panel that just went
+      await waitFor(() => expect(updateIframeHeight).toHaveBeenCalledWith());
     });
 
     it('should not close dropdown by clickOutside message from a foreign source', async () => {


### PR DESCRIPTION
The sign-in panel is positioned absolutely, so it grows the iframe without growing the document: `useDropdown` measures the panel itself and posts the sum, and a `ResizeObserver` on the panel keeps that number current while it is open.

Closing it resizes no box anything watches. The panel observer goes with the element, and the document observer in `Root` sees nothing, because the document height never changed in the first place. Nothing then tells the parent to come back down, so the iframe keeps the open panel's height and the embedding page carries a hole under the widget for as long as the reader stays on it. Here that is 541px of iframe over a 292px document.

The effect's cleanup now reports the height, with no element, so the number is the document's own. That is the one place both close paths reach: the click inside the widget, and the `clickOutside` message the host page posts when the reader clicks anywhere else.

`TestGeometry_HeightFollowsTheAuthPanelAndTheTextarea` covers this and has been intermittently green: whether the frame comes back down without the fix depends on timing, and it fails on every run on this machine while CI has been passing. It passes three times out of three against a stack built from this branch. The unit test fails with the cleanup reverted.


Suggested order: this one first. #2214 and #2215 both carry its commit and each collapses to a single commit once it lands.
