### PR TITLE
Drop the origin-anchored public path from the delete-me bundle

### DIFF
--- a/frontend/apps/remark42/app/deleteme.ts
+++ b/frontend/apps/remark42/app/deleteme.ts
@@ -10,8 +10,6 @@ if (document.readyState === 'loading') {
 }
 
 async function init(): Promise<void> {
-  __webpack_public_path__ = `${window.location.origin}/web/`;
-
   const node = document.getElementById(NODE_ID);
 
   if (!node) {


### PR DESCRIPTION
Follow-up hygiene from #2203, deliberately scoped small and described as what it is.

`deleteme.ts` sets `__webpack_public_path__` to `${window.location.origin}/web/`. That discards whatever path prefix the instance is served under, which is precisely the shape #2203 was about, and it survived that fix because the fix changed `output.publicPath` to `'auto'` while this bundle overrides the value in application code.

It does not reproduce today. The bundle references no asset and loads no chunk, so the runtime public path is assigned and never read, and nothing 404s. I checked the built output rather than assuming: `n.p` appears twice in `public/deleteme.mjs`, once for webpack's own `auto` derivation and once for this override, and there is no consumer.

So this is a footgun rather than a fault, and it goes in on that basis. The first person to put an image on the delete-me page inherits a broken path on every prefixed installation, with no test that would catch it: `TestWeb_NoBundleHardcodesTheWebRoot` matches a string literal and this is an expression. Removing the line leaves `publicPath: 'auto'`, which derives the base from the script's own URL and is correct whether or not there is a prefix.

The two sibling bundles are left alone. `remark.tsx` and `last-comments.tsx` set the same variable from `BASE_URL`, which comes from `remark_config.host` and carries the prefix, so they are already right.