### PR TITLE
Measure the Safari column on Safari, and fix two sentences it makes false

### DIFF
--- a/site/content/docs/manuals/separate-domain/index.md
+++ b/site/content/docs/manuals/separate-domain/index.md
@@ -12,9 +12,9 @@ Unless discussion [#1139](https://github.com/umputun/remark42/discussions/1139) 
 
 Set `ALLOWED_HOSTS="'self',https://example1.org,https://example2.org"` with your domain names, and `AUTH_SEND_JWT_HEADER=true`.
 
-`AUTH_SEND_JWT_HEADER` is what keeps a reader signed in across a page reload on Safari, in Chrome Incognito, and in any browser configured to block third-party cookies. Read [its security considerations](../../configuration/parameters/#security-considerations-for-authsend-jwt-header) before enabling it: it puts the token in a cookie JavaScript can read, which costs XSS exposure that a server-set `HttpOnly` cookie does not.
+`AUTH_SEND_JWT_HEADER` is what keeps a reader signed in across a page reload on Safari, in Chrome Incognito, and in Chrome configured to block third-party cookies. The one setting it does not survive is Firefox's "block all third-party cookies", which discards partitioned cookies as well, and which no configuration survives. Read [its security considerations](../../configuration/parameters/#security-considerations-for-authsend-jwt-header) before enabling it: it puts the token in a cookie JavaScript can read, which costs XSS exposure that a server-set `HttpOnly` cookie does not.
 
-**`AUTH_SAME_SITE=none` is not needed alongside it**, which reverses what this page recommended for years, so it is worth showing the measurement instead of asserting it. Signing in anonymously from an embedded widget over https and dumping the browser's cookie jar gives, with the setting:
+**`AUTH_SAME_SITE=none` is not needed alongside it**, which reverses what this page recommended for years, so it is worth showing the measurement instead of asserting it. Signing in anonymously from an embedded widget over https on Chromium with its default third-party cookie policy, and dumping the browser's cookie jar, gives with the setting:
 
 | name | httpOnly | partition key | written by |
 | --- | --- | --- | --- |
@@ -37,7 +37,7 @@ The `'self'` in `ALLOWED_HOSTS` value means "domain where Remark42 is installed 
 
 The `default` setting does not mean `Lax`. It means Remark42 emits no `SameSite` attribute at all and leaves the choice to the browser, and browsers differ: Chromium treats a missing attribute as `Lax` and so refuses the cookie cross-site, while Firefox accepts it. That difference is not a detail, because it decides which of the two cookie pairs below a reader actually ends up with.
 
-`SameSite=None` is not sufficient on its own, and with `AUTH_SEND_JWT_HEADER` it is not necessary either. A browser that blocks third-party cookies drops a cookie set by Remark42 for a reader on another domain no matter what its `SameSite` value is, unless the cookie is explicitly marked [`Partitioned`](https://developer.mozilla.org/en-US/docs/Web/Privacy/Privacy_sandbox/Partitioned_cookies), and the server-set cookies are not. `AUTH_SEND_JWT_HEADER=true` is what closes that: the token comes back in an `X-JWT` response header and the widget stores it in its own cookie, written from inside the embedded frame and marked `SameSite=None; Secure; Partitioned`, so the browser keeps it for that embedding site and sends it back after a reload. That cookie is the widget's own doing and owes nothing to `AUTH_SAME_SITE`, which reaches only the pair the server sets.
+`SameSite=None` is not sufficient on its own, and with `AUTH_SEND_JWT_HEADER` it is not necessary either. A browser that blocks third-party cookies drops a cookie set by Remark42 for a reader on another domain no matter what its `SameSite` value is, unless the cookie is explicitly marked [`Partitioned`](https://developer.mozilla.org/en-US/docs/Web/Privacy/Privacy_sandbox/Partitioned_cookies), and the server-set cookies are not. `AUTH_SEND_JWT_HEADER=true` is what closes that: the token comes back in an `X-JWT` response header and the widget stores it in its own cookie, written from inside the embedded frame and marked `SameSite=None; Secure; Partitioned`, so the browser keeps it for that embedding site and sends it back after a reload. That cookie is the widget's own doing and owes nothing to `AUTH_SAME_SITE`, which reaches only the pair the server sets. The exception is Firefox's "block all third-party cookies", which discards partitioned cookies too, so the flag closes nothing there and no configuration does.
 
 A browser that refuses a cross-site `Set-Cookie` lacking `SameSite=None` refuses it outright, so with the setting left at its default the server's pair is absent from the jar, not present with a stricter attribute.
 
@@ -46,21 +46,27 @@ Note that this applies to Email, Telegram and anonymous authorisation, which the
 ### What each browser actually does
 
 Measured on real domains over real certificates, with Remark42 on one registrable domain and the
-host page on another, signing in and then reloading. Every "blocked" column below was verified with
-a control cookie: an ordinary third-party cookie written from inside the widget frame has to be
-dropped, or the run is not blocking anything and proves nothing.
+host page on another, signing in and then reloading. Chrome and Firefox were driven through
+Playwright, Safari 27 through its own WebDriver, so the Safari column is Safari itself and not an
+approximation of it. Every "blocked" column below was verified with a control cookie: an ordinary
+third-party cookie written from inside the widget frame has to be dropped, or the run is not
+blocking anything and proves nothing.
 
 | configuration | Chrome, default | Chrome, third-party cookies blocked | Firefox, default | Firefox, "block all third-party" | Safari |
 | --- | --- | --- | --- | --- | --- |
+| neither set | fails | fails | works | fails | fails |
 | `AUTH_SEND_JWT_HEADER` only | works | works | works | fails | works |
 | `AUTH_SAME_SITE=none` only | works | fails | works | fails | fails |
 | both | works | works | works | fails | works |
 
-Three things in that table are worth spelling out.
+Four things in that table are worth spelling out.
+
+**Firefox keeps a reader signed in with nothing configured at all.** Its Total Cookie Protection files the server's attribute-less cookie under the embedding site's partition instead of refusing it, so Email, Telegram and anonymous authorisation survive a reload cross-domain on a stock Firefox with neither variable set. No other browser measured here does that: Chrome sends no `SameSite` attribute by default and treats the cookie as `Lax`, and Safari blocks it as third-party. Do not read that row as a recommendation, since it holds on one engine and breaks the moment the reader turns on "block all third-party cookies".
 
 **Safari needs no configuring to break the old recipe.** It blocks third-party cookies out of the
-box, so `AUTH_SAME_SITE=none` on its own has already stopped working there for every reader. This
-is not a future deprecation to plan for.
+box while still honouring `Partitioned`, so `AUTH_SAME_SITE=none` on its own has already stopped
+working there for every reader. This is not a future deprecation to plan for. With the header flag
+the widget's own partitioned cookie is readable in the frame and the session survives the reload.
 
 **Firefox reaches "works" by a different route, and a weaker one.** Chrome and Safari refuse the
 server's cookie when it carries no `SameSite` attribute, which leaves the field clear for the
@@ -76,8 +82,8 @@ it on cannot stay signed in on an embedded widget, and nothing in Remark42 can c
 
 Here are all possible combinations of these two:
 
-- Default setup with unaltered variables: comments are shown on any domain, but the authorisation wouldn't work anywhere, except on the same domain Remark42 is installed on and subdomains of it.
-- `ALLOWED_HOSTS` set to a set of domains: comments are shown only on listed domains, and authorisation wouldn't work anywhere, except on the same domain Remark42 is installed on and subdomains of it.
+- Default setup with unaltered variables: comments are shown on any domain, and the authorisation wouldn't work anywhere, except on the same domain Remark42 is installed on and subdomains of it, and on Firefox with its default settings. Firefox stores the server's attribute-less cookie in a per-site partition instead of refusing it, so Email, Telegram and anonymous authorisation survive a reload cross-domain there with neither variable set. Every other browser measured below refuses that cookie cross-site.
+- `ALLOWED_HOSTS` set to a set of domains: comments are shown only on listed domains, and authorisation wouldn't work anywhere, except on the same domain Remark42 is installed on and subdomains of it, and on Firefox with its default settings, for the reason above.
 - `AUTH_SAME_SITE` set to `None`: comments are shown on any domain. Authorisation works on browsers that still permit third-party cookies, and stops working on the ones that block them.
 - `ALLOWED_HOSTS` set to a set of domains and `AUTH_SAME_SITE` set to `None`: comments are shown on listed domains, with the same authorisation caveat.
-- `ALLOWED_HOSTS` and `AUTH_SEND_JWT_HEADER=true`, with `AUTH_SAME_SITE` left alone: comments are shown on listed domains, and Email, Telegram and anonymous authorisation survives a reload whatever the browser's third-party cookie policy. This is the recommended arrangement. Adding `AUTH_SAME_SITE=none` on top changes nothing about whether a reader stays signed in; it only adds the server's unpartitioned cookies where the browser still takes them.
+- `ALLOWED_HOSTS` and `AUTH_SEND_JWT_HEADER=true`, with `AUTH_SAME_SITE` left alone: comments are shown on listed domains, and Email, Telegram and anonymous authorisation survives a reload under every third-party cookie policy except Firefox's "block all third-party cookies", which no configuration survives. This is the recommended arrangement. Adding `AUTH_SAME_SITE=none` on top changes nothing about whether a reader stays signed in; it only adds the server's unpartitioned cookies where the browser still takes them.


### PR DESCRIPTION
Two things against `manuals/separate-domain`, both following from #2222.

**The Safari column is now Safari, not WebKit.** That table measured WebKit through Playwright, which is Safari's engine but not Safari: ITP sits above WebKit and could plausibly have been stricter, and the table did not say which had been measured. Driven through Safari 27's own WebDriver against the same rig, all three configurations match the WebKit result exactly. A useful side effect is that the e2e suite's existing WebKit coverage is now a measured proxy for Safari on this behaviour instead of an assumed one.

Evidence for the recommended configuration, read from inside the widget frame on real Safari with blocking confirmed by a control cookie: `document.cookie` returns the partitioned sentinel and a JS-readable `JWT`, which is the widget's own cookie rather than the server's `HttpOnly` one, while the ordinary third-party control written beside them is gone. Sign-in succeeds and the reload keeps the reader signed in. On `AUTH_SAME_SITE=none` alone the reload fails, with nothing configured on the browser side.

**Two sentences that #2222 made false.** Both predate it and both are on master, so they currently contradict the table three lines away from them. One said the header flag keeps a reader signed in in any browser configured to block third-party cookies; the other said the recommended arrangement survives a reload whatever the browser's third-party cookie policy. Firefox's "block all third-party cookies" is the exception to both, because it discards partitioned cookies as well, and no configuration survives it. Both are now scoped to that case, so the table, the prose and the Firefox paragraph agree.

umputun offered to take these himself; folding them in here since this branch was already editing the file.

Documentation only, one file.
