### PR TITLE
Let dependabot open security updates for the widget

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,9 @@
 
 version: 2
 
-# npm updates are switched off entirely. open-pull-requests-limit bounds version
-# updates only, so the ignore entries below are what also stops security updates;
-# removing the npm entries would not work, as security updates come from alerts
-# rather than from this file.
+# npm version updates are switched off: open-pull-requests-limit bounds them, and the
+# ignore entry below is scoped to version updates so that security updates, which come
+# from alerts and not from this file, still open pull requests for the widget.
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -33,22 +32,14 @@ updates:
       "Go modules updates":
         dependency-type: "production"
   - package-ecosystem: "npm"
-    directory: "/frontend"
-    open-pull-requests-limit: 0
-    ignore:
-      - dependency-name: "*"
-    schedule:
-      interval: "monthly"
-    groups:
-      "NPM modules updates":
-        dependency-type: "production"
-      "NPM modules updates for tests":
-        dependency-type: "development"
-  - package-ecosystem: "npm"
     directory: "/frontend/apps/remark42"
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     schedule:
       interval: "monthly"
     groups:


### PR DESCRIPTION
Previously, the npm entry in `dependabot.yml` ignored every dependency outright, and the file's own comment recorded that this was also what stopped security updates. So the alert for `fast-uri` produced a failing `Dependabot Updates` job on every push to master and nothing else, until the override was raised by hand.

After this change, the ignore is scoped to version updates, which stay switched off as before, and security updates open pull requests for the widget again. The entry for the frontend root is gone with it: no manifest has lived there since the workspace root was removed, so it only produced errors.

Verified that the file parses as YAML; the effect itself shows on the next security alert, which is the first time the job can open a pull request instead of failing.
