### PR TITLE
Whitelist the docker build context, and ignore worktrees

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,37 +1,45 @@
-/logs/
-/target/
-/var/
-/.vscode/
-/.idea/
-/bin/
-/.git/
+# A whitelist, not a blacklist: everything is excluded and only the paths the images build
+# from are restored. Anything new at the repo root then stays out of the build context by
+# default, which is what the previous blacklist kept getting wrong as directories appeared
+# beside it.
+*
 
-# frontend files not needed in docker image
-/frontend/node_modules/
-/frontend/apps/remark42/node_modules/
-/frontend/apps/remark42/public/
+# the backend module. the main image builds ./app from it, and the memory_store example
+# image builds backend/_example/memory_store out of this same context
+!backend
 
-# source files
-docker-compose.yml
-compose-dev-backend.yml
-compose-dev-frontend.yml
-compose-private-backend.yml
-compose-private-frontend.yml
-compose-e2e-test.yml
-compose-private.yml
-rest-client.env.json
-Makefile
+# the widget. package.json and pnpm-lock.yaml prime the dependency layer, the rest of the
+# directory feeds the build stage
+!frontend/apps/remark42
 
-# generated files
-*.cov
+# installed as /srv/init.sh in the final image
+!docker-init.sh
+
+# dependencies and build output are produced inside the image, so a local copy is dead
+# weight that also invalidates the layer it lands in
+**/node_modules
+frontend/apps/remark42/public
+backend/_example/*/vendor
+backend/var
+backend/app/var
+backend/app/cmd/var
+
+# the frontend build stage supplies these; the committed placeholder has to stay, because
+# a SKIP_FRONTEND_BUILD image has nothing else to satisfy the go:embed with
+backend/app/cmd/web
+!backend/app/cmd/web/index.html
+
+# binaries built by hand in the tree. the images build their own, and a stale one here is both
+# dead weight and a chance of being copied over the real thing
+backend/remark42
+backend/debug
+
+# local test and profiling residue
+**/.idea
+**/.vscode
+**/coverage
+**/.DS_Store
+**/*.cov
+**/*.prof
+**/*.test
 .cover
-target
-debug
-debug.test
-*.prof
-*.test
-remark42
-/backend/var/
-
-# go e2e suite, never built into the image
-/e2e/

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ http-client.env.json
 
 # profiles from `make e2e-cover`
 e2e/coverage/
+
+# git worktrees, kept inside the repo so they are easy to find and easy to forget
+.worktrees/
+.claude/worktrees/


### PR DESCRIPTION
`.dockerignore` listed what to keep out, so whatever appeared at the repository root next rode along uninvited. A `.worktrees` directory reached 362MB before anyone noticed it was being uploaded on every build, and `site/`, `docs/`, `.github/`, `screenshots/` and jest coverage output were going with it.

It is now a whitelist: everything is excluded and only the three paths the images build from are restored. `backend`, which the main image builds `./app` from and the `memory_store` example image builds its own binary from; `frontend/apps/remark42` for the widget; and `docker-init.sh` for the entrypoint. Anything new at the root stays out until someone says otherwise.

`backend/app/cmd/web/index.html` keeps an explicit exception, because a `SKIP_FRONTEND_BUILD` image has nothing else to satisfy the `go:embed` in `server.go` with.

Measured on a clean checkout with a probe image that copies the context and counts it: **2937 files and 37MB before, 2826 and 35MB after**. The saving is small because a fresh tree carries none of the residue that prompted this. The point is the default, not the two megabytes.

What is left is `backend/vendor` at 2321 files, `frontend/apps` at 329, `backend/app` at 147, the `memory_store` example at 20, `backend/scripts` at 3, and a handful of single files. Vendor stays wholesale: both Dockerfiles add the backend module whole, Go selects vendor mode from the checked-in directory and `modules.txt`, and pruning its internals would mean maintaining a second rule in parallel with it. The example's own README, compose and test files stay for the same reason: excluding tens of kilobytes would turn a subtree whitelist into an inventory somebody has to keep current.

Three patterns the old blacklist carried are restored explicitly, since a subtree whitelist does not imply them: `backend/remark42` and `backend/debug` for binaries built by hand in the tree, and `**/.vscode` beside the existing `**/.idea`. `debug.test` is already covered by `**/*.test`.

Verified: the full e2e suite passes against an image built this way, the `memory_store` example image still builds from this same context, and `.github/` is now genuinely absent from it while `rest_public.go` and the 1347 vendored `github.com/…` files are not.

`.gitignore` gains `.worktrees/` and `.claude/worktrees/`, which is what let the directory grow unnoticed in the first place.
