### PR TITLE
Correct stale configuration and contributor documentation

### DIFF
--- a/site/content/docs/backup/migration/index.md
+++ b/site/content/docs/backup/migration/index.md
@@ -8,17 +8,17 @@ Remark42 supports importing comments from Disqus, WordPress, Commento, or native
 
 1. Disqus provides export of all comments on your site in a gzipped file. This option is available in your Moderation panel at Disqus Admin > Setup > Export. The export will be sent into a queue and then emailed to the address associated with your account once it's ready. Direct link to export will be something like `https://<siteud>.disqus.com/admin/discussions/export/`. See [importing-exporting](https://help.disqus.com/en/articles/1717199-importing-exporting) for more details
 2. Move this file to your Remark42 host within `./var` and extract, i.e., `gunzip <disqus-export-name>.xml.gz`
-3. Run import command (`ADMIN_PASSWD` must to be enabled on server for it to work) - `docker exec -it remark42 import -p disqus -f /srv/var/{disqus-export-name}.xml -s {your site ID}`
+3. Run import command (`ADMIN_PASSWD` must be enabled on the server for it to work) - `docker exec -it remark42 import -p disqus -f /srv/var/{disqus-export-name}.xml -s {your site ID}`
 
 ### Initial import from WordPress
 
 1. Use [that instruction](https://wordpress.com/support/export/) to export comments to file using standard WordPress functionality
 2. Move this file to your Remark42 host within `./var`
-3. Run import command (`ADMIN_PASSWD` must to be enabled on server for it to work) - `docker exec -it remark42 import -p wordpress -f /srv/var/{wordpress-export-name}.xml -s {your site ID}`
+3. Run import command (`ADMIN_PASSWD` must be enabled on the server for it to work) - `docker exec -it remark42 import -p wordpress -f /srv/var/{wordpress-export-name}.xml -s {your site ID}`
 
 ### Initial import from Commento
 
 1. Move exported json file to your Remark42 host within `./var`
-2. Run import command (`ADMIN_PASSWD` must to be enabled on server for it to work) - `docker exec -it remark42 import -p commento -f /srv/var/{commento-export-name}.json -s {your site ID}`
+2. Run import command (`ADMIN_PASSWD` must be enabled on the server for it to work) - `docker exec -it remark42 import -p commento -f /srv/var/{commento-export-name}.json -s {your site ID}`
 
 Comments are imported for the domain specified in the provided file, with `https://` prefix. If you want to import comments for a different domain or for `http://` domain, you'll need to export them after importing, alter the export file `url` property and re-import them.

--- a/site/content/docs/backup/restore/index.md
+++ b/site/content/docs/backup/restore/index.md
@@ -2,9 +2,9 @@
 title: Restore Backup
 ---
 
-Restore will clean all comments first and then process with complete import from a given file.
+Restore removes all existing comments before importing the contents of the supplied file.
 
-For safety and security reasons, restore functionality not exposed outside your server by default. The recommended way to restore from the backup is to use provided `scripts/restore.sh`. It can run inside the container (`ADMIN_PASSWD` must to be enabled on server for it to work):
+For safety and security reasons, restore functionality is not exposed outside your server by default. The recommended way to restore from the backup is to use the provided [`backend/scripts/restore.sh`](https://github.com/umputun/remark42/blob/master/backend/scripts/restore.sh). It can run inside the container (`ADMIN_PASSWD` must be enabled on the server for it to work):
 
 `docker exec -it remark42 restore -f {backup-filename.gz} -s {your site ID}`
 

--- a/site/content/docs/backup/url-migration/index.md
+++ b/site/content/docs/backup/url-migration/index.md
@@ -17,7 +17,7 @@ https://example.org/old-url-2/ https://example.org/new-url-2/
 
 ### Applying the remap
 
-After rules file is ready, run the following command (`ADMIN_PASSWD` must to be enabled on server for it to work):
+After rules file is ready, run the following command (`ADMIN_PASSWD` must be enabled on the server for it to work):
 
 ```shell
 remark42 remap --admin-passwd <password> -s <your site ID> -f var/rules

--- a/site/content/docs/configuration/authorization/index.md
+++ b/site/content/docs/configuration/authorization/index.md
@@ -4,7 +4,7 @@ title: Authorization
 
 ## OAuth Providers
 
-Authentication is handled by external providers. You should set up OAuth2 for at least one to allow users to comment. It is not mandatory to have all of them, but one should be correctly configured.
+Users can sign in through external providers, [email](https://remark42.com/docs/configuration/email/) or [anonymous login](#anonymous). Configure at least one method to allow commenting; OAuth2 is optional when email or anonymous login is enabled.
 
 ### Apple
 

--- a/site/content/docs/configuration/email/index.md
+++ b/site/content/docs/configuration/email/index.md
@@ -234,7 +234,7 @@ If the file is mounted correctly, the page will render the new file content imme
 
 ### Template variables
 
-Each template has access to different variables. All templates use Go's [text/template](https://pkg.go.dev/text/template) syntax.
+Each template has access to different variables. Email templates use Go's [html/template](https://pkg.go.dev/html/template), which escapes ordinary values for HTML output.
 
 #### `email_reply.html.tmpl` — comment notification
 
@@ -277,33 +277,20 @@ Sent when a user logs in via email authentication.
 |----------|------|-------------|
 | `{{.User}}` | string | Username |
 | `{{.Token}}` | string | Login token |
-| `{{.Email}}` | string | Recipient email address |
 | `{{.Site}}` | string | Site name |
 | `{{.Address}}` | string | Recipient address |
 
 ### Plain-text emails
 
-The default templates produce HTML emails. To send plain-text emails instead, set `AUTH_EMAIL_CONTENT_TYPE=text/plain` (for login confirmation) or `NOTIFY_EMAIL_CONTENT_TYPE=text/plain` (for notifications), and provide custom templates that output plain text instead of HTML.
+For plain-text login confirmations, set `AUTH_EMAIL_CONTENT_TYPE=text/plain` and provide a plain-text `email_confirmation_login.html.tmpl`:
 
-Note that `{{.CommentText}}` and `{{.ParentCommentText}}` contain HTML markup. There is no built-in HTML-to-text conversion, so for comments with rich formatting the output will include raw HTML tags.
+```text
+Confirmation for {{.User}} on site {{.Site}}
 
-Example plain-text notification template (`email_reply.html.tmpl`):
+Copy this token into the login form:
+{{.Token}}
 
+Sent to {{.Address}}
 ```
-New reply from {{.UserName}}{{if .PostTitle}} on "{{.PostTitle}}"{{end}}
 
-{{.CommentText}}
-{{.CommentDate.Format "02.01.2006 at 15:04"}}
-{{.CommentLink}}
-{{- if .ParentCommentText}}
-
-In reply to {{.ParentUserName}}:
-{{.ParentCommentText}}
-{{.ParentCommentLink}}
-{{- end}}
-
-Sent to {{.Email}}
-{{- if .UnsubscribeLink}}
-Unsubscribe: {{.UnsubscribeLink}}
-{{- end}}
-```
+The template still uses `html/template`, so values are HTML-escaped even with a plain-text content type. Comment and subscription notification emails always use `text/html`; there is no `NOTIFY_EMAIL_CONTENT_TYPE` setting. Keep their custom templates in HTML.

--- a/site/content/docs/configuration/frontend/_index.md
+++ b/site/content/docs/configuration/frontend/_index.md
@@ -7,7 +7,7 @@ aliases:
 ## Configuration
 
 - **`host`**`: string` (required) – hostname of Remark42 server, same as REMARK_URL in backend config, e.g. "https://demo.remark42.com"
-- **`site_id`**`: string` (optional, `remark` by default) – the `SITE` that you passed to Remark42 instance on start of backend.
+- **`site_id`**`: string` (required) – the `SITE` that you passed to Remark42 instance on start of backend.
 - **`url`**`: string` (optional, `window.location.origin + window.location.pathname` by default) – url to the page with comments, it is used as unique identificator for comments thread
   Note that if you use query parameters as significant part of URL (the one that actually changes content on page) you will have to configure URL manually to keep query params, as `window.location.origin + window.location.pathname` doesn't contain query params and hash. For example, default URL for `https://example/com/example-post?id=1#hash` would be `https://example/com/example-post`
 - **`components`**`: ['embed' | 'last-comments' | 'counter']` (optional, `['embed']` by default) – an array of widgets that should be rendered on a page. You may use more than one widget on a page.
@@ -15,17 +15,18 @@ aliases:
   - `'embed'` – basic comments widget
   - `'last-comments'` – last comments widget, see [Last Comments](#last-comments-widget) section below
   - `'counter'` – counter widget, see [Counter](#counter-widget) section below
-- **`max_shown_comments`**`: number` (optional, `15` by default) – maximum number of comments that is rendered on mobile version
+- **`max_shown_comments`**`: number` (optional, `10` by default) – initial number of top-level comments shown on mobile
 - **`max_last_comments`**`: number` (optional, `15` by default) – maximum number of comments in the last comments widget
 - **`theme`**`: 'light' | 'dark'` (optional, `'light'` by default) – changes UI theme
 - **`page_title`**`: string` (optional, `document.title` by default) – title for current comments page
 - **`locale`**`: enum` (optional, `'en'` by default) – interface localization, [check possible localizations](#locales)
 - **`show_email_subscription`**`: boolean` (optional, `true` by default) – enables email subscription feature in interface when enable it from backend side, if you set this param in `false` you will get notifications email notifications as admin but your users won't have interface for subscription
+- **`show_telegram_subscription`**`: boolean` (optional, `true` by default) – shows Telegram subscription controls when Telegram user notifications are enabled on the backend
 - **`show_rss_subscription`**`: boolean` (optional, `true` by default) – enables RSS subscription feature in interface
-- **`simple_view`**`: boolean` (optional, `false` by default) – overrides the parameter from the backend minimized UI with basic info only
+- **`simple_view`**`: boolean` (optional, `false` by default) – enables a minimal UI with basic information only; `false` does not disable `SIMPLE_VIEW` enabled on the backend
 - **`no_footer`**`: boolean` (optional, `false` by default) – hides footer with signature and links to Remark42
 
-Example with all of the params:
+Configuration example:
 
 ```html
 <script>
@@ -86,7 +87,7 @@ window.REMARK42.changeTheme("light")
 
 #### Locales
 
-Right now Remark42 is translated to English (en), Belarusian (be), Brazilian Portuguese (bp), Bulgarian (bg), Chinese (zh), Finnish (fi), French (fr), German (de), Japanese (ja), Korean (ko), Polish (pl), Russian (ru), Spanish (es), Turkish (tr), Ukrainian (ua), Italian (it) and Vietnamese (vi) languages. You can pick one using a [configuration object](https://remark42.com/docs/getting-started/installation/#setup-on-your-website).
+Right now Remark42 is translated to English (en), Russian (ru), German (de), Finnish (fi), Spanish (es), Chinese (zh), Turkish (tr), Bulgarian (bg), Ukrainian (ua), Polish (pl), Vietnamese (vi), Belarusian (be), French (fr), Japanese (ja), Korean (ko), Brazilian Portuguese (bp), Italian (it), Arabic (ar), Traditional Chinese (zh-tw), Thai (th), Czech (cs), Persian (fa), Macedonian (mk), Romanian (ro), Swedish (sv) and Hebrew (he). You can pick one using a [configuration object](https://remark42.com/docs/getting-started/installation/#setup-on-your-website).
 
 Do you want to translate Remark42 to other locales? Please see [this documentation](https://remark42.com/docs/contributing/translations/) for details.
 
@@ -118,11 +119,11 @@ And then add this node in the place where you want to see last comments widget:
 <div class="remark42__last-comments" data-max="50"></div>
 ```
 
-`data-max` sets the max amount of comments (default: `15`).
+`data-max` sets the maximum number of comments for this widget, overriding `max_last_comments` in `remark_config`. If neither is set, the default is `15`.
 
 ### Counter widget
 
-It's a widget that renders several comments for the specified page.
+This widget displays the number of comments for the specified page.
 Add this snippet to the bottom of web page, or adjust already present `remark_config` to have `counter` in `components` list:
 
 ```html
@@ -148,6 +149,6 @@ And then add a node like this in the place where you want to see a number of com
 ></span>
 ```
 
-You can use as many nodes like this as you need to. The script will find all of them by the class `remark__counter`, and it will use the `data-url` attribute to define the page with comments.
+You can use as many nodes like this as you need to. The script will find all of them by the class `remark42__counter`, and it will use the `data-url` attribute to define the page with comments.
 
 Also, the script can use `url` property from `remark_config` object or `window.location.origin + window.location.pathname` if nothing else is defined.

--- a/site/content/docs/configuration/frontend/spa.md
+++ b/site/content/docs/configuration/frontend/spa.md
@@ -31,7 +31,7 @@ Created `remark42Instance` when the `div` containing remark42 has appeared, usua
 
       this.remark42Instance = window.REMARK42.createInstance({
         node: this.$refs.remark42 as HTMLElement,
-        ...remark42_config  // See <https://github.com/patarapolw/remark42#setup-on-your-website>
+        ...remark42_config  // See <https://remark42.com/docs/configuration/frontend/>
       })
     }
   }

--- a/site/content/docs/configuration/parameters/index.md
+++ b/site/content/docs/configuration/parameters/index.md
@@ -4,11 +4,12 @@ title: Command-Line Interface parameters
 
 ### Required parameters
 
-Most of the parameters have sane defaults and don't require customization. There are only a few parameters the user has to define:
+Only two parameters are required to start the server:
 
 1. `SECRET` - secret key, can be any long and hard-to-guess string
 2. `REMARK_URL` - URL pointing to your Remark42 server, i.e., `https://demo.remark42.com`
-3. At least one OAuth2 provider, either via `AUTH_<PROVIDER>_CID` + `AUTH_<PROVIDER>_CSEC` or via `AUTH_CUSTOM_*`
+
+To let users sign in and comment, enable at least one [authentication method](https://remark42.com/docs/configuration/authorization/), such as OAuth2, email (`AUTH_EMAIL_ENABLE=true`) or anonymous login (`AUTH_ANON=true`). OAuth2 is not required when using email or anonymous login.
 
 The minimal `docker-compose.yml` has to include all required parameters:
 
@@ -82,7 +83,7 @@ services:
 | auth.send-jwt-header           | AUTH_SEND_JWT_HEADER           | `false`                 | also send JWT as a header, so the frontend can store it in a client-side cookie that survives third-party cookie blocking; the server-set cookies are still sent. [See security considerations](#security-considerations-for-authsend-jwt-header). |
 | auth.same-site                 | AUTH_SAME_SITE                 | `default`               | SameSite attribute for the server-set auth cookies (`default`, `none`, `lax` or `strict`). `default` emits no attribute at all and leaves the choice to the browser, which is not the same as `lax` |
 | auth.apple.cid                 | AUTH_APPLE_CID                 |                         | Apple client ID (App ID or Services ID)                  |
-| auth.apple.tid                 | AUTH_APPLE_TID                 |                         | Apple service ID                                         |
+| auth.apple.tid                 | AUTH_APPLE_TID                 |                         | Apple Team ID                                            |
 | auth.apple.kid                 | AUTH_APPLE_KID                 |                         | Apple Private key ID                                     |
 | auth.apple.private-key-filepath | AUTH_APPLE_PRIVATE_KEY_FILEPATH | `/srv/var/apple.p8`       | Apple Private key file location                          |
 | auth.google.cid                | AUTH_GOOGLE_CID                |                         | Google OAuth client ID                                   |
@@ -176,7 +177,7 @@ services:
 | trusted-proxy                  | TRUSTED_PROXY                  | none (trust any)        | reverse-proxy networks (CIDR/IP, comma-separated) trusted to set the client IP; see [Trusted proxies and client IP](#trusted-proxies-and-client-ip) |
 | subscribers-only               | SUBSCRIBERS_ONLY               | `false`                 | enable commenting only for Patreon subscribers           |
 | disable-signature              | DISABLE_SIGNATURE              | `false`                 | disable server signature in headers                      |
-| disable-fancy-text-formatting  | DISABLE_FANCY_HTML_FORMATTING  | `false`                 | disable fancy comments text formatting (replacement of quotes, dashes, fractions, etc) |
+| disable-fancy-text-formatting  | DISABLE_FANCY_TEXT_FORMATTING  | `false`                 | disable fancy comments text formatting (replacement of quotes, dashes, fractions, etc) |
 | admin-passwd                   | ADMIN_PASSWD                   | none (disabled)         | password for `admin` basic auth                          |
 | dbg                            | DEBUG                          | `false`                 | debug mode                                               |
 

--- a/site/content/docs/contributing/backend/index.md
+++ b/site/content/docs/contributing/backend/index.md
@@ -22,7 +22,7 @@ It starts Remark42 on `127.0.0.1:8080` and adds local OAuth2 provider "Dev". To 
 Please use `127.0.0.1` and not `localhost` to access the server; otherwise, CORS will prevent your browser from authentication to work correctly. You could alter the address for dev auth with the `REMARK_URL` environment variable.
 {{< /note >}}
 
-Backend Docker Compose config (`compose-dev-backend.yml`) by default skips running frontend related tests. Frontend Docker Compose config (`compose-dev-frontend.yml`) by default skips running backend related tests and sets `NODE_ENV=development` for frontend build.
+Backend Docker Compose config (`compose-dev-backend.yml`) by default skips running frontend related tests. Frontend Docker Compose config (`compose-dev-frontend.yml`) skips backend tests and the frontend build. Run the frontend separately with `pnpm dev` as described in the [frontend development guide](https://remark42.com/docs/contributing/frontend/#run-frontend-with-backend-locally).
 
 ### Backend development
 
@@ -74,7 +74,7 @@ User's activity throttled globally (up to 1000 simultaneous requests) and limite
 
 Request timeout set to 60sec.
 
-Admin authentication (`--admin-password` set) allows to hit Remark42 API without social login and admin privileges. Adds basic-auth for username: `admin`, password: `${ADMIN_PASSWD}`. Enable it only for the initial comment import or for manual backups. Do not leave the server running with admin password set if you don't have an intention to keep creating backups manually!
+Admin authentication (`--admin-passwd` set) allows to hit Remark42 API without social login and admin privileges. Adds basic-auth for username: `admin`, password: `${ADMIN_PASSWD}`. Enable it only for the initial comment import or for manual backups. Do not leave the server running with admin password set if you don't have an intention to keep creating backups manually!
 
 User can vote for the comment multiple times but only to change the vote. Double voting is not allowed.
 

--- a/site/content/docs/contributing/frontend/index.md
+++ b/site/content/docs/contributing/frontend/index.md
@@ -37,16 +37,16 @@ Please use `127.0.0.1` and not `localhost` to access the server; otherwise, CORS
 
 You can run frontend against demo instance of Remark42. This method of running Remark42 frontend code is preferred when you make a translation or visual adjustments that are easy to see without extensive testing. For this method we use our demo instance of Remark42 served on https://demo.remark42.com
 
-For local development mode with Hot Reloading, use `pnpm dev`. In this case, `webpack` will serve files using `webpack-dev-server` on `127.0.0.1:9000`. By visiting <http://127.0.0.1:9000/web/>, you will get a page with the main comments' widget communicating with a demo server backend running on `https://demo.remark42.com`. But you will not be able to log in with any OAuth providers due to security reasons.
+For local development mode with Hot Reloading, use `pnpm dev:demo`. In this case, `webpack` will serve files using `webpack-dev-server` on `127.0.0.1:9000`. By visiting <http://127.0.0.1:9000/web/>, you will get a page with the main comments' widget communicating with a demo server backend running on `https://demo.remark42.com`. But you will not be able to log in with any OAuth providers due to security reasons.
 
-You can attach the frontend to the locally running backend from `frontend/apps/remark42` folder and providing the `REMARK_URL` environment variable.
+You can attach the frontend to the locally running backend from `frontend/apps/remark42` folder and providing the `REMARK_API_BASE_URL` environment variable.
 
 ```shell
-npx cross-env REMARK_URL=http://127.0.0.1:8080 pnpm dev:custom
+pnpm exec cross-env REMARK_API_BASE_URL=http://127.0.0.1:8080 pnpm dev:custom
 ```
 
 {{< note "ℹ️" >}}
-If you want to redefine env variables such as `PORT` on your local instance, you can add the `.env` file to the `./frontend` folder and rewrite variables as you wish. For such functional, we use `dotenv`.
+If you want to redefine env variables such as `PORT` on your local instance, you can add the `.env` file to the `./frontend/apps/remark42` folder and rewrite variables as you wish. For such functional, we use `dotenv`.
 {{< /note >}}
 
 ### Run frontend with backend locally
@@ -103,11 +103,9 @@ so prettier, stylelint and `pnpm lint` do not see them.
 
 ## CSS Styles
 
-- Now we are migrating to CSS Modules, which is a recommended way of stylization. A file with styles should be named like `component.module.css`
-- Old component styles use BEM notation (at least it should): `block__element_modifier`. Also, there are `mix` classes: `block_modifier`
-- The new way to name CSS selectors is camel-case like `blockElemenModifier` and use `clsx` to combine it
-- Component base style resides in the component's root directory with a name of component converted to kebab-case. For example, `ListComments` style is located in `./app/components/list-comments/list-component.tsx`
-- Any other files should also be named in kebab-case. For example, `./app/utils/get-param.ts`
+- Component styles use CSS Modules in `component.module.css` files.
+- Use `root` for the component block and camelCase for element and modifier classes; combine classes with `clsx`.
+- Keep the stylesheet next to its component, for example `app/components/list-comments/list-comments.module.css` and `app/components/list-comments/list-comments.tsx`.
 
 ## Imports
 
@@ -119,7 +117,7 @@ so prettier, stylelint and `pnpm lint` do not see them.
   costs nothing outside those files. It applies to value imports only; a type-only import erases
   before either runtime sees it, and keeps the ordinary style
 - If the file resides in the same directory or subdirectory, the import should be relative: `./types/something`
-- Otherwise, it should be imported by absolute path relative to `src` folder like `common/store` which mapped to `./app/common/store.ts` in webpack, tsconfig, and Jest
+- Otherwise, it should be imported by absolute path relative to the `app` folder like `common/types` which maps to `./app/common/types.ts` in webpack, tsconfig, and Jest
 
 ## Testing
 
@@ -131,7 +129,7 @@ Tests come in two layers, and which one a test belongs in is decided by what it 
 - [Testing Library](https://testing-library.com) is used for UI tests
 - Jest checks files that match regex `\.(test|spec)\.ts(x?)$`, i.e., `comment.test.tsx`, `comment.spec.ts`, and skips `*.unit.test.ts`
 - Tests are running on push attempt
-- Example tests can be found in `./app/components/auth/auth.spec.tsx`, `./app/store/user/reducers.test.ts`
+- Example tests can be found in `./app/components/auth/auth.spec.tsx`
 
 ### Dependency-free tests, `*.unit.test.ts`
 

--- a/site/content/docs/contributing/translations/index.md
+++ b/site/content/docs/contributing/translations/index.md
@@ -53,14 +53,26 @@ below to have your translation available to all remark42 users and included in t
 1.  Run `pnpm translation:generate` in the `frontend/apps/remark42` folder
 1.  Translate all values in the newly created JSON file in
     [frontend/apps/remark42/app/locales/](https://github.com/umputun/remark42/tree/master/frontend/apps/remark42/app/locales)
-1.  Commit all changes above in your fork
+1.  Run `pnpm translation-check` in `frontend/apps/remark42` to validate the translation keys, tags and placeholders
+1.  Update the [documented locale list](https://github.com/umputun/remark42/blob/master/site/content/docs/configuration/frontend/_index.md#locales) with the language name and code
+1.  Commit all changes above in your fork, including the generated `app/utils/loadLocale.ts`
 1.  Test your changes in the interface:
 
     1.  Uncomment `locale: "ru"` line in [frontend/apps/remark42/templates/demo.ejs](https://github.com/umputun/remark42/blob/master/frontend/apps/remark42/templates/demo.ejs) and replace `ru` with your translation language code
-    2.  [Run remark42 in Docker](https://github.com/umputun/remark42#development) by issuing the following commands from the root directory of your remark42 fork:
-        `shell docker compose -f compose-dev-frontend.yml build docker compose -f compose-dev-frontend.yml up `
+    2.  Start the backend from the root directory of your fork:
 
-    3.  open <http://127.0.0.1:8080/web/>, log in, make a comment, make a reply to a comment, and make sure your translation looks as you expect it to look
-    4.  make a screenshot from <http://127.0.0.1:8080> with your translation in place
+        ```shell
+        docker compose -f compose-dev-frontend.yml up --build
+        ```
+
+    3.  Start the frontend in another terminal:
+
+        ```shell
+        cd frontend/apps/remark42
+        pnpm dev
+        ```
+
+    4.  Open <http://127.0.0.1:9000/web/>, log in, make a comment, make a reply to a comment, and check your translation
+    5.  Take a screenshot of that page with your translation in place
 
 1.  after all previous steps are done, create a [Pull Request](https://github.com/umputun/remark42/pulls) to umputun/remark42 repo with your changes, attaching a screenshot or two from your local test instance to it

--- a/site/content/docs/getting-started/installation/index.md
+++ b/site/content/docs/getting-started/installation/index.md
@@ -30,7 +30,7 @@ _This is the recommended way to run Remark42_
 ### Installation with Binary
 
 - download [archive for the stable release](https://github.com/umputun/remark42/releases)
-- unpack with `gunzip` (Linux, macOS) or with `zip` (Windows)
+- extract the `.tar.gz` archive with `tar -xzf <archive>.tar.gz` (Linux, macOS), or extract the `.zip` archive (Windows)
 - run as `remark42.{os}-{arch} server {parameters...}`, i.e., `remark42.linux-amd64 server --secret=12345 --url=http://127.0.0.1:8080`
 - alternatively compile from the sources - `make OS=[linux|darwin|windows] ARCH=[amd64,386,arm64,arm]`. Source binary builds require Go 1.27, Node 24+, PNPM 10, and Perl because the frontend assets are built and embedded locally.
 


### PR DESCRIPTION
The documentation lists 17 of the 26 shipped locales and contains stale widget defaults, configuration names and contributor commands.

Update the locale list, mobile comment limit, subscription options and widget behaviour. Correct the authentication requirements, formatting environment variable, email template options, frontend development and translation instructions, and outdated paths and archive extraction commands.

Validation: Hugo build, internal link and anchor checks across all 35 generated HTML files, and an exact comparison of the documented locale codes with all 26 supported catalogues. Configuration and command changes were checked against their source definitions.
