### PR TITLE
Fail the release build on a name go:embed would drop

### DIFF
--- a/scripts/prepare-release-assets.sh
+++ b/scripts/prepare-release-assets.sh
@@ -56,4 +56,21 @@ if ! grep -Rq "{% REMARK_URL %}" "$EMBED_DIR"; then
   exit 1
 fi
 
+# `//go:embed web` in app/cmd/server.go takes the default pattern rules, which skip every name
+# beginning with a dot or an underscore. A bundle emitted under such a name would be absent from
+# the binary while still present in frontend/apps/remark42/public, so it would serve correctly from
+# --web-root and 404 from a released binary, which is the arrangement nobody tests. Nothing emits
+# one today; this fails the release if that ever changes, instead of shipping the hole.
+# The marker below is written after this check because it is itself such a name.
+# sed, not head: head closes the pipe once it has its five lines, and on a tree with enough of
+# them sort dies of SIGPIPE, which pipefail turns into a failed assignment and errexit turns into
+# an exit before the message below is ever printed
+hidden=$(find "$EMBED_DIR" -mindepth 1 \( -name '.*' -o -name '_*' \) | sort | sed -n '1,5p')
+if [[ -n "$hidden" ]]; then
+  echo "error: go:embed would drop these from the binary, since it ignores names starting with a" >&2
+  echo "dot or an underscore, and they would 404 from a release while working under --web-root:" >&2
+  echo "$hidden" >&2
+  exit 1
+fi
+
 touch "$PREPARED_MARKER"


### PR DESCRIPTION
Previously, the release build could ship widget assets the binary cannot serve, and nothing would say so. `//go:embed web` in `app/cmd/server.go` takes the default pattern rules, which skip every name beginning with a dot or an underscore. A bundle emitted under such a name stays in `frontend/apps/remark42/public`, so it resolves correctly from `--web-root` and returns 404 from a released binary. That is the arrangement nobody runs locally, which is how the fallback page went missing for four years.

After this change, `prepare-release-assets.sh` fails the build when the embedded tree contains such a name, beside the existing check that the instance-URL placeholder survived. The check runs before the prepared marker is written, since `.release-assets-prepared` is itself such a name.

Nothing emits one today, so this is a guard and not a fix.

Verified by running the real script, which passes on the current build and embeds the expected assets, and by running the guard against synthesised trees: it fails on a dot-prefixed file, on an underscore-prefixed file and on a nested underscore-prefixed directory, passes on a clean one, and still prints the offending paths on a tree large enough for the truncation to close the pipe early. `shellcheck` is clean and `shfmt -i 2` matches the file's existing indentation.
