### PR TITLE
Give each import request in TestMigrator_ImportDouble its own reader

### DIFF
--- a/backend/app/rest/api/migrator_test.go
+++ b/backend/app/rest/api/migrator_test.go
@@ -280,10 +280,14 @@ func TestMigrator_ImportDouble(t *testing.T) {
 	for i := range 50 {
 		recs = append(recs, fmt.Sprintf(tmpl, i))
 	}
-	r := strings.NewReader(`{"version":1}` + strings.Join(recs, "\n")) // reader with 10k records
+	// each request needs its own reader. client.Do returns once the response headers are in, which
+	// for an accepted import is before the transport's writeLoop has finished copying the body, so
+	// handing the same strings.Reader to the second NewRequest races that copy: NewRequest reads
+	// Len() to set ContentLength while WriteTo is still advancing it
+	body := `{"version":1}` + strings.Join(recs, "\n")
 	client := &http.Client{Timeout: waitTimeout}
 	defer client.CloseIdleConnections()
-	req, err := http.NewRequest("POST", ts.URL+"/api/v1/admin/import?site=remark42&provider=native", r)
+	req, err := http.NewRequest("POST", ts.URL+"/api/v1/admin/import?site=remark42&provider=native", strings.NewReader(body))
 	require.NoError(t, err)
 	req.SetBasicAuth("admin", "password")
 	assert.NoError(t, err)
@@ -294,7 +298,7 @@ func TestMigrator_ImportDouble(t *testing.T) {
 
 	client = &http.Client{Timeout: 5 * time.Second}
 	defer client.CloseIdleConnections()
-	req, err = http.NewRequest("POST", ts.URL+"/api/v1/admin/import?site=remark42&provider=native", r)
+	req, err = http.NewRequest("POST", ts.URL+"/api/v1/admin/import?site=remark42&provider=native", strings.NewReader(body))
 	require.NoError(t, err)
 	req.SetBasicAuth("admin", "password")
 	assert.NoError(t, err)


### PR DESCRIPTION
`TestMigrator_ImportDouble` failed on CI with `race detected during execution of test`, on a branch that touches nothing it exercises. The race is real and lives in the test.

It passes a single `strings.Reader` as the body of both POSTs. `client.Do` returns once the response headers arrive, and an accepted import answers 202 well before the transport has finished copying the body, so the second `http.NewRequest` reads the reader's `Len` to set `ContentLength` while the first request's `writeLoop` is still advancing the same reader. CI reported it as a write in `strings.(*Reader).WriteTo` from `persistConn.writeLoop` against a read in `NewRequestWithContext` at the second `NewRequest`.

It does not reproduce in this package locally, which is why it reads as a flake: thirty runs under `-race`, including with `GOMAXPROCS=2`, all clean. So I reproduced the mechanism in isolation instead of trusting the trace. A handler that answers 202 without draining an 8 MiB body, two requests sharing one reader, and `-race` reports `strings.(*Reader).Len` inside `NewRequestWithContext` against `strings.(*Reader).Read` on every run.

Both requests now build their own reader over the same content. One behavioural note: the second request previously inherited an already-consumed reader and so sent an empty body, and now sends a full one. That is closer to what the case is checking, since a second import arriving while the first is still running has to be refused whatever it carries, and the assertion on `StatusConflict` is unchanged.

Test-only.