### PR TITLE
Stop prefixing the instance origin onto an already absolute asset url

### DIFF
--- a/e2e/assets_test.go
+++ b/e2e/assets_test.go
@@ -81,3 +81,60 @@ func TestAssets_WidgetRunsOnTheCompiledInURL(t *testing.T) {
 		"the widget addressed %q rather than this instance", configURL)
 	assert.NotContains(t, configURL, remarkURLPlaceholder)
 }
+
+// TestAssets_WidgetImagesActuallyLoad covers a class of defect the unit suite structurally cannot
+// see. Asset URLs come from webpack's public path, and the jest stub for `.svg` returns a relative
+// string, so a component that prefixes an already-absolute asset URL with the instance origin
+// looks right under test and ships a doubled URL. That is how the oauth provider icons and the
+// ghost avatar came to 404 on every master build: `${BASE_URL}${icon}` produced
+// `https://hosthttps://host/web/google.svg`.
+//
+// naturalWidth is the discriminator. A broken <img> still exists in the DOM with its src attribute
+// intact, so asserting the element or the attribute proves nothing; only a decoded image has a
+// non-zero natural size. That catches a 404, a malformed URL and a CSP refusal alike.
+func TestAssets_WidgetImagesActuallyLoad(t *testing.T) {
+	page := newPage(t)
+
+	pauseForAuthLimit()
+	_, err := page.Goto(threadURL(t))
+	require.NoError(t, err)
+
+	frame := page.FrameLocator("#remark42 iframe")
+
+	// the auth panel is where the provider icons live, and they are the case that regressed
+	require.NoError(t, frame.Locator(".auth-button").Click())
+	waitVisible(t, frame.Locator(".auth-dropdown"))
+	waitVisible(t, frame.Locator(".oauth-icon").First())
+
+	report, err := frame.Locator(":root").Evaluate(`() => {
+		const imgs = [...document.querySelectorAll('img')];
+		return imgs.map(i => ({
+			src: i.getAttribute('src') || '',
+			loaded: i.complete && i.naturalWidth > 0,
+		}));
+	}`, nil)
+	require.NoError(t, err)
+
+	entries, ok := report.([]any)
+	require.True(t, ok, "unexpected probe shape %T", report)
+	require.NotEmpty(t, entries, "no images in the widget, so this asserts nothing")
+
+	checked := 0
+	for _, e := range entries {
+		m, ok := e.(map[string]any)
+		require.True(t, ok)
+		src, _ := m["src"].(string)
+		loaded, _ := m["loaded"].(bool)
+		if src == "" {
+			continue
+		}
+		checked++
+
+		// the doubling is worth naming separately, because "did not load" alone sends the reader
+		// looking at the file rather than at the url that asked for it
+		assert.LessOrEqual(t, strings.Count(src, "://"), 1,
+			"image url carries more than one origin, so something prefixed an absolute asset url: %s", src)
+		assert.True(t, loaded, "image did not load: %s", src)
+	}
+	require.NotZero(t, checked, "every image had an empty src, so nothing was checked")
+}

--- a/frontend/apps/remark42/app/__stubs__/svg.tsx
+++ b/frontend/apps/remark42/app/__stubs__/svg.tsx
@@ -1,3 +1,6 @@
-const SvgrUrl = '/image.svg';
+// the real build resolves an svg import through webpack's public path, which is absolute at
+// runtime. a relative stub hides a component that prefixes the instance origin onto an already
+// absolute asset url: the concatenation looks right here and ships a doubled url
+const SvgrUrl = 'http://localhost:8080/web/image.svg';
 
 export default SvgrUrl;

--- a/frontend/apps/remark42/app/components/auth/components/oauth.tsx
+++ b/frontend/apps/remark42/app/components/auth/components/oauth.tsx
@@ -41,7 +41,7 @@ export function OAuth({ providers, onOauthClick }: Props) {
               data-provider-name={name}
               title={intl.formatMessage(messages.oauthTitle, { provider: name })}
             >
-              <img className="oauth-icon" src={`${BASE_URL}${icon}`} width="20" height="20" alt="" aria-hidden={true} />
+              <img className="oauth-icon" src={icon} width="20" height="20" alt="" aria-hidden={true} />
             </a>
           </li>
         );

--- a/frontend/apps/remark42/app/components/avatar/avatar.spec.tsx
+++ b/frontend/apps/remark42/app/components/avatar/avatar.spec.tsx
@@ -2,13 +2,13 @@ import '@testing-library/jest-dom';
 import { render } from '@testing-library/preact';
 
 import { Avatar } from './avatar';
-import { BASE_URL } from 'common/constants.config';
 
 describe('<Avatar/>', () => {
   it('should have correct url', () => {
     const { container } = render(<Avatar />);
 
-    expect(container.querySelector('img')).toHaveAttribute('src', `${BASE_URL}/image.svg`);
+    // the asset url already carries the public path; prefixing BASE_URL onto it doubles the origin
+    expect(container.querySelector('img')).toHaveAttribute('src', 'http://localhost:8080/web/image.svg');
   });
 
   it("shouldn't be accessible with screen reader", () => {

--- a/frontend/apps/remark42/app/components/avatar/avatar.tsx
+++ b/frontend/apps/remark42/app/components/avatar/avatar.tsx
@@ -1,8 +1,6 @@
 import clsx from 'clsx';
 import { h } from 'preact';
 
-import { BASE_URL } from 'common/constants.config';
-
 import ghostIconUrl from './assets/ghost.svg';
 import styles from './avatar.module.css';
 
@@ -11,7 +9,7 @@ type Props = {
 };
 
 export function Avatar({ url }: Props) {
-  const avatarUrl = url || `${BASE_URL}${ghostIconUrl}`;
+  const avatarUrl = url || ghostIconUrl;
 
   return (
     // eslint-disable-next-line jsx-a11y/alt-text


### PR DESCRIPTION
The oauth provider icons and the ghost avatar fail to load on every `master` build since #2197. Reported from a live instance; the screenshot is three empty circles where the provider icons belong.

**What happens.** Both components build their `src` as `${BASE_URL}${icon}`, where `icon` comes from a webpack `require` of an svg. That was correct while `output.publicPath` was the fixed `/web/`, because the require then resolved to a relative `/web/name.svg` and the concatenation produced exactly one origin. #2197 changed it to `'auto'`, which the runtime resolves to an absolute url at bootstrap, so the same expression now yields `https://hosthttps://host/web/google.svg`.

**Blast radius.** Every `master` build, embedded or same-domain, since `'auto'` resolves absolute either way. No release is affected: `git tag --contains` returns nothing for #2197, and the newest tag still carries the fixed public path. So it is `:master` users only.

**Why nothing caught it.** The jest stub at `app/__stubs__/svg.tsx` returns a relative `/image.svg`, so a component prefixing the origin onto an asset url looks correct under test while being wrong in every real build. The avatar spec asserted the doubled form as the contract. The stub now returns an absolute url like the real thing, which makes that spec fail the moment the prefix returns; verified by putting it back.

**The durable guard is e2e**, because only e2e sees real asset urls. `TestAssets_WidgetImagesActuallyLoad` opens the auth panel and checks every image in the widget document. It asserts `naturalWidth`, not the presence of the element or its `src`, since a broken `<img>` keeps both and asserting either proves nothing. It separately asserts no url carries more than one `://`, so a recurrence names its cause rather than its symptom.

Mutation-checked both ways. With the prefix restored the e2e test fails with `image url carries more than one origin ... http://remark42:8080http://remark42:8080/web/dev.svg` and the unit spec fails alongside it; with the fix in place both pass.
