### PR TITLE
Fix: serve compiled bundles under /web/ in dev mode

### DIFF
--- a/frontend/apps/remark42/webpack.config.js
+++ b/frontend/apps/remark42/webpack.config.js
@@ -179,6 +179,10 @@ module.exports = (_, { mode, analyze }) => {
     port: PORT,
     devMiddleware: {
       stats: 'minimal',
+      // serve the in-memory build output under the same PUBLIC_PATH the devServer.static entries
+      // and every template's script tags use. output.publicPath stays 'auto' for the runtime
+      // bundle; this only affects where the dev server itself serves its own output from.
+      publicPath: PUBLIC_PATH,
     },
     headers: {
       'Access-Control-Allow-Origin': '*',


### PR DESCRIPTION
## Title

Fix(dev-only): serve compiled bundles under /web/ in webpack-dev-server

## Body

`output.publicPath: 'auto'` (from #2197, needed for instances mounted under a URL prefix) also
changed where `webpack-dev-server` itself serves the compiled bundles in dev mode, which no longer
matches `devServer.static`'s entries or any template's hardcoded `/web/<name>.mjs` script tags. The
documented `pnpm dev` workflow (`http://127.0.0.1:9000/web/`) 404s as a result — everything is
served from the root instead. This only affects the local dev server; production is unaffected.

Fix: `publicPath: isDev ? PUBLIC_PATH : 'auto'`. Production keeps `'auto'` untouched (verified via
`pnpm build`, no hardcoded `/web/` in the emitted bundle), so this doesn't reintroduce the bugs
#2219 and #2224 fixed for that mode.

### Verification

- `pnpm dev`: `/web/`, `/web/embed.mjs`, `/web/counter.mjs`, `/web/remark.mjs` all resolve, and the
  demo page's widget, last-comments iframe, and counter all render correctly.
- `pnpm build` still compiles cleanly with `'auto'` in production.
- `pnpm lint` passes.

<img width="902" height="966" alt="Screenshot 2026-08-30 at 13 02 44" src="https://github.com/user-attachments/assets/7741b8e6-4cb9-48a9-b0c0-f3e177c665e4" />

### Notes

Developed with Github Copilot