### PR TITLE
Say what the auth limiter is actually keyed by

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -142,9 +142,14 @@ var (
 	}
 )
 
-// Everything under /auth/ is a token bucket refilling twice a second per instance and client IP.
-// Each browser context has its own forwarded IP, so one refill interval is enough between auth
-// actions by the same reader. Fresh contexts need no delay because their bucket starts full.
+// Everything under /auth/ is a token bucket refilling twice a second, keyed by instance, client IP
+// and request path, with a burst equal to the rate. Each browser context has its own forwarded IP,
+// so one refill interval is enough between repeat requests by one reader to one path, and two
+// paths never compete.
+//
+// The sleep is unconditional at every call site. A fresh context starts with a full bucket and
+// needs none of it, so most of these are paid for nothing; the ones that earn it are the repeated
+// requests inside a single context, and the probeClient calls this process makes to /auth/.
 func pauseForAuthLimit() {
 	time.Sleep(600 * time.Millisecond)
 }


### PR DESCRIPTION
The comment on `pauseForAuthLimit` describes the `/auth/` token bucket as keyed by instance and client IP. Tollbooth builds the key from the client IP and the request path, joined, and sets the burst to the rate, so a refill interval covers repeat requests by one reader to one path and two paths never compete at all.

The same comment says a fresh context needs no delay, while all thirteen call sites sleep unconditionally. Both statements are true and they read as a contradiction; the comment now says which calls the sleep is there for, namely repeat requests inside one context and the `/auth/` probes this process makes itself.

Comment only, no behaviour change.