### PR TITLE
Report what the browser suite reaches in the backend

### DIFF
--- a/.github/workflows/ci-compose.yml
+++ b/.github/workflows/ci-compose.yml
@@ -36,7 +36,12 @@ jobs:
           while IFS= read -r -d '' f; do
             docker compose -f "$f" config --quiet
             n=$((n + 1))
-          done < <(git ls-files -z '*compose*.yml' '*compose*.yaml' ':!:*/vendor/*' ':!:.github/*')
+          done < <(git ls-files -z '*compose*.yml' '*compose*.yaml' ':!:*/vendor/*' ':!:.github/*' ':!:compose-e2e-coverage.yml')
+          # compose-e2e-coverage.yml is an overlay: its services carry no image and no build
+          # context of their own, so it parses only merged onto the base it extends, which is
+          # the only way anything runs it
+          docker compose -f compose-e2e-test.yml -f compose-e2e-coverage.yml config --quiet
+          n=$((n + 1))
           if [ "$n" -eq 0 ]; then
             echo "no compose files found" >&2
             exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ http-client.env.json
 
 # self-signed certificate for the e2e https services, made by e2e/tls/generate.sh
 /e2e/tls/*.pem
+
+# profiles from `make e2e-cover`
+e2e/coverage/

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,10 +77,20 @@ RUN \
       echo "skip backend tests and linter" \
     ; fi
 
+# COVERAGE builds an instrumented binary that writes a profile to GOCOVERDIR as it exits, which
+# is what lets the e2e suite report what it reached. It is an argument and not an environment
+# variable because the instrumented binary is a different build, and it must not be what a
+# published image ships.
+ARG COVERAGE
+
 RUN \
     version="$(/script/version.sh)" && \
     echo "version=$version" && \
-    go build -o remark42 -ldflags "-X main.revision=${version} -s -w" ./app
+    if [ "$COVERAGE" = "1" ] ; then \
+        go build -cover -covermode=atomic -coverpkg=./... -o remark42 -ldflags "-X main.revision=${version}" ./app ; \
+    else \
+        go build -o remark42 -ldflags "-X main.revision=${version} -s -w" ./app ; \
+    fi
 
 FROM umputun/baseimage:app-v1.17.0
 

--- a/Makefile
+++ b/Makefile
@@ -56,4 +56,10 @@ e2e:
 e2e-ui:
 	cd e2e && E2E_HEADLESS=false E2E_KEEP=1 go test -tags=e2e -count 1 -parallel 4 -v -timeout 20m ./...
 
-.PHONY: bin docker dockerx release race_test backend frontend rundev e2e e2e-up e2e-down e2e-ui
+# what the browser suite reaches in the backend, which the unit profile cannot show: the code runs
+# in a container, so it is measured by instrumenting the binary instead of the test process.
+# compose-e2e-coverage.yml is the overlay that does it, and it names the instrumented instances
+e2e-cover:
+	./e2e/coverage.sh
+
+.PHONY: bin docker dockerx release race_test backend frontend rundev e2e e2e-up e2e-down e2e-ui e2e-cover

--- a/compose-e2e-coverage.yml
+++ b/compose-e2e-coverage.yml
@@ -1,0 +1,55 @@
+# coverage overlay for the e2e stack, used only by `make e2e-cover`.
+#
+# Kept out of compose-e2e-test.yml on purpose. A bind mount in the short form creates its host
+# path if it is missing, so carrying these in the base file would have an ordinary `make e2e`
+# create e2e/coverage itself, owned by whatever the daemon runs as. A plain run must leave no
+# trace of coverage at all.
+#
+# Only the first service carries the build argument: every instance runs the one image the first
+# builds, so instrumenting it instruments all of them.
+
+services:
+  remark42:
+    build:
+      args:
+        - COVERAGE=1
+    environment:
+      - GOCOVERDIR=/coverage
+    volumes:
+      - ./e2e/coverage/remark42:/coverage
+
+  remark42-shortedit:
+    environment:
+      - GOCOVERDIR=/coverage
+    volumes:
+      - ./e2e/coverage/remark42-shortedit:/coverage
+
+  remark42-adminedit:
+    environment:
+      - GOCOVERDIR=/coverage
+    volumes:
+      - ./e2e/coverage/remark42-adminedit:/coverage
+
+  remark42-jwtheader:
+    environment:
+      - GOCOVERDIR=/coverage
+    volumes:
+      - ./e2e/coverage/remark42-jwtheader:/coverage
+
+  remark42-noauth:
+    environment:
+      - GOCOVERDIR=/coverage
+    volumes:
+      - ./e2e/coverage/remark42-noauth:/coverage
+
+  remark42-anonvote:
+    environment:
+      - GOCOVERDIR=/coverage
+    volumes:
+      - ./e2e/coverage/remark42-anonvote:/coverage
+
+  remark42-https:
+    environment:
+      - GOCOVERDIR=/coverage
+    volumes:
+      - ./e2e/coverage/remark42-https:/coverage

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -43,6 +43,55 @@ Rate-limit responses are logged whether or not `E2E_DEBUG` is set, because they 
 
 The build tag keeps these out of `go test ./...`; nothing runs without `-tags=e2e`.
 
+## Coverage
+
+```
+make e2e-cover
+```
+
+Reports what the suite reaches in the backend. The code under test runs in a container instead of
+in the test process, so `go test -cover` cannot see it; `compose-e2e-coverage.yml` overlays the
+stack to build the image with `go build -cover` and mount a profile directory per instance, and
+`e2e/coverage.sh` runs the suite, stops the instances so the profiles flush, merges them into
+`e2e/coverage/e2e.cov` and prints the total.
+
+The overlay is a separate file because a bind mount in the short form creates its host path when
+it is missing. Carried in `compose-e2e-test.yml`, it would have an ordinary `make e2e` create
+`e2e/coverage` itself, owned by whatever the daemon runs as. A plain run leaves no trace of
+coverage, and `compose-e2e-test.yml` is what a plain run uses.
+
+Three ways this could report nothing and still look like a result, so each one fails instead:
+
+- **A killed instance writes no profile.** The instances are asked to stop with a 30 second grace,
+  and every directory is then checked rather than the total, because six clean exits and one kill
+  merge into a plausible report with that instance's code reading as unreached. The failure names
+  the services that produced nothing.
+- **A failing suite still has coverage worth keeping.** The run's exit status is preserved, but the
+  instances are stopped and the profiles merged either way, so the run that most needed explaining
+  is not the one that discards its evidence.
+- **A plain stack answers for an instrumented one.** `E2E_COVERAGE` feeds `e2e/stamp.sh` as well as
+  the image build, so the two stacks carry different stamps and the suite refuses the one it was
+  not built for. Only the value `1` instruments, in the stamp and in the Dockerfile alike, so
+  `E2E_COVERAGE=0` is the plain build and not a third variant.
+
+The profile is written in `atomic` mode and with the same `_mock.go` exclusion the unit run
+applies, so the two are one population and can be reported as a single figure. Appending it to the
+unit profile without repeating the `mode:` header is enough:
+
+```
+cat profile.cov > combined.cov && tail -n +2 e2e/coverage/e2e.cov >> combined.cov
+cd backend && go tool cover -func=../combined.cov
+```
+
+The read has to run from `backend/`. `covdata` writes file names as full import paths, and
+`go tool cover` resolves them through `go list`, so from the repository root, which has no
+`go.mod`, it reports that no module provides the package instead of anything about coverage.
+
+`atomic` is also the only mode `-race` accepts, so the instrumented build stays compatible if the
+binary is ever built with it.
+
+The instrumented binary is a build argument and never what a published image ships.
+
 ## When something fails
 
 A failed test writes a Playwright trace to `e2e/traces/`, which CI uploads as an artifact. Nothing else writes one, so a run carrying the artifact is a run with a failure to look at. Open one with `npx playwright show-trace e2e/traces/<name>.zip`.

--- a/e2e/coverage.sh
+++ b/e2e/coverage.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+# Statement coverage of the backend as the browser suite exercises it.
+#
+# The code under test runs in a container instead of in the test process, so `go test -cover`
+# cannot see it. The image is built with `go build -cover` instead, each instance writes a profile
+# to a mounted directory as it exits, and the profiles are merged here.
+#
+# The instrumented services are read out of the coverage overlay, so that file is the only place
+# the list is written down.
+set -eu
+
+cd "$(dirname "$0")/.."
+
+compose="-f compose-e2e-test.yml -f compose-e2e-coverage.yml"
+instances=$(awk '/^  [a-z0-9-]*:$/ { gsub(/[ :]/, ""); print }' compose-e2e-coverage.yml)
+
+./e2e/tls/generate.sh
+
+# an interrupted run leaves the stack up, and `up` below would not recreate a container whose
+# configuration has not changed: it would keep the mount it already holds, which the wipe just
+# unlinked, and write its profile into a directory nothing can read. Start from no stack at all.
+# shellcheck disable=SC2086
+docker compose $compose down -v >/dev/null 2>&1 || true
+
+rm -rf e2e/coverage
+# the container writes as its own user, and this directory is generated, gitignored, and holds
+# nothing but profiles
+for i in $instances; do
+	install -d -m 0777 "e2e/coverage/$i"
+done
+
+# shellcheck disable=SC2086 # the compose file list is deliberately split into arguments
+E2E_COVERAGE=1 E2E_STAMP=$(E2E_COVERAGE=1 ./e2e/stamp.sh) \
+	docker compose $compose up -d --build --quiet-pull --wait
+
+# the suite's exit status is kept, but the instances are stopped either way. A profile is written
+# as the process exits, so returning early on a failing run would discard the coverage of the run
+# that most needed explaining, and leave the stack up as well.
+status=0
+E2E_COVERAGE=1 make e2e || status=$?
+
+# shellcheck disable=SC2086
+docker compose $compose stop -t 30 $instances
+
+# every instance is checked, not the total: one killed while the others exited cleanly would
+# otherwise merge into a plausible report with its own code reading as unreached
+missing=""
+for i in $instances; do
+	if [ -z "$(find "e2e/coverage/$i" -name 'covcounters.*' 2>/dev/null)" ]; then
+		missing="$missing $i"
+	fi
+done
+
+if [ -n "$missing" ]; then
+	echo "no coverage profile from:$missing"
+	echo "those instances did not shut down cleanly; the report would understate them silently"
+	status=1
+else
+	dirs=""
+	for i in $instances; do
+		dirs="${dirs:+$dirs,}e2e/coverage/$i"
+	done
+	go tool covdata textfmt -i="$dirs" -o e2e/coverage/e2e.cov_tmp
+	# the same exclusion the unit profile applies, so the two can be added together
+	grep -v "_mock.go" e2e/coverage/e2e.cov_tmp >e2e/coverage/e2e.cov
+	rm e2e/coverage/e2e.cov_tmp
+	(cd backend && go tool cover -func=../e2e/coverage/e2e.cov | tail -1)
+fi
+
+# the profiles are on the host, so the stack has nothing left to hold, and leaving it half stopped
+# is what the next plain run would find
+# shellcheck disable=SC2086
+docker compose $compose down -v >/dev/null 2>&1
+
+exit $status

--- a/e2e/stamp.sh
+++ b/e2e/stamp.sh
@@ -33,4 +33,13 @@ digest() {
 	git diff HEAD -- $sources
 	# shellcheck disable=SC2086
 	git status --porcelain -- $sources
+	# an instrumented build is a different binary from the same sources, so it has to be a
+	# different stamp: without this a coverage stack is accepted for a plain run, and a plain
+	# stack for a coverage run, which reports no coverage at all and looks like untested code
+	# only "1" instruments, which is the Dockerfile's test too: anything else has to digest as
+	# the plain build, or E2E_COVERAGE=0 becomes a third stamp for a stack built the ordinary way
+	case "${E2E_COVERAGE:-}" in
+	1) printf 'coverage=1\n' ;;
+	*) printf 'coverage=\n' ;;
+	esac
 } | digest | cut -c1-16


### PR DESCRIPTION
The e2e suite drives the real binary through a browser, and none of what it reaches was counted anywhere. The code runs in a container instead of in the test process, so `go test -cover` cannot see it, and packages the suite exercises heavily read as untested.

```
make e2e-cover
```

`compose-e2e-coverage.yml` overlays the stack to build the image with `go build -cover` and mount a profile directory per instance. `e2e/coverage.sh` runs the suite, stops the instances so the profiles flush, merges them into `e2e/coverage/e2e.cov` and prints the total.

Across the seven remark42 instances the suite reaches **37% of backend statements**, including packages the unit profile barely touches:

| package | e2e |
|---|---|
| `app/store` | 67.4% |
| `app/store/engine` | 51.1% |
| `app/rest` | 50.0% |
| `app/store/service` | 49.7% |
| `app/rest/api` | 40.6% |

## Why the overlay is a separate file

A bind mount in the short form creates its host path when it is missing. Carried in `compose-e2e-test.yml`, these mounts would have an ordinary `make e2e` create `e2e/coverage` itself, owned by whatever the daemon runs as, which on Linux leaves a directory the next run cannot remove. A plain run leaves no trace of coverage, and `compose-e2e-test.yml` is unchanged by this PR.

## Reporting nothing must not look like a result

An empty profile directory and code no test reached produce the same number, so each way of getting there fails instead:

- **A killed instance writes no profile.** The instances are asked to stop with a 30 second grace, and every directory is checked rather than the total, because six clean exits and one kill would otherwise merge into a plausible report with that instance reading as unreached. The failure names the services that produced nothing.
- **A failing suite still holds coverage worth keeping.** The suite's exit status is preserved, but the stop and the merge happen either way, so the run that most needs explaining is not the one that discards its evidence.
- **A plain stack must not answer for an instrumented one.** `E2E_COVERAGE` feeds `e2e/stamp.sh` as well as the image build, so the two carry different stamps and the suite refuses the one it was not built for. Only the value `1` instruments, in the stamp and in the Dockerfile alike, so setting it to `0` is the plain build and not a third variant.
- **An interrupted run leaves the stack up.** `up` does not recreate a container whose configuration is unchanged, so it would keep a mount the next run has already unlinked and write where nothing can read. The script starts from `down -v`.

## Combining with the unit profile

The profile is written in `atomic` mode, which is also the only mode `-race` accepts, and with the same `_mock.go` exclusion the unit run applies. The two are one population and append directly:

```
cat profile.cov > combined.cov && tail -n +2 e2e/coverage/e2e.cov >> combined.cov
cd backend && go tool cover -func=../combined.cov
```

`covdata` writes file names as full import paths and `go tool cover` resolves them through `go list`, so that read has to run from `backend/`.

No workflow change is included. Wiring this into CI needs one workflow producing both profiles, since the backend workflow is path filtered and a change touching only `e2e/` never produces `profile.cov`.

The instrumentation is a build argument, off by default, so a published image is unaffected.
