### PR TITLE
Claim a site before accepting its migration, and clean up a failed upload

### DIFF
--- a/backend/app/rest/api/migrator.go
+++ b/backend/app/rest/api/migrator.go
@@ -48,11 +48,17 @@ type KeyStore interface {
 func (m *Migrator) importCtrl(w http.ResponseWriter, r *http.Request) {
 	siteID := r.URL.Query().Get("site")
 
-	if m.isBusy(siteID) {
+	if !m.setBusyIfFree(siteID) {
 		rest.SendErrorJSON(w, r, http.StatusConflict, fmt.Errorf("already running"),
 			"import rejected", rest.ErrActionRejected)
 		return
 	}
+	handedOff := false
+	defer func() {
+		if !handedOff {
+			m.clearBusy(siteID)
+		}
+	}()
 
 	tmpfile, err := m.saveTemp(r.Body)
 	if err != nil {
@@ -60,7 +66,8 @@ func (m *Migrator) importCtrl(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	go m.runImport(siteID, r.URL.Query().Get("provider"), tmpfile) // import runs in background and sets busy flag for site
+	handedOff = true
+	go m.runImport(siteID, r.URL.Query().Get("provider"), tmpfile)
 
 	_ = R.EncodeJSON(w, http.StatusAccepted, R.JSON{"status": "import request accepted"})
 }
@@ -70,11 +77,17 @@ func (m *Migrator) importCtrl(w http.ResponseWriter, r *http.Request) {
 func (m *Migrator) importFormCtrl(w http.ResponseWriter, r *http.Request) {
 	siteID := r.URL.Query().Get("site")
 
-	if m.isBusy(siteID) {
+	if !m.setBusyIfFree(siteID) {
 		rest.SendErrorJSON(w, r, http.StatusConflict, fmt.Errorf("already running"),
 			"import rejected", rest.ErrActionRejected)
 		return
 	}
+	handedOff := false
+	defer func() {
+		if !handedOff {
+			m.clearBusy(siteID)
+		}
+	}()
 
 	r.Body = http.MaxBytesReader(w, r.Body, 256*1024*1024) // hard cap on upload to prevent memory exhaustion
 	reader, err := r.MultipartReader()
@@ -114,7 +127,8 @@ func (m *Migrator) importFormCtrl(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	go m.runImport(siteID, r.URL.Query().Get("provider"), tmpfile) // import runs in background and sets busy flag for site
+	handedOff = true
+	go m.runImport(siteID, r.URL.Query().Get("provider"), tmpfile)
 
 	_ = R.EncodeJSON(w, http.StatusAccepted, R.JSON{"status": "import request accepted"})
 }
@@ -204,11 +218,15 @@ func (m *Migrator) remapCtrl(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer r.Body.Close() //nolint gosec // we don't care about response body
+	if !m.setBusyIfFree(siteID) {
+		rest.SendErrorJSON(w, r, http.StatusConflict, fmt.Errorf("already running"),
+			"remap rejected", rest.ErrActionRejected)
+		return
+	}
 
 	// start remap procedure with mapper
 	go func() {
-		m.setBusy(siteID, true)
-		defer m.setBusy(siteID, false)
+		defer m.clearBusy(siteID)
 
 		// do export
 		fh, e := os.CreateTemp("", "remark42_convert")
@@ -249,10 +267,8 @@ func (m *Migrator) remapCtrl(w http.ResponseWriter, r *http.Request) {
 
 // runImport reads from tmpfile and import for given siteID and provider
 func (m *Migrator) runImport(siteID, provider, tmpfile string) {
-	m.setBusy(siteID, true)
-
 	defer func() {
-		m.setBusy(siteID, false)
+		m.clearBusy(siteID)
 		if err := os.Remove(tmpfile); err != nil {
 			log.Printf("[WARN] failed to remove tmp file %s, %v", tmpfile, err)
 		}
@@ -292,6 +308,13 @@ func (m *Migrator) saveTemp(r io.Reader) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("can't make temp file: %w", err)
 	}
+	keep := false
+	defer func() {
+		if !keep {
+			_ = tmpfile.Close()
+			_ = os.Remove(tmpfile.Name())
+		}
+	}()
 
 	if _, err = io.Copy(tmpfile, r); err != nil {
 		return "", fmt.Errorf("can't copy to temp file: %w", err)
@@ -301,7 +324,23 @@ func (m *Migrator) saveTemp(r io.Reader) (string, error) {
 		return "", fmt.Errorf("can't close temp file: %w", err)
 	}
 
+	keep = true
 	return tmpfile.Name(), nil
+}
+
+// setBusyIfFree claims a site's migration slot. The handler calls it before starting background
+// work, so wait and competing requests see the operation as soon as its acceptance is returned.
+func (m *Migrator) setBusyIfFree(siteID string) bool {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	if m.busy == nil {
+		m.busy = map[string]bool{}
+	}
+	if m.busy[siteID] {
+		return false
+	}
+	m.busy[siteID] = true
+	return true
 }
 
 // isBusy checks busy flag from the map by siteID as key
@@ -314,12 +353,12 @@ func (m *Migrator) isBusy(siteID string) bool {
 	return m.busy[siteID]
 }
 
-// setBusy sets/resets busy flag to the map by siteID as key
-func (m *Migrator) setBusy(siteID string, status bool) {
+// clearBusy releases a site's migration slot
+func (m *Migrator) clearBusy(siteID string) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	if m.busy == nil {
 		m.busy = map[string]bool{}
 	}
-	m.busy[siteID] = status
+	m.busy[siteID] = false
 }

--- a/backend/app/rest/api/migrator_test.go
+++ b/backend/app/rest/api/migrator_test.go
@@ -21,6 +21,86 @@ import (
 	"github.com/umputun/remark42/backend/app/store/service"
 )
 
+type gatedReadError struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (r *gatedReadError) Read([]byte) (int, error) {
+	close(r.started)
+	<-r.release
+	return 0, io.ErrUnexpectedEOF
+}
+
+type immediateReadError struct{}
+
+func (immediateReadError) Read([]byte) (int, error) { return 0, io.ErrUnexpectedEOF }
+
+func TestMigrator_ImportClaimsSiteWhileReadingBody(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("TMPDIR", tempDir)
+	m := Migrator{}
+	firstBody := &gatedReadError{started: make(chan struct{}), release: make(chan struct{})}
+	firstDone := make(chan struct{})
+
+	go func() {
+		defer close(firstDone)
+		m.importCtrl(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/?site=remark42", firstBody))
+	}()
+
+	select {
+	case <-firstBody.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the first import did not start reading its body")
+	}
+
+	competing := httptest.NewRecorder()
+	m.importCtrl(competing, httptest.NewRequest(http.MethodPost, "/?site=remark42", immediateReadError{}))
+
+	close(firstBody.release)
+	select {
+	case <-firstDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the first import did not return after its body failed")
+	}
+	require.Equal(t, http.StatusConflict, competing.Code, "a concurrent import acquired the same site")
+	require.False(t, m.isBusy("remark42"), "a failed upload kept the migration slot")
+	entries, err := os.ReadDir(tempDir)
+	require.NoError(t, err)
+	require.Empty(t, entries, "a failed upload left its temporary file behind")
+}
+
+func TestMigrator_ImportFormClaimsSiteWhileReadingBody(t *testing.T) {
+	m := Migrator{}
+	firstBody := &gatedReadError{started: make(chan struct{}), release: make(chan struct{})}
+	firstDone := make(chan struct{})
+	firstRequest := httptest.NewRequest(http.MethodPost, "/?site=remark42", firstBody)
+	firstRequest.Header.Set("Content-Type", "multipart/form-data; boundary=test-boundary")
+
+	go func() {
+		defer close(firstDone)
+		m.importFormCtrl(httptest.NewRecorder(), firstRequest)
+	}()
+
+	select {
+	case <-firstBody.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the first form import did not start reading its body")
+	}
+
+	competing := httptest.NewRecorder()
+	m.importCtrl(competing, httptest.NewRequest(http.MethodPost, "/?site=remark42", immediateReadError{}))
+
+	close(firstBody.release)
+	select {
+	case <-firstDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the first form import did not return after its body failed")
+	}
+	require.Equal(t, http.StatusConflict, competing.Code, "a concurrent import acquired the same site")
+	require.False(t, m.isBusy("remark42"), "a rejected form upload kept the migration slot")
+}
+
 func TestMigrator_Import(t *testing.T) {
 	ts, _, teardown := startupT(t)
 	defer teardown()
@@ -573,7 +653,7 @@ func TestMigrator_Remap(t *testing.T) {
 }
 
 func TestMigrator_RemapReject(t *testing.T) {
-	ts, _, teardown := startupT(t)
+	ts, srv, teardown := startupT(t)
 	defer teardown()
 
 	// without admin credentials
@@ -586,6 +666,13 @@ func TestMigrator_RemapReject(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
 	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	require.True(t, srv.Migrator.setBusyIfFree("remark42"))
+	t.Cleanup(func() { srv.Migrator.clearBusy("remark42") })
+	resp, err = post(t, ts.URL+"/api/v1/admin/remap?site=remark42", "https://remark42.com/* https://www.remark42.com/*")
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusConflict, resp.StatusCode)
 }
 
 func waitForMigrationCompletion(t *testing.T, ts *httptest.Server) {


### PR DESCRIPTION
Two requests could start a migration for the same site at once, and a failed upload left a temporary file behind.

## The race

`Migrator` already tracks a busy site behind a mutex, but the handlers checked and claimed in two steps: `isBusy` first, then acceptance returned, and only the background `runImport` set the flag. Between the check and that goroutine running, a second request saw the site as free and was accepted too, so both imported into the same site.

`setBusyIfFree` makes that a single compare-and-set under the lock the type already has, and the handlers call it before returning acceptance. `remapCtrl` never claimed at all and now does. The slot is released by the background work as before, and by the handler itself if it fails before handing off, so a rejected upload does not strand the site.

**A behaviour change worth knowing about**: another migration for the same site is refused with `409` from the start of the upload until the upload and import finish, or until reading the upload fails. Previously the window began only when the import did. The endpoint is administrator-only and the multipart body is capped at 256 MiB, which is what makes holding the slot for the upload the right trade against overlapping writes.

## The temporary file

`saveTemp` returned early when `io.Copy` failed, leaving the partial file on disk with its descriptor open. It now closes and removes an incomplete file on every failure path.

## Tests

The regression test blocks a handler between its claim and the hand-off, fires a competing request, and asserts both the `409` and that the slot is released afterwards. Raw and multipart uploads are covered on the claim and on the release, `remapCtrl` has an assertion against an occupied slot, and the temporary directory is checked for leftovers.

Each was mutation-checked separately: restoring the check-then-set ordering, removing the failed-upload release, dropping the remap claim, and removing the `saveTemp` cleanup each fail the case that names them.

`go test -race`, `golangci-lint`, `go build` and `gofmt` pass.
